### PR TITLE
Nonview acceptRelayedCall

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -237,7 +237,6 @@ contract RelayHub is IRelayHub {
         bytes memory approvalData
     )
     public
-    view
     returns (uint256 status, bytes memory recipientContext)
     {
         // Verify the sender's signature on the transaction - note that approvalData is *not* signed

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -15,8 +15,9 @@ import "./utils/GsnUtils.sol";
 import "./utils/RLPReader.sol";
 import "./interfaces/IRelayHub.sol";
 import "./interfaces/IGasSponsor.sol";
+import "./utils/DryRun.sol";
 
-contract RelayHub is IRelayHub {
+contract RelayHub is IRelayHub, DryRun {
 
     string constant public COMMIT_ID = "$Id$";
 
@@ -254,7 +255,7 @@ contract RelayHub is IRelayHub {
         );
 
         (bool success, bytes memory returndata) =
-        relayRequest.relayData.gasSponsor.staticcall.gas(acceptRelayedCallGasLimit)(encodedTx);
+        relayRequest.relayData.gasSponsor.call.gas(acceptRelayedCallGasLimit)(encodedTx);
 
         if (!success) {
             return (uint256(PreconditionCheck.AcceptRelayedCallReverted), "");
@@ -513,7 +514,7 @@ contract RelayHub is IRelayHub {
         bytes data;
     }
 
-    function decodeTransaction(bytes memory rawTransaction) private pure returns (Transaction memory transaction) {
+    function decodeTransaction(bytes memory rawTransaction) internal pure returns (Transaction memory transaction) {
         (transaction.nonce,
         transaction.gasPrice,
         transaction.gasLimit,
@@ -584,7 +585,7 @@ contract RelayHub is IRelayHub {
         penalize(relay);
     }
 
-    function penalize(address relay) private {
+    function penalize(address relay) internal {
         require((relays[relay].state == RelayState.Staked) ||
         (relays[relay].state == RelayState.Registered) ||
             (relays[relay].state == RelayState.Removed), "Unstaked relay");

--- a/contracts/interfaces/IGasSponsor.sol
+++ b/contracts/interfaces/IGasSponsor.sol
@@ -41,7 +41,6 @@ interface IGasSponsor {
         uint256 maxPossibleGas
     )
     external
-    view
     returns (uint256, bytes memory);
 
     /** this method is called before the actual relayed function call.

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -217,6 +217,9 @@ interface IRelayHub {
         bytes calldata approvalData
     ) external;
 
+    function dryRun(address from, address target, bytes calldata encodedFunction, uint gasLimit)
+    external returns (bool success, string memory err);
+
     // Relay penalization. Any account can penalize relays, removing them from the system immediately, and rewarding the
     // reporter with half of the relay's stake. The other half is burned so that, even if the relay penalizes itself, it
     // still loses half of its stake.

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -193,7 +193,6 @@ interface IRelayHub {
         bytes calldata approvalData
     )
     external
-    view
     returns (uint256 status, bytes memory recipientContext);
 
     /// Relays a transaction. For this to succeed, multiple conditions must be met:

--- a/contracts/samples/DryRunSponsor.sol
+++ b/contracts/samples/DryRunSponsor.sol
@@ -1,0 +1,56 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "../BaseGasSponsor.sol";
+import "../BaseRelayRecipient.sol";
+
+/**
+ * Dry-run the target method as an indicator whether to accept it or not.
+ * This sponsor won't accept target method that fails.
+ * It also verifies the target contract is in a given whitelist.
+ */
+contract DryRunSponsor is BaseGasSponsor, BaseRelayRecipient {
+
+    mapping(address => bool) public recipients;
+    mapping(address => bool) public admins;
+
+    constructor(IRelayHub _relayHub) public {
+        relayHub = _relayHub;
+    }
+
+    function addRecipient(address recipient, bool add) public onlyOwner() {
+        recipients[recipient] = add;
+    }
+
+    function acceptRelayedCall(
+        GSNTypes.RelayRequest calldata relayRequest,
+        bytes calldata approvalData,
+        uint256 maxPossibleCharge
+    )
+    external
+    returns (uint256, bytes memory) {
+        (approvalData, maxPossibleCharge);
+        if ( !recipients[relayRequest.target] ) {
+            return ( 98, "unknown recipient");
+        }
+        (bool success, string memory ret ) = relayHub.dryRun( 
+                relayRequest.relayData.senderAccount,
+                relayRequest.target,
+                relayRequest.encodedFunction,
+                relayRequest.gasData.gasLimit
+            );
+        if ( !success )
+            return (99, bytes(ret));
+
+        return (0,'');
+    }
+
+    function preRelayedCall(bytes calldata context) external returns (bytes32) {
+        (this, context);
+        return "";
+    }
+
+    function postRelayedCall(bytes calldata context, bool success, uint actualCharge, bytes32 preRetVal) view external {
+        (this, context, success, actualCharge, preRetVal);
+    }
+}

--- a/contracts/samples/DryRunSponsor.sol
+++ b/contracts/samples/DryRunSponsor.sol
@@ -49,8 +49,19 @@ contract DryRunSponsor is BaseGasSponsor, BaseRelayRecipient {
         (this, context);
         return "";
     }
-
-    function postRelayedCall(bytes calldata context, bool success, uint actualCharge, bytes32 preRetVal) view external {
-        (this, context, success, actualCharge, preRetVal);
+    function postRelayedCall(
+        bytes calldata context,
+        bool success,
+        bytes32 preRetVal,
+        uint256 gasUseWithoutPost,
+        uint256 txFee,
+        uint256 gasPrice
+    ) external {
+        (this, context, success, preRetVal, gasUseWithoutPost, txFee, gasPrice);
     }
 }
+
+library dryNonAbstract { function run() internal {
+	new DryRunSponsor(IRelayHub(address(0)));
+}}
+

--- a/contracts/samples/KnownUsersSponsor.sol
+++ b/contracts/samples/KnownUsersSponsor.sol
@@ -61,7 +61,6 @@ contract KnownUsersSponsor is BaseGasSponsor, BaseRelayRecipient {
         uint256 maxPossibleCharge
     )
     external
-    view
     returns (uint256, bytes memory) {
         (approvalData, maxPossibleCharge);
         address from = relayRequest.relayData.senderAccount;
@@ -72,11 +71,11 @@ contract KnownUsersSponsor is BaseGasSponsor, BaseRelayRecipient {
     }
 
     function preRelayedCall(bytes calldata context) external returns (bytes32) {
-        (context);
+        (this, context);
         return "";
     }
 
-    function postRelayedCall(bytes calldata context, bool success, uint actualCharge, bytes32 preRetVal) external {
-        (context, success, actualCharge, preRetVal);
+    function postRelayedCall(bytes calldata context, bool success, uint actualCharge, bytes32 preRetVal) view external {
+        (this, context, success, actualCharge, preRetVal);
     }
 }

--- a/contracts/samples/TokenRecipient.sol
+++ b/contracts/samples/TokenRecipient.sol
@@ -43,7 +43,7 @@ contract TokenRecipient is BaseRelayRecipient {
      *  Later, the RelayHub calls it again, to validate the transaction on-chain, and thus perform
      *  the actual payment.
      */
-    function acceptRelayedCall(address, address from, bytes memory/* transaction */) view public returns (uint) {
+    function acceptRelayedCall(address, address from, bytes memory/* transaction */) public view returns (uint) {
 
         //user doesn't have enough tokens. reject request.
         if (mytoken.balanceOf(from) < txPrice)

--- a/contracts/samples/TokenRecipient.sol
+++ b/contracts/samples/TokenRecipient.sol
@@ -43,7 +43,7 @@ contract TokenRecipient is BaseRelayRecipient {
      *  Later, the RelayHub calls it again, to validate the transaction on-chain, and thus perform
      *  the actual payment.
      */
-    function acceptRelayedCall(address, address from, bytes memory/* transaction */) public view returns (uint) {
+    function acceptRelayedCall(address, address from, bytes memory/* transaction */) view public returns (uint) {
 
         //user doesn't have enough tokens. reject request.
         if (mytoken.balanceOf(from) < txPrice)

--- a/contracts/test/TestSponsorConfigurableMisbehavior.sol
+++ b/contracts/test/TestSponsorConfigurableMisbehavior.sol
@@ -38,7 +38,6 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
         uint256 maxPossibleCharge
     )
     external
-    view
     returns (uint256, bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
         if (overspendAcceptGas) {

--- a/contracts/test/TestSponsorConfigurableMisbehavior.sol
+++ b/contracts/test/TestSponsorConfigurableMisbehavior.sol
@@ -12,6 +12,8 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
     bool public overspendAcceptGas;
     bool public revertPreRelayCall;
 
+    bool public arcModifies;
+    uint public modified;
     function setWithdrawDuringPostRelayedCall(bool val) public {
         withdrawDuringPostRelayedCall = val;
     }
@@ -20,6 +22,9 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
     }
     function setReturnInvalidErrorCode(bool val) public {
         returnInvalidErrorCode = val;
+    }
+    function setARCmodifies(bool val) public {
+        arcModifies=val;
     }
     function setRevertPostRelayCall(bool val) public {
         revertPostRelayCall = val;
@@ -31,6 +36,7 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
         overspendAcceptGas = val;
     }
 
+    event ARCmodified(uint counter);
 
     function acceptRelayedCall(
         GSNTypes.RelayRequest calldata relayRequest,
@@ -40,6 +46,10 @@ contract TestSponsorConfigurableMisbehavior is TestSponsorEverythingAccepted {
     external
     returns (uint256, bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
+        if ( arcModifies ) {
+            modified++;
+            emit ARCmodified(modified);
+        }
         if (overspendAcceptGas) {
             uint i = 0;
             while (true) {

--- a/contracts/test/TestSponsorEverythingAccepted.sol
+++ b/contracts/test/TestSponsorEverythingAccepted.sol
@@ -14,7 +14,6 @@ contract TestSponsorEverythingAccepted is BaseGasSponsor {
         uint256 maxPossibleCharge
     )
     external
-    view
     returns (uint256, bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
         return (0, "");

--- a/contracts/test/TestSponsorOwnerSignature.sol
+++ b/contracts/test/TestSponsorOwnerSignature.sol
@@ -17,7 +17,6 @@ contract TestSponsorOwnerSignature is TestSponsorEverythingAccepted {
         uint256 maxPossibleCharge
     )
     external
-    view
     returns (uint256, bytes memory) {
         (maxPossibleCharge);
         address signer =

--- a/contracts/test/TestSponsorPreconfiguredApproval.sol
+++ b/contracts/test/TestSponsorPreconfiguredApproval.sol
@@ -17,7 +17,6 @@ contract TestSponsorPreconfiguredApproval is TestSponsorEverythingAccepted {
         uint256 maxPossibleCharge
     )
     external
-    view
     returns (uint256, bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
         if (keccak256(expectedApprovalData) != keccak256(approvalData)) {

--- a/contracts/test/TestSponsorStoreContext.sol
+++ b/contracts/test/TestSponsorStoreContext.sol
@@ -38,7 +38,6 @@ contract TestSponsorStoreContext is TestSponsorEverythingAccepted {
         uint256 maxPossibleGas
     )
     external
-    view
     returns (uint256, bytes memory) {
         return (0, abi.encode(
             relayRequest.relayData.relayAddress,

--- a/contracts/test/TestSponsorVariableGasLimits.sol
+++ b/contracts/test/TestSponsorVariableGasLimits.sol
@@ -22,7 +22,6 @@ contract TestSponsorVariableGasLimits is TestSponsorEverythingAccepted {
         uint256 maxPossibleGas
     )
     external
-    view
     returns (uint256, bytes memory) {
         (relayRequest, approvalData);
         return (0, abi.encode(

--- a/contracts/utils/DryRun.sol
+++ b/contracts/utils/DryRun.sol
@@ -1,0 +1,94 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+//import "@nomiclabs/buidler/console.sol";
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
+
+//"library" with dry-run function.
+//NOTE: since we actively call a method, we can't be a stand-alone library, and you must
+// inherit this library
+contract DryRun {
+
+    //we try to estimate gas usage, but there's some "slack" due to our very test
+    // (using "gasleft()")
+    uint  callGasOverhead = 1000; // TODO: find proper value
+
+    function setGasOverhead(uint a) internal {
+        callGasOverhead = a;
+    }
+
+    /**
+     * make a "dry-run" test on the given function
+     * check if the given encodedFunction would revert.
+     * NOTE: even when the function's execution is successful, all state-changes
+     *  are reverted. That's why we call this a "dry-run"
+     * @param from the "from" address to set (see note below)
+     * @param target the contract to run the function
+     * @param encodedFunction the function to run
+     * @param gasLimit gas to give the call
+     * return:
+     *  success - true if the call would complete without revert, false otherwise
+     *  err - in case success==false, the revert string
+     *
+     * @notice the sender is appended to the encoded function, so that a recipient can
+     * use getSender() to extract it - but reciepient does NOT extract it unless the caller
+     * is the RelayHub - so it must have a modified "gasSender", to accept this contract too.
+     */
+    function dryRun(address from, address target, bytes calldata encodedFunction, uint gasLimit) external returns (bool success, string memory err) {
+        //note that we append "from" just like RelayHub, but for this to work,
+        // the recipient must accept the sponsor as a "trusted caller", just like
+        // a RelayHub (or else, it will check with the wrong sender)
+        bytes memory callInner = abi.encodeWithSelector(
+            this.internalRunAndRevert.selector,
+            target, abi.encodePacked(encodedFunction, from), gasLimit);
+        (bool neverSuccess, bytes memory buf) = address(this).call(callInner);
+        (neverSuccess);
+        bytes memory ret;
+        (success, ret) = abi.decode(buf, (bool, bytes));
+        err = getError(ret);
+    }
+
+
+    //check that the given function can be called successfully.
+    // always revert with return value of (bool success, bytes revertData)
+    //  success - true if succeeded, false if reverted
+    //  revertData - if success==false, the revert returned data
+
+    // NOTE: getSender() works correctly only when used from RelayHub
+    function internalRunAndRevert(address target, bytes calldata encodedFunction, uint gasLimit) external {
+        bool success;
+        bytes memory ret;
+        if (msg.sender != address(this)) {
+            success=false;
+            ret = abi.encodeWithSignature("Error(string)", "only from dryRun()");
+        } else {
+            uint gasBefore = gasleft();
+            (success, ret) = target.call.gas(gasLimit )(encodedFunction);
+            uint gasused = gasBefore - gasleft();
+    //        console.log( "gas used success", gasused, success, ret.length);
+            //try to translate revert caused by "out of gas" to readable message
+            if (!success && ret.length == 0 && (gasLimit < callGasOverhead) || (gasused > gasLimit - callGasOverhead)) {
+                ret = abi.encodeWithSignature("Error(string)", "out-of-gas");
+            }
+        }
+
+        revertWithData(abi.encode(success, ret));
+    }
+
+    //extract the error string from a revert return value
+    function getError(bytes memory err) internal pure returns (string memory ret) {
+        if (err.length < 4 + 32)
+            return string(err);
+        //not a valid revert with error. return as-is.
+        (ret) = abi.decode(LibBytes.slice(err, 4, err.length), (string));
+    }
+
+    function revertWithData(bytes memory data) private pure {
+        assembly {
+            let dataSize := mload(data)
+            let dataPtr := add(data, 32)
+
+            revert(dataPtr, dataSize)
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "0.4.5",
+  "version": "0.5.0-nonview-arc3",
   "description": "Openeth Gas Stations Network",
   "name": "@openeth/gsn",
   "license": "MIT",

--- a/scripts/singleton/compute.sh
+++ b/scripts/singleton/compute.sh
@@ -28,7 +28,7 @@ rm -rf "$output_dir" # Delete possible remains from previous run
 mkdir -p "$output_dir"
 
 echo "Flattening source files into a single file"
-npx truffle-flattener contracts/RelayHub.sol > $output_dir/RelayHub.flattened.sol
+( echo "pragma experimental ABIEncoderV2;"; npx truffle-flattener contracts/RelayHub.sol |grep -v 'pragma experimental ABIEncoderV2') > $output_dir/RelayHub.flattened.sol
 
 echo "Compiling with solcjs version $(npx solcjs --version)"
 npx solcjs --optimize --optimize-runs 200 --abi --bin --output-dir $output_dir "$output_dir/RelayHub.flattened.sol"

--- a/scripts/singleton/deploy.js
+++ b/scripts/singleton/deploy.js
@@ -1,11 +1,10 @@
 const deployData = require('../../singleton/deploy.json')
-const { BN, toWei } = require('web3-utils')
 
 // Deploys a RelayHub instance, reading required data from singleton/deploy.json, the output of scripts/singleton/compute.sh
 // Call this file with truffle exec on the target network.
 async function deploy () {
   const funder = (await web3.eth.getAccounts())[0]
-  await web3.eth.sendTransaction({ from: funder, to: deployData.deployer, value: new BN(toWei('0.42', 'ether')) })
+  await web3.eth.sendTransaction({ from: funder, to: deployData.deployer, value: deployData.gas })
 
   await web3.eth.sendSignedTransaction(deployData.contract.deployTx)
   console.log(`Deployed at ${deployData.contract.address}`)

--- a/scripts/singleton/get-deploy-data.js
+++ b/scripts/singleton/get-deploy-data.js
@@ -1,6 +1,6 @@
-import Transaction from 'ethereumjs-tx'
-import ethUtils from 'ethereumjs-util'
-import fs from 'fs'
+const Transaction = require('ethereumjs-tx')
+const ethUtils = require('ethereumjs-util')
+const fs = require('fs')
 
 function toHexString (buffer) {
   return '0x' + buffer.toString('hex')
@@ -8,12 +8,17 @@ function toHexString (buffer) {
 
 const bin = fs.readFileSync('singleton/singleton_RelayHub_flattened_sol_RelayHub.bin', 'ascii')
 
+// gas price for nonzero byte. 68 pre-instanbul, 16 >= istanbul
+const gtxdatanonzero = 68
+const gasLimit = 5400000
+const gasPrice = 100000000000 /// 100 gigawei
+
 const tx = new Transaction({
   nonce: 0,
-  data: '0x' + bin,
+  data: '0x' + bin + gtxdatanonzero.toString(16).padStart(64, '0'),
   value: 0,
-  gasPrice: 100000000000, /// 100 gigawei
-  gasLimit: 4200000,
+  gasPrice,
+  gasLimit,
   v: 27,
   r: '0x1613161316131613161316131613161316131613161316131613161316131613',
   s: '0x1613161316131613161316131613161316131613161316131613161316131613'
@@ -23,6 +28,7 @@ const deployer = tx.getSenderAddress()
 
 console.log(JSON.stringify({
   deployer: toHexString(deployer),
+  gas: gasPrice * gasLimit,
   contract: {
     address: toHexString(ethUtils.generateAddress(deployer, ethUtils.toBuffer(0))),
     deployTx: toHexString(tx.serialize())

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -219,7 +219,7 @@ contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other,
             relayHub,
             ...sharedTransactionData
           })
-          const canRelay = await relayHub.canRelay(
+          const canRelay = await relayHub.canRelay.call(
             relayRequest,
             gasLimits.maxPossibleGas,
             gasLimits.acceptRelayedCallGasLimit,
@@ -235,7 +235,7 @@ contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other,
             relayHub,
             ...sharedTransactionData
           })
-          const canRelay = await relayHub.canRelay(relayRequest,
+          const canRelay = await relayHub.canRelay.call(relayRequest,
             gasLimits.maxPossibleGas,
             gasLimits.acceptRelayedCallGasLimit,
             wrongSig, '0x')
@@ -255,7 +255,7 @@ contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other,
             ...sharedTransactionData
           })
 
-          const canRelay = await relayHub.canRelay(
+          const canRelay = await relayHub.canRelay.call(
             relayRequest,
             gasLimits.maxPossibleGas,
             gasLimits.acceptRelayedCallGasLimit,

--- a/test/RelayHub.test.js
+++ b/test/RelayHub.test.js
@@ -372,6 +372,18 @@ contract('RelayHub', function ([_, relayOwner, relay, otherRelay, sender, other,
           })
         })
 
+        it('should succeed if acceptRelayedCall modifies data', async function () {
+          await misbehavingSponsor.setARCmodifies(true)
+          const relayRequest = getRelayRequest(sender, recipient.address, txData, fee, gasPrice, gasLimit, senderNonce, relay, misbehavingSponsor.address)
+          const { logs } = await relayHub.relayCall(relayRequest, signatureWithMisbehavingSponsor, '0x', {
+            from: relay,
+            gasPrice
+          })
+
+          console.log('logs=', logs)
+          expectEvent.inLogs(logs, 'TransactionRelayed', { status: RelayCallStatusCodes.OK })
+        })
+
         it('relaying is aborted if the recipient returns an invalid status code', async function () {
           await misbehavingSponsor.setReturnInvalidErrorCode(true)
           const relayRequest = getRelayRequest(sender, recipient.address, txData, fee, gasPrice, gasLimit, senderNonce, relay, misbehavingSponsor.address)

--- a/test/RelayHubGasCalculations.test.js
+++ b/test/RelayHubGasCalculations.test.js
@@ -155,7 +155,7 @@ contract('RelayHub gas calculations', async function ([_, relayOwner, relayAddre
       const acceptRelayedCallGasLimit = 50000
       const relayRequest = getRelayRequest(senderAccount, recipient.address, encodedFunction,
         fee, gasPrice, gasLimit, senderNonce, relayAddress, misbehavingSponsor.address)
-      const canRelayResponse = await relayHub.canRelay(relayRequest, maxPossibleGasIrrelevantValue, acceptRelayedCallGasLimit, signature, '0x')
+      const canRelayResponse = await relayHub.canRelay.call(relayRequest, maxPossibleGasIrrelevantValue, acceptRelayedCallGasLimit, signature, '0x')
       assert.equal(AcceptRelayedCallReverted, canRelayResponse.status)
 
       const res = await relayHub.relayCall(relayRequest, signature, '0x', {

--- a/test/RelayHubPenalizations.test.js
+++ b/test/RelayHubPenalizations.test.js
@@ -13,6 +13,9 @@ const TestSponsor = artifacts.require('./test/TestSponsorEverythingAccepted')
 const { expect } = require('chai')
 const Environments = require('../src/js/relayclient/Environments')
 
+// (helper for buidler, which doesn't handle contract.skip
+//if (!contract.skip) contract.skip = (title) => { console.warn('skipping: ', title) }
+
 contract('RelayHub Penalizations', function ([_, relayOwner, relay, otherRelay, sender, other]) { // eslint-disable-line no-unused-vars
   /* ganache still has issues with chainId API: https://github.com/trufflesuite/ganache-core/issues/515 */
   const chainId = 1


### PR DESCRIPTION
make `acceptRelayedCall` *nonview* function.
added `dryRun` utility method, that can run a method call, only to check if a method doesn't revert.
`DryRunSponsor` uses it, as it checks if `encodedFunction` would succeed