### PR TITLE
Lower-cost relays

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -54,6 +54,7 @@ contract RelayHub is IRelayHub {
     uint256 public gtxdatanonzero;
     uint256 constant public GTRANSACTION = 21000;
 
+
     // Nonces of senders, used to prevent replay attacks
     mapping(address => uint256) private nonces;
 

--- a/server/src/librelay/relay_server_test.go
+++ b/server/src/librelay/relay_server_test.go
@@ -313,7 +313,7 @@ func TestRegisterRelay(t *testing.T) {
 	}
 	client.Commit()
 	test.ErrFail(relay.awaitTransactionMined(tx), t)
-	count, err := relay.BlockCountSinceRegistration()
+	count, err := relay.BlockCountSinceLastEvent()
 	if err != nil {
 		fmt.Println("ERROR", err)
 	}
@@ -413,6 +413,19 @@ func TestCreateRelayTransaction(t *testing.T) {
 	test.ErrFailWithDesc(err, t, "Creating relay transaction")
 	client.Commit()
 	assertTransactionRelayed(t, signedTx.Hash())
+
+}
+
+func TestBlockCountShouldCheckAllEvents(t *testing.T) {
+    //make sure that not only RelayAdded, but also TransactionRelayed counts for
+    // "last relay message"
+    count, err := relay.BlockCountSinceLastEvent()
+    if err != nil {
+        fmt.Println("ERROR", err)
+    }
+    if count != 1  {
+        t.Error("expected TransactionRelayed to be counted in BlockCountSinceLastEvent",  count)
+    }
 }
 
 func TestResendRelayTransaction(t *testing.T) {

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -22,7 +22,11 @@ relayHubAbi.push(versionAbi)
 
 const paymasterAbi = require('./interfaces/IPaymaster')
 
-const relayLookupLimitBlocks = 6000
+const SecondsPerBlock = 12
+
+// default history lookup for relays
+// assuming 12 seconds per block
+const relayLookupLimitBlocks = 3600 * 24 / SecondsPerBlock * 30
 abiDecoder.addABI(relayHubAbi)
 
 // default timeout (in ms) for http requests
@@ -45,11 +49,14 @@ class RelayClient {
    * create a RelayClient library object, to force contracts to go through a relay.
    * @param web3  - the web3 instance to use.
    * @param {object} config options
+   *    preferredRelays - if set, try to use these relays first. only if none of them return
+   *      a valid address (by calling its "/getaddr"), use the use the lookup mechanism.
    *    pctRelayFee
    *    validateCanRelay - client calls canRelay before calling the relay the first time (defaults to true)
    *lookup for relay
    *    minStake - ignore relays with stake below this (wei) value.
    *    minDelay - ignore relays with delay lower this (sec) value
+   *    relayLookupLimitBlocks - how many blocks back to look for relays. default = ~30 days
    *
    *    calculateRelayScore - function to give a "score" to a relay, based on its properties:
    *          transactionFee, stake, unstakeDelay, relayUrl.

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -1,18 +1,24 @@
 const BN = require('web3').utils.toBN
 
+const { event2topic } = require('./utils')
 // relays are "down-scored" in case they timed out a request.
 // they are "forgiven" after this timeout.
 const DEFAULT_RELAY_TIMEOUT_GRACE_SEC = 60 * 30
 
+// assume veri high stake values for preferred relays, so we don't need
+// to change the filter logic to always support them.
+const PREFERRED_STAKE = 1e30
+const PREFERRED_DELAY = 1e10
 class ActiveRelayPinger {
   // TODO: 'httpSend' should be on a network layer
-  constructor (filteredRelays, httpSend, gasPrice, verbose) {
+  constructor (filteredRelays, httpSend, gasPrice, verbose, nextPinger) {
     this.remainingRelays = filteredRelays.slice()
     this.httpSend = httpSend
     this.pingedRelays = 0
     this.relaysCount = filteredRelays.length
     this.gasPrice = gasPrice
     this.verbose = verbose
+    this.nextPinger = nextPinger
   }
 
   /**
@@ -20,10 +26,15 @@ class ActiveRelayPinger {
    * @returns the first relay to respond to a ping message. Note: will never return the same relay twice.
    */
   async nextRelay () {
-    if (this.remainingRelays.length === 0) {
-      return null
+    let ret = await this.nextRelay1()
+    // only if no relay found in this ActivePinger, start using the next ActivePinger
+    if (!ret && this.nextPinger) {
+      ret = await this.nextPinger.nextRelay()
     }
+    return ret
+  }
 
+  async nextRelay1 () {
     while (this.remainingRelays.length) {
       const bulkSize = Math.min(3, this.remainingRelays.length)
       try {
@@ -106,6 +117,7 @@ class ServerHelper {
   constructor (httpSend, failedRelays,
     {
       verbose,
+      preferredRelays, // URLs of relays to use always first, before any globally found relays
       minStake, minDelay, // params for relayFilter: filter out this relay if unstakeDelay or stake are too low.
       relayTimeoutGrace, // ignore score drop of a relay after this time (seconds)
       calculateRelayScore, // function: return relay score, higher the better. default uses transaction fees and some randomness
@@ -114,6 +126,9 @@ class ServerHelper {
       // (used by test to REMOVE the randomness, and make the test deterministic.
     }) {
     this.httpSend = httpSend
+    if (typeof preferredRelays !== 'undefined') {
+      this.preferredRelays = Array.isArray(preferredRelays) ? preferredRelays : [preferredRelays]
+    }
     this.verbose = verbose
     this.failedRelays = failedRelays
     this.relayTimeoutGrace = relayTimeoutGrace || DEFAULT_RELAY_TIMEOUT_GRACE_SEC
@@ -181,11 +196,24 @@ class ServerHelper {
       this.fromBlock = fromBlock
       await this.fetchRelaysAdded()
     }
-    return this.createActiveRelayPinger(this.filteredRelays, this.httpSend, gasPrice, this.verbose)
+    return this.createActiveRelayPinger(this.filteredRelays, this.httpSend, gasPrice, this.verbose, this.preferredRelays)
   }
 
-  createActiveRelayPinger (filteredRelays, httpSend, gasPrice, verbose) {
-    return new ActiveRelayPinger(filteredRelays, httpSend, gasPrice, verbose)
+  createActiveRelayPinger (filteredRelays, httpSend, gasPrice, verbose, preferredRelays) {
+    let pinger = new ActiveRelayPinger(filteredRelays, httpSend, gasPrice, verbose)
+    if (preferredRelays) {
+      const prefs = this.preferredRelays.map(relayUrl => ({
+        relayUrl,
+        transactionFee: 0,
+        stake: PREFERRED_STAKE,
+        unstakeDelay: PREFERRED_DELAY
+      })
+      )
+      // if there are preferred relays, create a pinger that uses them FIRST, and only
+      // falls-back to the "normal" pinger, based on the filtered list.
+      pinger = new ActiveRelayPinger(prefs, httpSend, gasPrice, verbose, pinger)
+    }
+    return pinger
   }
 
   /**
@@ -193,37 +221,65 @@ class ServerHelper {
    * initializes an array {@link filteredRelays} of relays curently registered on given RelayHub contract
    */
   async fetchRelaysAdded () {
-    const activeRelays = {}
+    this.verbose = true
     const fromBlock = this.fromBlock || 2
-    const addedAndRemovedEvents = await this.relayHubInstance.getPastEvents('allEvents', {
-      fromBlock: fromBlock
-      // topics: [["RelayAdded", "RelayRemoved"]]
+    const eventTopics = event2topic(this.relayHubInstance,
+      ['RelayAdded', 'RelayRemoved', 'TransactionRelayed', 'CanRelayFailed'])
+
+    const relayEvents = await this.relayHubInstance.getPastEvents('allEvents', {
+      fromBlock: fromBlock,
+      topics: [eventTopics]
     })
 
     if (this.verbose) {
-      console.log('fetchRelaysAdded: found ' + addedAndRemovedEvents.length + ' events')
+      console.log('fetchRelaysAdded: found ', relayEvents.length + ' events')
     }
-    // TODO: better filter RelayAdded, RelayRemoved events: otherwise, we'll be scanning all TransactionRelayed too...
-    // since RelayAdded can't be called after RelayRemoved, its OK to scan first for add, and the remove all removed relays.
-    for (var index in addedAndRemovedEvents) {
-      const event = addedAndRemovedEvents[index]
-      if (event.event === 'RelayAdded') {
-        const args = event.returnValues
-        const relay = {
-          address: args.relay,
-          relayUrl: args.url,
-          baseRelayFee: args.baseRelayFee,
-          pctRelayFee: args.pctRelayFee,
-          stake: args.stake,
-          unstakeDelay: args.unstakeDelay
-        }
-        relay.score = this.calculateRelayScore(relay)
-        activeRelays[args.relay] = relay
-      } else if (event.event === 'RelayRemoved') {
-        delete activeRelays[event.returnValues.relay]
+    const foundRelays = {}
+    relayEvents.forEach(event => {
+      if (event.event === 'RelayRemoved') {
+        delete foundRelays[event.returnValues.relay]
+      } else {
+        foundRelays[event.returnValues.relay] = 1
       }
+    })
+
+    if (this.verbose) {
+      console.log('fetchRelaysAdded: found', Object.keys(foundRelays).length, 'unique relays')
     }
 
+    const relayAddedTopic = event2topic(this.relayHubInstance, 'RelayAdded')
+
+    function toBytes32 (addr) {
+      return '0x' + addr.replace(/^0x/, '').padStart(64, '0').toLowerCase()
+    }
+    // found all addresses. 2nd round to get the RelayAdded event for each of those relays.
+    // TODO: at least some of the found relays above was due to "RelayAdded" event,
+    // we _could_ optimize for that, but since at least _some_ relays
+    // were found by the TransactionRelayed event, we are forced to search them
+    // for actual address.
+    const relayAddedEvents = await this.relayHubInstance.getPastEvents('RelayAdded', {
+      fromBlock: 1,
+      topics: [relayAddedTopic, Object.keys(foundRelays).map(toBytes32)]
+    })
+
+    if (this.verbose) {
+      console.log('== fetchRelaysAdded: found ', relayAddedEvents.length + ' unique RelayAdded events (should have at least as unique relays, above)')
+    }
+
+    const activeRelays = {}
+    relayAddedEvents.forEach(event => {
+      const args = event.returnValues
+      const relay = {
+        address: args.relay,
+        relayUrl: args.url,
+        baseRelayFee: args.baseRelayFee,
+        pctRelayFee: args.pctRelayFee,
+        stake: args.stake,
+        unstakeDelay: args.unstakeDelay
+      }
+      relay.score = this.calculateRelayScore(relay)
+      activeRelays[args.relay] = relay
+    })
     const origRelays = Object.values(activeRelays)
     const filteredRelays = origRelays.filter(this.relayFilter).sort(this.compareRelayScores.bind(this))
 

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -234,12 +234,12 @@ class ServerHelper {
     if (this.verbose) {
       console.log('fetchRelaysAdded: found ', relayEvents.length + ' events')
     }
-    const foundRelays = {}
+    const foundRelays = new Set()
     relayEvents.forEach(event => {
       if (event.event === 'RelayRemoved') {
-        delete foundRelays[event.returnValues.relay]
+        foundRelays.delete(event.returnValues.relay)
       } else {
-        foundRelays[event.returnValues.relay] = 1
+        foundRelays.add(event.returnValues.relay)
       }
     })
 
@@ -259,7 +259,7 @@ class ServerHelper {
     // for actual address.
     const relayAddedEvents = await this.relayHubInstance.getPastEvents('RelayAdded', {
       fromBlock: 1,
-      topics: [relayAddedTopic, Object.keys(foundRelays).map(toBytes32)]
+      topics: [relayAddedTopic, Array.from(foundRelays, toBytes32)]
     })
 
     if (this.verbose) {

--- a/src/js/relayclient/ServerHelper.js
+++ b/src/js/relayclient/ServerHelper.js
@@ -26,7 +26,7 @@ class ActiveRelayPinger {
    * @returns the first relay to respond to a ping message. Note: will never return the same relay twice.
    */
   async nextRelay () {
-    let ret = await this.nextRelay1()
+    let ret = await this._nextRelayInternal()
     // only if no relay found in this ActivePinger, start using the next ActivePinger
     if (!ret && this.nextPinger) {
       ret = await this.nextPinger.nextRelay()
@@ -34,7 +34,7 @@ class ActiveRelayPinger {
     return ret
   }
 
-  async nextRelay1 () {
+  async _nextRelayInternal () {
     while (this.remainingRelays.length) {
       const bulkSize = Math.min(3, this.remainingRelays.length)
       try {

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -67,7 +67,6 @@ module.exports = {
     })
   },
 
-
   /**
    * @param gasLimits
    * @param hubOverhead

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -4,6 +4,7 @@ const web3Utils = require('web3-utils')
 
 const getDataToSign = require('./EIP712/Eip712Helper')
 
+const abi = require('web3-eth-abi')
 function removeHexPrefix (hex) {
   return hex.replace(/^0x/, '')
 }
@@ -17,7 +18,19 @@ function padTo64 (hex) {
   return hex
 }
 
+function event2topic (contract, names) {
+  // for testing: don't crash on mockup..
+  if (!contract.options || !contract.options.jsonInterface) { return names }
+  if (typeof names === 'string') {
+    return event2topic(contract, [names])[0]
+  }
+  return contract.options.jsonInterface
+    .filter(e => names.includes(e.name))
+    .map(abi.encodeEventSignature)
+}
 module.exports = {
+  event2topic,
+
   getEip712Signature: async function (
     {
       web3,
@@ -53,6 +66,7 @@ module.exports = {
       })
     })
   },
+
 
   /**
    * @param gasLimits

--- a/test/SampleRecipient.test.js
+++ b/test/SampleRecipient.test.js
@@ -35,7 +35,7 @@ contract('SampleRecipient', function (accounts) {
     })
     const a0BalanceAfter = await web3.eth.getBalance(accounts[0])
     const expectedBalanceAfter = new Big(a0BalanceBefore).add(deposit).sub(res.receipt.gasUsed * gasPrice)
-    assert.equal(expectedBalanceAfter.toString(), a0BalanceAfter.toString())
+    assert.equal(expectedBalanceAfter.toFixed(), a0BalanceAfter.toString())
     depositActual = await rhub.balanceOf(sample.address)
     assert.equal('0', depositActual.toString())
   })

--- a/test/server_helper_test.js
+++ b/test/server_helper_test.js
@@ -1,6 +1,7 @@
 const assert = require('chai').use(require('chai-as-promised')).assert
 const ServerHelper = require('../src/js/relayclient/ServerHelper')
 const HttpWrapper = require('../src/js/relayclient/HttpWrapper')
+const http = require('http')
 const testutils = require('./testutils')
 const registerNewRelay = testutils.registerNewRelay
 const increaseTime = testutils.increaseTime
@@ -13,6 +14,16 @@ const gasPricePercent = 20
 // ServerHelper adds "noise" to shuffle requests with the same score.
 // this will prevent this randomness, to make tests deterministic.
 const noRandomness = () => 0
+
+function mockserver (port, data) {
+  const s = http.createServer(function (req, res) {
+    res.writeHead(200, { 'Content-Type': 'text/plain' })
+    res.write(JSON.stringify(data))
+    res.end()
+  })
+  s.listen(port)
+  return s
+}
 
 contract('ServerHelper', function (accounts) {
   const minStake = 1.5e18
@@ -39,7 +50,7 @@ contract('ServerHelper', function (accounts) {
       EthereumNodeUrl: web3.currentProvider.host,
       GasPricePercent: gasPricePercent
     })
-    serverHelper.setHub(rhub)
+    serverHelper.setHub(rhub.contract)
   })
 
   after(async function () {
@@ -124,7 +135,7 @@ contract('ServerHelper', function (accounts) {
       await increaseTime(3600 * 24 * 7 * 2)
       await rhub.unstake(accounts[2], { from: accounts[0] })
 
-      serverHelper.setHub(rhub)
+      serverHelper.setHub(rhub.contract)
     })
 
     it('should list all relays from relay contract', async function () {
@@ -139,6 +150,33 @@ contract('ServerHelper', function (accounts) {
       const pinger = await serverHelper.newActiveRelayPinger()
       const relay = await pinger.nextRelay()
       assert.equal(localhostOne, relay.relayUrl)
+    })
+
+    it('should discover preferred relay first', async () => {
+      let mockrelay
+      try {
+        const mockport = 12345
+        mockrelay = mockserver(mockport, {
+          RelayServerAddress: '0x' + 'a'.repeat(40),
+          MinGasPrice: 1111000000,
+          Ready: true,
+          Version: '0.4.2'
+        })
+        serverHelper.preferredRelays = [
+          'http://localhost:19999', // a preferred relay, but missing..
+          'http://localhost:' + mockport
+        ]
+        await serverHelper.fetchRelaysAdded()
+        console.log('list=', serverHelper.filteredRelays)
+        const pinger = await serverHelper.newActiveRelayPinger()
+        let relay = await pinger.nextRelay()
+        assert.equal('http://localhost:12345', relay.relayUrl)
+        relay = await pinger.nextRelay()
+        assert.equal(localhostOne, relay.relayUrl)
+      } finally {
+        serverHelper.preferredRelays = undefined
+        mockrelay.close()
+      }
     })
   })
 
@@ -237,6 +275,11 @@ contract('ServerHelper', function (accounts) {
       customServerHelper.setHub(this.mockRelayHub)
       const relays = await customServerHelper.fetchRelaysAdded()
       assert.deepEqual(relays.map(r => r.address), ['5', '7', '6', '1', '2', '3', '4'])
+    })
+
+    it('preferredRelays can be a url or an array', () => {
+      assert.deepEqual(['url'], new ServerHelper(httpWrapper, {}, { preferredRelays: 'url' }).preferredRelays)
+      assert.deepEqual(['url1', 'url2'], new ServerHelper(httpWrapper, {}, { preferredRelays: ['url1', 'url2'] }).preferredRelays)
     })
 
     it('should use custom strategy for filtering and sorting relays', async function () {


### PR DESCRIPTION
### Purpose:
Don't require relays to re-register. once is enough.

### New relay lookup mechanism:
- look for all relay events (not only RelayAdded) in the past X blocks (~30 days)
- after finding unique relays, look up for latest RelayAdded for each one of them.

### API change
- client can specify `preferredRelays` (urls)
- these relays are always added at the beginning of the relays list (only checked for "ping", not txfee/stake/delay)
- only if none of the preferred relays answer, it will continue with the rest of the "public" relays