### PR TITLE
Add BaseGsnAware baseclass

### DIFF
--- a/contracts/BaseGsnAware.sol
+++ b/contracts/BaseGsnAware.sol
@@ -1,0 +1,18 @@
+pragma solidity ^0.5.16;
+
+import "./interfaces/IRelayHub.sol";
+
+/**
+ * Shared base-class of BasePaymaster and BaseRelayRecipient
+ * required, so that a single contract can implement both, and still have a single
+ * referenced relayHub.
+ */
+contract BaseGsnAware {
+
+    /// The RelayHub singleton that is allowed to call us
+    IRelayHub internal relayHub;
+
+    function getHubAddr() public view returns (address) {
+        return address(relayHub);
+    }
+}

--- a/contracts/BasePaymaster.sol
+++ b/contracts/BasePaymaster.sol
@@ -3,6 +3,7 @@ pragma experimental ABIEncoderV2;
 
 import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
+import "./BaseGsnAware.sol";
 import "./interfaces/IPaymaster.sol";
 import "./interfaces/IRelayHub.sol";
 
@@ -13,15 +14,12 @@ import "./interfaces/IRelayHub.sol";
  *  - preRelayedCall
  *  - postRelayedCall
  */
-contract BasePaymaster is IPaymaster, Ownable {
+contract BasePaymaster is IPaymaster, Ownable, BaseGsnAware {
 
     // Gas stipends for acceptRelayedCall, preRelayedCall and postRelayedCall
     uint256 constant private ACCEPT_RELAYED_CALL_GAS_LIMIT = 50000;
     uint256 constant private PRE_RELAYED_CALL_GAS_LIMIT = 100000;
     uint256 constant private POST_RELAYED_CALL_GAS_LIMIT = 110000;
-
-    /// The IRelayHub singleton which is allowed to call us
-    IRelayHub internal relayHub;
 
     function getGasLimits()
     external
@@ -36,9 +34,6 @@ contract BasePaymaster is IPaymaster, Ownable {
         );
     }
 
-    function getHubAddr() public view returns (address) {
-        return address(relayHub);
-    }
     /*
      * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
      */

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -2,16 +2,13 @@ pragma solidity ^0.5.16;
 
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 
-import "./interfaces/IRelayHub.sol";
+import "./BaseGsnAware.sol";
 
 /**
  * A base class to be inherited by a concrete Relay Recipient
  * A subclass must use "getSender()" instead of "msg.sender"
  */
-contract BaseRelayRecipient {
-
-    /// The RelayHub singleton that is allowed to call us
-    IRelayHub internal relayHub;
+contract BaseRelayRecipient is BaseGsnAware {
 
     /*
      * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
@@ -21,9 +18,6 @@ contract BaseRelayRecipient {
         _;
     }
 
-    function getHubAddr() public view returns (address) {
-        return address(relayHub);
-    }
     /**
      * return the sender of this call.
      * if the call came through the valid RelayHub, return the original sender.


### PR DESCRIPTION
Paymaster and RelayRecipient are different entities, each knows about a
RelayHub.
But if a single entity has to inherit them both, it must still have a
single relayHub for both purposes.
Without this base class, there are two members named `relayHub`, and its
very confusing as to which one is in use.

So we add a base contract named `BaseGsnAware` which only has the
`relayHub` member for that purpose.