### PR TITLE
Sendbatch

### DIFF
--- a/contracts/test/TestSponsorConfigurableMisbehavior.sol
+++ b/contracts/test/TestSponsorConfigurableMisbehavior.sol
@@ -54,6 +54,7 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
     }
 
     function preRelayedCall(bytes calldata context) relayHubOnly external returns (bytes32) {
+        (context);
         if (withdrawDuringPreRelayedCall) {
             withdrawAllBalance();
         }
@@ -71,6 +72,7 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
     relayHubOnly
     external
     {
+        (context, success, actualCharge, preRetVal);
         if (withdrawDuringPostRelayedCall) {
             withdrawAllBalance();
         }

--- a/contracts/test/TestSponsorEverythingAccepted.sol
+++ b/contracts/test/TestSponsorEverythingAccepted.sol
@@ -23,6 +23,7 @@ contract TestSponsorEverythingAccepted is BaseGasSponsor {
     relayHubOnly
     external
     returns (bytes32){
+        (context);
         emit SampleRecipientPreCall();
         return bytes32(uint(123456));
     }

--- a/contracts/test/TestSponsorOwnerSignature.sol
+++ b/contracts/test/TestSponsorOwnerSignature.sol
@@ -19,6 +19,7 @@ contract TestSponsorOwnerSignature is TestSponsorEverythingAccepted {
     external
     view
     returns (uint256, bytes memory){
+        (relayRequest, approvalData, maxPossibleCharge);
         address signer =
             keccak256(abi.encodePacked("I approve", relayRequest.relayData.senderAccount))
             .toEthSignedMessageHash()

--- a/contracts/test/TestSponsorPreconfiguredApproval.sol
+++ b/contracts/test/TestSponsorPreconfiguredApproval.sol
@@ -19,6 +19,7 @@ contract TestSponsorPreconfiguredApproval is TestSponsorEverythingAccepted {
     external
     view
     returns (uint256, bytes memory){
+        (relayRequest, approvalData, maxPossibleCharge);
         if (keccak256(expectedApprovalData) != keccak256(approvalData)) {
             return (14,
             abi.encodePacked(

--- a/contracts/test/TestSponsorStoreContext.sol
+++ b/contracts/test/TestSponsorStoreContext.sol
@@ -66,6 +66,7 @@ contract TestSponsorStoreContext is TestSponsorEverythingAccepted {
     function postRelayedCall(
         bytes calldata context, bool success, uint actualCharge, bytes32 preRetVal
     ) relayHubOnly external {
+        (context, success, actualCharge, preRetVal);
         (
         address relay, address from, bytes memory encodedFunction,
         uint256 transactionFee, uint256 gasPrice, uint256 gasLimit,

--- a/contracts/utils/CallBatcher.sol
+++ b/contracts/utils/CallBatcher.sol
@@ -1,0 +1,86 @@
+pragma solidity ^0.5.10;
+
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
+
+library CallBatcher {
+    using LibBytes for bytes;
+
+    struct Call {
+        address target;
+        bytes callData;
+    }
+
+    //amount of gas needed by sendBatch to "gracefully" exit
+    uint32 constant gasOverhead = 100;
+
+    event outofgas(uint left, uint overhead);
+    event gasaftercall(uint gasleft, uint gasBeforecall);
+    /**
+     * send multiple calls.
+     * @param calls - array of calls to make
+     * @param abortOnFirstRevert  - stop sending requests on first revert.
+     *  if set to false, then continue to make all calls.
+     * @return successfulCalls - counter on how many successful calls.
+     * @return error - in case success at least one call failed, error contains
+     *          the revert message of the first reverted call.
+     *
+     * This method will never revert.
+     *
+     * ## Gas usage: ##
+     * Will attempt to execute as many calls as possible given the gaslimit.
+     */
+    function sendBatch(Call[] memory calls, bool abortOnFirstRevert)
+    internal returns (uint successfulCalls, bytes memory error) {
+        for (uint i = 0; i < calls.length; i++) {
+            Call memory c = calls[i];
+            uint gasLeft = gasleft();
+            bool success;
+            bytes memory ret;
+            if (gasLeft < gasOverhead) {
+                success = false;
+                ret = "out-of-gas";
+            } else {
+                (success, ret) = c.target.call.gas(gasLeft - gasOverhead)(c.callData);
+            }
+            if (success) {
+                successfulCalls++;
+            } else {
+                if (error.length == 0) {
+                    error = ret;
+                }
+                if (abortOnFirstRevert) {
+                    break;
+                }
+            }
+        }
+    }
+
+    //send the batch. revert on first failure.
+    // (since we perform a revert, there's no meaning for "continue after revert")
+    function sendBatchAndRevert(Call[] memory calls) internal {
+        (uint count, bytes memory error) = sendBatch(calls, true);
+        require(count == calls.length, getErrorString(error));
+    }
+
+    //utility method for parsing returned data from address.call()
+    // extract error string, or return buffer as-is.
+    // usage:
+    //```
+    //  (uint count, bytes memory error) = CallBatcher.sendBatch(calls, abortOnFirst);
+    //  require(count == calls.length, CallBatcher.getErrorString(error));
+    //```
+
+    function getErrorString(bytes memory error) internal pure returns (string memory) {
+        //extract string from error message
+        if (error.length >= 4 + 32 && error.readBytes4(0) == ErrorSig) {
+            return abi.decode(error.slice(4, error.length), (string));
+        }
+        // otherwise, return buffer as-is.
+        return string(error);
+    }
+
+    bytes4 constant ErrorSig = bytes4(keccak256("Error(string)"));
+    //    bytes4 constant ErrorSig = 0x08c379a0;
+
+
+}

--- a/test/batcher/CallBatcher.test.js
+++ b/test/batcher/CallBatcher.test.js
@@ -1,37 +1,17 @@
 /* global contract it before */
 const TestBatcher = artifacts.require('TestBatcher')
+const chai = require('chai')
 const { assert } = require('chai')
 const { packLogs } = require('../testutils')
 
-async function dump (f) {
-  try {
-    const ret = await f
-    if (!ret.receipt.status) {
-      console.log('tx failed, gasused=', ret.receipt.gasUsed)
-    } else if (ret.receipt) {
-      console.log('gas=', ret.receipt.gasUsed, JSON.stringify(packLogs(ret.receipt.logs)))
-    } else {
-      console.log('ret=', ret)
-    }
-  } catch (e) {
-    console.log('ex=', e)
-  }
-}
-
+chai.use(require('chai-as-promised'))
 contract.only('CallBatcher', accounts => {
   let testBatcher
   before('init', async () => {
     testBatcher = await TestBatcher.new()
   })
 
-  it.skip('gastest', async () => {
-    // await dump( testBatcher.gasSomething(3000, {gas:28174}))
-    // await dump( testBatcher.gasSomething(2091, {gas:28174}))
-    // await dump( testBatcher.gasSomething(2090, {gas:28174}))
-    // await dump( testBatcher.gasSomething(2000, {gas:28174}))
-    await dump(testBatcher.gasSomething(1), { gas: 2e6 })
-  })
-  it('#sendBatch() of single request', async () => {
+  it('#sendBatch() should call a single successful request', async () => {
     const ret = await testBatcher.sendBatch(
       [
         [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()]
@@ -43,7 +23,7 @@ contract.only('CallBatcher', accounts => {
       { event: 'BatchSent', sender: accounts[0], successful: '1', error: '' }
     ])
   })
-  it('#sendBatch() failed request', async () => {
+  it('#sendBatch() should return zero successful on failed request', async () => {
     // can use either {target,callData} (object) or [target,callData] (array)
     const ret = await testBatcher.sendBatch([
       { target: testBatcher.address, callData: testBatcher.contract.methods.somethingFailed().encodeABI() }
@@ -55,7 +35,7 @@ contract.only('CallBatcher', accounts => {
     ])
   })
 
-  it('#sendBatch() of multiple calls', async () => {
+  it('#sendBatch() should send multiple successful requests', async () => {
     const ret = await testBatcher.sendBatch(
       [
         [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
@@ -71,7 +51,8 @@ contract.only('CallBatcher', accounts => {
       { event: 'BatchSent', sender: accounts[0], successful: '3', error: '' }
     ])
   })
-  it('#sendBatch() return on first failure', async () => {
+
+  it('#sendBatch() should abort on first failure', async () => {
     const ret = await testBatcher.sendBatch(
       [
         [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
@@ -86,21 +67,7 @@ contract.only('CallBatcher', accounts => {
     ])
   })
 
-  it('#batchAndRevert() revert on first failure', async () => {
-    try {
-      await testBatcher.sendBatchAndRevert([
-        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.somethingFailed().encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
-      ])
-    } catch (e) {
-      assert.match(e, /called somethingFailed/)
-      return
-    }
-    assert.ok(false, 'should revert')
-  })
-
-  it('#sendBatch() don\'t return on first failure', async () => {
+  it('#sendBatch() should continue after failure', async () => {
     const ret = await testBatcher.sendBatch(
       [
         [testBatcher.address, testBatcher.contract.methods.somethingElse(false).encodeABI()],
@@ -117,29 +84,24 @@ contract.only('CallBatcher', accounts => {
     ])
   })
 
-  it('#sendBatch should send as many calls on gas limit ', async () => {
-    const call = testBatcher.contract.methods.sendBatch(
-      [
-        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.something(2).encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
-      ], false)
-
-    const gas = await call.estimateGas()
-
-    console.log('gas=', gas)
-    const ret = await testBatcher.sendBatch(
-      [
-        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.something(2).encodeABI()],
-        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
-      ], false, { gas: gas - 1 })
-
-    const logs = packLogs(ret.receipt.logs)
-    assert.deepEqual(logs, [
-      { event: 'Something', x: '1', msgsender: testBatcher.address },
-      { event: 'Something', x: '2', msgsender: testBatcher.address },
-      { event: 'BatchSent', sender: accounts[0], successful: '2', error: 'out-of-gas' }
+  it('#sendBatchAsTransaction() should send multiple requests', async () => {
+    const ret = await testBatcher.sendBatchAsTransaction([
+      [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+      [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
     ])
+    assert.deepEqual(packLogs(ret.receipt.logs), [
+      { event: 'Something', x: '1', msgsender: testBatcher.address },
+      { event: 'Something', x: '3', msgsender: testBatcher.address }
+    ])
+  })
+
+  it('#sendBatchAsTransaction() should revert on first failure', async () => {
+    return assert.isRejected(
+      testBatcher.sendBatchAsTransaction([
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingFailed().encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ])
+      , /revert.*called somethingFailed/)
   })
 })

--- a/test/batcher/CallBatcher.test.js
+++ b/test/batcher/CallBatcher.test.js
@@ -1,0 +1,145 @@
+/* global contract it before */
+const TestBatcher = artifacts.require('TestBatcher')
+const { assert } = require('chai')
+const { packLogs } = require('../testutils')
+
+async function dump (f) {
+  try {
+    const ret = await f
+    if (!ret.receipt.status) {
+      console.log('tx failed, gasused=', ret.receipt.gasUsed)
+    } else if (ret.receipt) {
+      console.log('gas=', ret.receipt.gasUsed, JSON.stringify(packLogs(ret.receipt.logs)))
+    } else {
+      console.log('ret=', ret)
+    }
+  } catch (e) {
+    console.log('ex=', e)
+  }
+}
+
+contract.only('CallBatcher', accounts => {
+  let testBatcher
+  before('init', async () => {
+    testBatcher = await TestBatcher.new()
+  })
+
+  it.skip('gastest', async () => {
+    // await dump( testBatcher.gasSomething(3000, {gas:28174}))
+    // await dump( testBatcher.gasSomething(2091, {gas:28174}))
+    // await dump( testBatcher.gasSomething(2090, {gas:28174}))
+    // await dump( testBatcher.gasSomething(2000, {gas:28174}))
+    await dump(testBatcher.gasSomething(1), { gas: 2e6 })
+  })
+  it('#sendBatch() of single request', async () => {
+    const ret = await testBatcher.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()]
+      ], false)
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'Something', x: '1', msgsender: testBatcher.address },
+      { event: 'BatchSent', sender: accounts[0], successful: '1', error: '' }
+    ])
+  })
+  it('#sendBatch() failed request', async () => {
+    // can use either {target,callData} (object) or [target,callData] (array)
+    const ret = await testBatcher.sendBatch([
+      { target: testBatcher.address, callData: testBatcher.contract.methods.somethingFailed().encodeABI() }
+    ], false)
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'BatchSent', sender: accounts[0], successful: '0', error: 'called somethingFailed' }
+    ])
+  })
+
+  it('#sendBatch() of multiple calls', async () => {
+    const ret = await testBatcher.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingElse(false).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ], false)
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'Something', x: '1', msgsender: testBatcher.address },
+      { event: 'Else', x: 'hello something else' },
+      { event: 'Something', x: '3', msgsender: testBatcher.address },
+      { event: 'BatchSent', sender: accounts[0], successful: '3', error: '' }
+    ])
+  })
+  it('#sendBatch() return on first failure', async () => {
+    const ret = await testBatcher.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingFailed().encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ], true)
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'Something', x: '1', msgsender: testBatcher.address },
+      { event: 'BatchSent', sender: accounts[0], successful: '1', error: 'called somethingFailed' }
+    ])
+  })
+
+  it('#batchAndRevert() revert on first failure', async () => {
+    try {
+      await testBatcher.sendBatchAndRevert([
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingFailed().encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ])
+    } catch (e) {
+      assert.match(e, /called somethingFailed/)
+      return
+    }
+    assert.ok(false, 'should revert')
+  })
+
+  it('#sendBatch() don\'t return on first failure', async () => {
+    const ret = await testBatcher.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.somethingElse(false).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingElse(true).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.somethingFailed().encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ], false)
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'Else', x: 'hello something else' },
+      { event: 'Something', x: '3', msgsender: testBatcher.address },
+      { event: 'BatchSent', sender: accounts[0], successful: '2', error: 'asked else to fail' }
+    ])
+  })
+
+  it('#sendBatch should send as many calls on gas limit ', async () => {
+    const call = testBatcher.contract.methods.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(2).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ], false)
+
+    const gas = await call.estimateGas()
+
+    console.log('gas=', gas)
+    const ret = await testBatcher.sendBatch(
+      [
+        [testBatcher.address, testBatcher.contract.methods.something(1).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(2).encodeABI()],
+        [testBatcher.address, testBatcher.contract.methods.something(3).encodeABI()]
+      ], false, { gas: gas - 1 })
+
+    const logs = packLogs(ret.receipt.logs)
+    assert.deepEqual(logs, [
+      { event: 'Something', x: '1', msgsender: testBatcher.address },
+      { event: 'Something', x: '2', msgsender: testBatcher.address },
+      { event: 'BatchSent', sender: accounts[0], successful: '2', error: 'out-of-gas' }
+    ])
+  })
+})

--- a/test/batcher/TestBatcher.sol
+++ b/test/batcher/TestBatcher.sol
@@ -1,0 +1,39 @@
+pragma solidity ^0.5.10;
+pragma experimental ABIEncoderV2;
+
+import "../../contracts/utils/CallBatcher.sol";
+
+//a sample contract using the CallBatcher
+contract TestBatcher {
+
+    event BatchSent(address indexed sender, uint successful, string error);
+
+    event Something(address msgsender, uint x);
+    event Else(string x);
+
+    //wrapper for sendBatch (since its internal)
+    function sendBatch(CallBatcher.Call[] memory calls, bool abortOnFirst) public {
+        (uint count, bytes memory error) = CallBatcher.sendBatch(calls, abortOnFirst);
+
+        emit BatchSent(msg.sender, count, CallBatcher.getErrorString(error));
+    }
+
+    function sendBatchAndRevert(CallBatcher.Call[] memory calls) public {
+        CallBatcher.sendBatchAndRevert(calls);
+    }
+
+    function somethingFailed() view public {
+        (this);
+        require(false, "called somethingFailed");
+    }
+
+    function something(uint x) public {
+        emit Something(msg.sender, x);
+    }
+
+    function somethingElse(bool fail) public {
+        require(!fail, "asked else to fail");
+        emit Else("hello something else");
+    }
+}
+

--- a/test/batcher/TestBatcher.sol
+++ b/test/batcher/TestBatcher.sol
@@ -18,8 +18,9 @@ contract TestBatcher {
         emit BatchSent(msg.sender, count, CallBatcher.getErrorString(error));
     }
 
-    function sendBatchAndRevert(CallBatcher.Call[] memory calls) public {
-        CallBatcher.sendBatchAndRevert(calls);
+    function sendBatchAsTransaction(CallBatcher.Call[] memory calls) public {
+
+        CallBatcher.sendBatchAsTransaction(calls);
     }
 
     function somethingFailed() view public {

--- a/test/testutils.js
+++ b/test/testutils.js
@@ -8,7 +8,25 @@ const HttpWrapper = require('../src/js/relayclient/HttpWrapper')
 const localhostOne = 'http://localhost:8090'
 const zeroAddr = '0'.repeat(40)
 
+// available on node13, as Object.fromEntries
+// this method is the reverse of Object.entries()
+function entriesToObject (entries) {
+  return entries.reduce((obj, [key, val]) => Object.assign(obj, { [key]: val }), {})
+}
+
 module.exports = {
+
+  // pack solidity logs into simpler structure, easier to assert.deepEquals.
+  // "event" member contains the event name. and then named members for all event params
+  packLogs: function (logs) {
+    return logs.map(log => ({
+      event: log.event,
+      ...entriesToObject(Object.entries({ ...log.args })
+        .filter(([name]) => /^[^_0-9]/.test(name))
+        .map(([name, val]) => ([name, val.toString()]))
+      )
+    }))
+  },
 
   // start a background relay process.
   // rhub - relay hub contract


### PR DESCRIPTION
A utility function for creating batch transactions, to be used by RelayRecipients.

The relay themselves don't use it: a relay process client request immediately, and can't wait for another client to send a request and batch them together.