### PR TITLE
TrustedForwarder contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@
 /ganache.pid
 /types/truffle-contracts/
 serverdock/
+cache

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -8,25 +8,33 @@ import "./BaseGsnAware.sol";
  * A base class to be inherited by a concrete Relay Recipient
  * A subclass must use "getSender()" instead of "msg.sender"
  */
-contract BaseRelayRecipient is BaseGsnAware {
+contract BaseRelayRecipient {
+
+    /// the TrustedForwarder singleton we accept calls from.
+    // we trust it to verify the caller's signature, and pass the caller's address as last 20 bytes
+    address internal trustedForwarder;
 
     /*
-     * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
+     * require a function to be called through GSN only
      */
-    modifier relayHubOnly() {
-        require(msg.sender == address(relayHub), "Function can only be called by RelayHub");
+    modifier trustedForwarderOnly() {
+        require(msg.sender == address(trustedForwarder), "Function can only be called through trustedForwarder");
         _;
+    }
+
+    function getTrustedForwarder() public view returns(address) {
+        return trustedForwarder;
     }
 
     /**
      * return the sender of this call.
-     * if the call came through the valid RelayHub, return the original sender.
+     * if the call came through our trusted forwarder, return the original sender.
      * otherwise, return `msg.sender`
      * should be used in the contract anywhere instead of msg.sender
      */
     function getSender() public view returns (address) {
-        if (msg.sender == address(relayHub)) {
-            // At this point we know that the sender is a trusted IRelayHub,
+        if (msg.sender == address(getTrustedForwarder())) {
+            // At this point we know that the sender is a trusted forwarder,
             // so we trust that the last bytes of msg.data are the verified sender address.
             // extract sender address from the end of msg.data
             return LibBytes.readAddress(msg.data, msg.data.length - 20);

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -15,6 +15,8 @@ import "./utils/GsnUtils.sol";
 import "./utils/RLPReader.sol";
 import "./interfaces/IRelayHub.sol";
 import "./interfaces/IPaymaster.sol";
+import "./interfaces/ITrustedForwarder.sol";
+import "./BaseRelayRecipient.sol";
 
 contract RelayHub is IRelayHub {
 
@@ -43,7 +45,7 @@ contract RelayHub is IRelayHub {
     */
 
     // Gas cost of all relayCall() instructions after actual 'calculateCharge()'
-    uint256 constant private GAS_OVERHEAD = 21717;
+    uint256 constant private GAS_OVERHEAD = 21739;
 
     function getHubOverhead() external view returns (uint256) {
         return GAS_OVERHEAD;
@@ -53,10 +55,6 @@ contract RelayHub is IRelayHub {
 
     uint256 public gtxdatanonzero;
     uint256 constant public GTRANSACTION = 21000;
-
-
-    // Nonces of senders, used to prevent replay attacks
-    mapping(address => uint256) private nonces;
 
     enum AtomicRecipientCallsStatus {OK, CanRelayFailed, RelayedCallFailed, PreRelayedFailed, PostRelayedFailed}
 
@@ -78,10 +76,7 @@ contract RelayHub is IRelayHub {
 
     string public version = "1.0.0";
 
-    EIP712Sig private eip712sig;
-
     constructor (uint256 _gtxdatanonzero) public {
-        eip712sig = new EIP712Sig(address(this));
         gtxdatanonzero = _gtxdatanonzero;
     }
 
@@ -120,6 +115,7 @@ contract RelayHub is IRelayHub {
 
         emit Staked(relay, relays[relay].stake, relays[relay].unstakeDelay);
     }
+
     function registerRelay(uint256 baseRelayFee, uint256 pctRelayFee, string memory url) public {
         address relay = msg.sender;
 
@@ -217,8 +213,12 @@ contract RelayHub is IRelayHub {
         emit Withdrawn(account, dest, amount);
     }
 
-    function getNonce(address from) external view returns (uint256) {
-        return nonces[from];
+    function getNonce(address target, address from) external view returns (uint256) {
+        return ITrustedForwarder(BaseRelayRecipient(target).getTrustedForwarder()).getNonce(from);
+    }
+
+    function getForwarder(address target) external view returns(address) {
+        return BaseRelayRecipient(target).getTrustedForwarder();
     }
 
     function requireCanUnstake(address relay) public view {
@@ -241,12 +241,14 @@ contract RelayHub is IRelayHub {
     returns (uint256 status, bytes memory recipientContext)
     {
         // Verify the sender's signature on the transaction - note that approvalData is *not* signed
-        if (!eip712sig.verify(relayRequest, signature)) {
+        ITrustedForwarder forwarder = ITrustedForwarder(BaseRelayRecipient(relayRequest.target).getTrustedForwarder());
+        if (!forwarder.verify(relayRequest, signature)) {
             return (uint256(CanRelayStatus.WrongSignature), "");
         }
 
+        //TODO: this check should be embedded in the "verify", above - once we use revert instead of error codes.
         // Verify the transaction is not being replayed
-        if (nonces[relayRequest.relayData.senderAddress] != relayRequest.relayData.senderNonce) {
+        if (forwarder.getNonce(relayRequest.relayData.senderAddress) != relayRequest.relayData.senderNonce) {
             return (uint256(CanRelayStatus.WrongNonce), "");
         }
 
@@ -280,11 +282,11 @@ contract RelayHub is IRelayHub {
         gasLimits =
         IPaymaster(paymaster).getGasLimits();
         uint256 requiredGas =
-            GAS_OVERHEAD +
-            gasLimits.acceptRelayedCallGasLimit +
-            gasLimits.preRelayedCallGasLimit +
-            gasLimits.postRelayedCallGasLimit +
-            gasData.gasLimit;
+        GAS_OVERHEAD +
+        gasLimits.acceptRelayedCallGasLimit +
+        gasLimits.preRelayedCallGasLimit +
+        gasLimits.postRelayedCallGasLimit +
+        gasData.gasLimit;
 
         // This transaction must have enough gas to forward the call to the recipient with the requested amount, and not
         // run out of gas later in this function.
@@ -365,16 +367,13 @@ contract RelayHub is IRelayHub {
         // From this point on, this transaction will not revert nor run out of gas, and the recipient will be charged
         // for the gas spent.
 
-        // The sender's nonce is advanced to prevent transaction replays.
-        nonces[relayRequest.relayData.senderAddress]++;
-
         // Calls to the recipient are performed atomically inside an inner transaction which may revert in case of
         // errors in the recipient. In either case (revert or regular execution) the return data encodes the
         // RelayCallStatus value.
         RelayCallStatus status;
         {
             bytes memory data =
-            abi.encodeWithSelector(this.recipientCallsAtomic.selector, relayRequest, gasLimits, initialGas, calldatagascost(), recipientContext);
+            abi.encodeWithSelector(this.recipientCallsAtomic.selector, relayRequest, signature, gasLimits, initialGas, calldatagascost(), recipientContext);
             (, bytes memory relayCallStatus) = address(this).call(data);
             status = abi.decode(relayCallStatus, (RelayCallStatus));
         }
@@ -412,6 +411,7 @@ contract RelayHub is IRelayHub {
 
     function recipientCallsAtomic(
         GSNTypes.RelayRequest calldata relayRequest,
+        bytes calldata signature,
         GSNTypes.GasLimits calldata gasLimits,
         uint256 totalInitialGas,
         uint256 calldataGas,
@@ -440,22 +440,22 @@ contract RelayHub is IRelayHub {
         atomicData.data = abi.encodeWithSelector(
             IPaymaster(address(0)).preRelayedCall.selector, recipientContext
         );
-        bytes memory retData;
         {
             bool success;
+            bytes memory retData;
             // preRelayedCall may revert, but the recipient will still be charged: it should ensure in
             // acceptRelayedCall that this will not happen.
             (success, retData) = relayRequest.relayData.paymaster.call.gas(gasLimits.preRelayedCallGasLimit)(atomicData.data);
             if (!success) {
                 revertWithStatus(RelayCallStatus.PreRelayedFailed);
             }
+            atomicData.preReturnValue = abi.decode(retData, (bytes32));
         }
-        atomicData.preReturnValue = abi.decode(retData, (bytes32));
 
         // The actual relayed call is now executed. The sender's address is appended at the end of the transaction data
         (atomicData.relayedCallSuccess,) =
-        relayRequest.target.call.gas(relayRequest.gasData.gasLimit)
-        (abi.encodePacked(relayRequest.encodedFunction, relayRequest.relayData.senderAddress));
+            ITrustedForwarder(BaseRelayRecipient(relayRequest.target).getTrustedForwarder())
+            .verifyAndCall(relayRequest, signature);
 
         // Finally, postRelayedCall is executed, with the relayedCall execution's status and a charge estimate
         // We now determine how much the recipient will be charged, to pass this value to postRelayedCall for accurate

--- a/contracts/TrustedForwarder.sol
+++ b/contracts/TrustedForwarder.sol
@@ -1,0 +1,40 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "./utils/GSNTypes.sol";
+import "./utils/EIP712Sig.sol";
+import "./interfaces/ITrustedForwarder.sol";
+
+contract TrustedForwarder is ITrustedForwarder {
+
+    EIP712Sig private eip712sig;
+
+    // Nonces of senders, used to prevent replay attacks
+    mapping(address => uint256) private nonces;
+
+    constructor() public {
+        eip712sig = new EIP712Sig(address(this));
+    }
+
+    function getNonce(address from) external view returns (uint256) {
+        return nonces[from];
+    }
+
+    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) view public returns (bool){
+        return eip712sig.verify(req, sig);
+    }
+
+    function verifyAndCall(GSNTypes.RelayRequest memory req, bytes memory sig) public returns (bool success, bytes memory ret) {
+        if (!verify(req, sig))
+            return (false, "can't call: wrong signature");
+
+        nonces[req.relayData.senderAddress]++;
+
+        return req.target.call.gas(req.gasData.gasLimit)
+        (abi.encodePacked(req.encodedFunction, req.relayData.senderAddress));
+    }
+}
+
+library asd {
+    function dsa() internal {new TrustedForwarder();}
+}

--- a/contracts/TrustedForwarder.sol
+++ b/contracts/TrustedForwarder.sol
@@ -20,7 +20,7 @@ contract TrustedForwarder is ITrustedForwarder {
         return nonces[from];
     }
 
-    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) view public returns (bool){
+    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) public view returns (bool) {
         return eip712sig.verify(req, sig);
     }
 
@@ -33,8 +33,4 @@ contract TrustedForwarder is ITrustedForwarder {
         return req.target.call.gas(req.gasData.gasLimit)
         (abi.encodePacked(req.encodedFunction, req.relayData.senderAddress));
     }
-}
-
-library asd {
-    function dsa() internal {new TrustedForwarder();}
 }

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -236,7 +236,8 @@ interface IRelayHub {
     // Penalize a relay that sent a transaction that didn't target RelayHub's registerRelay or relayCall.
     function penalizeIllegalTransaction(bytes calldata unsignedTx, bytes calldata signature) external;
 
-    function getNonce(address from) external view returns (uint256);
+    function getNonce(address target, address from) external view returns (uint256);
+    function getForwarder(address target) external view returns(address);
 
     function getHubOverhead() external view returns (uint256);
 

--- a/contracts/interfaces/ITrustedForwarder.sol
+++ b/contracts/interfaces/ITrustedForwarder.sol
@@ -7,10 +7,10 @@ contract ITrustedForwarder {
 
     // verify the signature matches the request.
     //  that is, the senderAccount is the signer
-    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) public view returns (bool);
-
-    function getNonce(address from) external view returns (uint256);
+    function verify(GSNTypes.RelayRequest calldata req, bytes calldata sig) external view;
 
     // validate the signature, and execute the call.
-    function verifyAndCall(GSNTypes.RelayRequest memory req, bytes memory sig) public returns (bool success, bytes memory ret);
+    function verifyAndCall(GSNTypes.RelayRequest calldata req, bytes calldata sig) external returns (bool success, bytes memory ret);
+
+    function getNonce(address from) external view returns (uint256);
 }

--- a/contracts/interfaces/ITrustedForwarder.sol
+++ b/contracts/interfaces/ITrustedForwarder.sol
@@ -7,7 +7,7 @@ contract ITrustedForwarder {
 
     // verify the signature matches the request.
     //  that is, the senderAccount is the signer
-    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) view public returns (bool);
+    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) public view returns (bool);
 
     function getNonce(address from) external view returns (uint256);
 

--- a/contracts/interfaces/ITrustedForwarder.sol
+++ b/contracts/interfaces/ITrustedForwarder.sol
@@ -1,0 +1,16 @@
+pragma solidity ^0.5.16;
+pragma experimental ABIEncoderV2;
+
+import "../utils/GSNTypes.sol";
+
+contract ITrustedForwarder {
+
+    // verify the signature matches the request.
+    //  that is, the senderAccount is the signer
+    function verify(GSNTypes.RelayRequest memory req, bytes memory sig) view public returns (bool);
+
+    function getNonce(address from) external view returns (uint256);
+
+    // validate the signature, and execute the call.
+    function verifyAndCall(GSNTypes.RelayRequest memory req, bytes memory sig) public returns (bool success, bytes memory ret);
+}

--- a/contracts/test/TestProxy.sol
+++ b/contracts/test/TestProxy.sol
@@ -6,12 +6,12 @@ import "openzeppelin-solidity/contracts/ownership/Ownable.sol";
 
 contract TestProxy is Ownable, BaseRelayRecipient {
 
-    function isOwner() public view returns (bool) {
-        return getSender() == owner();
+    constructor(address forwarder) public {
+        trustedForwarder = forwarder;
     }
 
-    function setRelayHub(IRelayHub _relayHub) public onlyOwner {
-        relayHub = _relayHub;
+    function isOwner() public view returns (bool) {
+        return getSender() == owner();
     }
 
     event Test(address getSender, address msg_sender);

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -8,8 +8,9 @@ import "../TrustedForwarder.sol";
 
 contract TestRecipient is BaseRelayRecipient {
 
-    constructor(address forwarder) public {
-        trustedForwarder = forwarder;
+    constructor() public {
+        //should be a singleton, since Paymaster should (eventually) trust it.
+        trustedForwarder = address(new TrustedForwarder());
     }
 
     event Reverting(string message);

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -2,14 +2,14 @@
 pragma solidity ^0.5.16;
 
 import "../utils/GsnUtils.sol";
-import "../interfaces/IRelayHub.sol";
 import "../BaseRelayRecipient.sol";
 import "./TestPaymasterConfigurableMisbehavior.sol";
+import "../TrustedForwarder.sol";
 
 contract TestRecipient is BaseRelayRecipient {
 
-    function setHub(IRelayHub _relayHub) public {
-        relayHub = _relayHub;
+    constructor(address forwarder) public {
+        trustedForwarder = forwarder;
     }
 
     event Reverting(string message);

--- a/contracts/utils/GsnUtils.sol
+++ b/contracts/utils/GsnUtils.sol
@@ -16,6 +16,17 @@ library GsnUtils {
     }
 
     /**
+     * extract error string from revert bytes
+     */
+    function getError(bytes memory err) internal pure returns (string memory ret) {
+        if (err.length < 4 + 32) {
+            //not a valid revert with error. return as-is.
+            return string(err);
+        }
+        (ret) = abi.decode(LibBytes.slice(err, 4, err.length), (string));
+    }
+
+    /**
      * extract method sig from encoded function call
      */
     function getMethodSig(bytes memory msgData) internal pure returns (bytes4) {
@@ -30,6 +41,14 @@ library GsnUtils {
      */
     function getParam(bytes memory msgData, uint index) internal pure returns (uint) {
         return LibBytes.readUint256(msgData, 4 + index * 32);
+    }
+
+    function getAddressParam(bytes memory msgData, uint index) internal pure returns (address) {
+        return address(getParam(msgData, index));
+    }
+
+    function getBytes32Param(bytes memory msgData, uint index) internal pure returns (bytes32) {
+        return bytes32(getParam(msgData, index));
     }
 
     /**

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,15 +1,13 @@
 const Environments = require('../src/js/relayclient/Environments')
 
 const RelayHub = artifacts.require('./RelayHub.sol')
-const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const TestRecipient = artifacts.require('./test/TestRecipient.sol')
 const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted.sol')
 
 module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
-  await deployer.deploy(TrustedForwarder)
 
-  await deployer.deploy(TestRecipient, TrustedForwarder.address)
+  await deployer.deploy(TestRecipient)
   const testPaymaster = await deployer.deploy(TestPaymasterEverythingAccepted)
   await testPaymaster.setHub(RelayHub.address)
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,13 +1,15 @@
 const Environments = require('../src/js/relayclient/Environments')
 
 const RelayHub = artifacts.require('./RelayHub.sol')
+const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const TestRecipient = artifacts.require('./test/TestRecipient.sol')
 const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted.sol')
 
 module.exports = async function (deployer) {
   await deployer.deploy(RelayHub, Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
-  const testRecipient = await deployer.deploy(TestRecipient)
+  await deployer.deploy(TrustedForwarder)
+
+  await deployer.deploy(TestRecipient, TrustedForwarder.address)
   const testPaymaster = await deployer.deploy(TestPaymasterEverythingAccepted)
-  await testRecipient.setHub(RelayHub.address)
   await testPaymaster.setHub(RelayHub.address)
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "lint:fix": "yarn run lint:js:fix",
     "lint:js": "eslint --ext .js,.ts --cache -f unix --ignore-path .gitignore .",
     "lint:sol": "solhint -f unix \"contracts/**/*.sol\" --max-warnings 0",
-    "lint:js:fix": "eslint --ext .js,.ts --ignore-path .gitignore . --fix",
+    "lint:js:fix": "eslint --ext .js,.ts -f unix --ignore-path .gitignore . --fix",
     "gsn-dock-relay": "./scripts/gsn-dock-relay",
     "gsn-dock-relay-ganache": "./scripts/gsn-dock-relay-ganache",
     "web": "./restart-relay.sh web",

--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "gsn-dock-relay-ganache": "./scripts/gsn-dock-relay-ganache"
   },
   "scripts": {
-    "test": "yarn generate && yarn tsc && npm run test-server && npm run test-js",
-    "test-server": "make test-server",
+    "test": "yarn generate && yarn tsc && npm run test-js",
+    "test-server": "echo obsolete go server; make test-server",
     "ganache": "ganache-cli --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --allowUnlimitedContractSize",
     "test-js": "run-with-testrpc --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic --allowUnlimitedContractSize 'npx truffle --network npmtest test'",
     "truffle-test": "yarn tsc && npx truffle test",

--- a/server/src/librelay/relay_server_test.go
+++ b/server/src/librelay/relay_server_test.go
@@ -137,6 +137,7 @@ var clk *fakeclock.FakeClock
 var sampleRecipient common.Address
 var testSponsor common.Address
 var rhaddr common.Address
+var forwarder common.Address
 
 var boundHub *bind.BoundContract
 var boundRecipient *bind.BoundContract
@@ -218,7 +219,9 @@ func TestMain(m *testing.M) {
 	if err != nil {
 		log.Fatalln(err)
 	}
-	_,err = sr.SetHub(auth, rhaddr)
+
+	callOpt := &bind.CallOpts{}
+	forwarder,err = sr.GetTrustedForwarder(callOpt)
 	if err != nil {
 		log.Fatalln(err)
 	}
@@ -270,7 +273,7 @@ func TestMain(m *testing.M) {
 	}
 	_, _ = client.TransactionReceipt(context.Background(), tx.Hash())
 
-	callOpt := &bind.CallOpts{}
+	callOpt = &bind.CallOpts{}
 	toBalance, err := rhub.BalanceOf(callOpt, testSponsor)
 	if err != nil {
 		log.Println(err)
@@ -329,9 +332,9 @@ func printSignature(txb string, baseFee int64, txFee int64, gasPrice int64, gasL
 	fmt.Println("const RelayRequest = require('../src/js/relayclient/EIP712/RelayRequest')")
 	fmt.Printf(
 		"=====\n" +
-			"utils.getEip712Signature({web3, chainId: 1, relayHub: '%v', relayRequest: new RelayRequest({web3, senderAddress: '%v', senderNonce: '%v', target: '%v', encodedFunction: '%v', baseRelayFee: '%v', pctRelayFee: '%v', gasPrice: '%v', gasLimit: '%v', paymaster: '%v', relayAddress: '%v'}) })\n" +
+			"utils.getEip712Signature({web3, chainId: 1, verifier: '%v', relayRequest: new RelayRequest({web3, senderAddress: '%v', senderNonce: '%v', target: '%v', encodedFunction: '%v', baseRelayFee: '%v', pctRelayFee: '%v', gasPrice: '%v', gasLimit: '%v', paymaster: '%v', relayAddress: '%v'}) })\n" +
 			"======\n",
-		rhaddr.Hex(), crypto.PubkeyToAddress(gaslessKey2.PublicKey).Hex(), senderNonce, sampleRecipient.Hex(), txb, baseFee, txFee, gasPrice, gasLimit, testSponsor.Hex(), relay.Address().Hex(),
+		forwarder.Hex(), crypto.PubkeyToAddress(gaslessKey2.PublicKey).Hex(), senderNonce, sampleRecipient.Hex(), txb, baseFee, txFee, gasPrice, gasLimit, testSponsor.Hex(), relay.Address().Hex(),
 	)
 }
 

--- a/src/js/relayclient/EIP712/Eip712Helper.js
+++ b/src/js/relayclient/EIP712/Eip712Helper.js
@@ -26,13 +26,14 @@ const RelayRequest = [
   { name: 'relayData', type: 'RelayData' }
 ]
 
-module.exports = function (
+module.exports = function getDataToSign (
   {
     chainId,
-    relayHub,
+    verifier,
     relayRequest
   }
 ) {
+  if (!verifier) throw new Error('missing "verifier"')
   // TODO: enable ChainID opcode in the EIP712Sig
   return {
     types: {
@@ -45,7 +46,7 @@ module.exports = function (
       name: 'GSN Relayed Transaction',
       version: '1',
       chainId: chainId,
-      verifyingContract: relayHub
+      verifyingContract: verifier
     },
     primaryType: 'RelayRequest',
     message: relayRequest

--- a/src/js/relayclient/utils.js
+++ b/src/js/relayclient/utils.js
@@ -34,14 +34,14 @@ module.exports = {
     {
       web3,
       chainId,
-      relayHub,
+      verifier,
       relayRequest,
       methodSuffix = '',
       jsonStringifyRequest = false
     }) {
     let data = getDataToSign({
       chainId,
-      relayHub,
+      verifier,
       relayRequest
     })
     if (jsonStringifyRequest) {

--- a/src/js/relayserver/RelayServer.js
+++ b/src/js/relayserver/RelayServer.js
@@ -150,9 +150,10 @@ class RelayServer extends EventEmitter {
       paymaster: paymaster,
       relayAddress: this.address
     })
+    // TODO: should not use signedData at all. only the relayRequest.
     const signedData = getDataToSign({
       chainId: this.chainId,
-      relayHub: relayHubAddress,
+      verifier: relayHubAddress,
       relayRequest
     })
 

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -8,7 +8,6 @@ import Environments from '../src/js/relayclient/Environments'
 
 import {
   RelayHubInstance,
-  TrustForwarderInstance,
   TestRecipientInstance,
   TestPaymasterEverythingAcceptedInstance,
   TestPaymasterConfigurableMisbehaviorInstance
@@ -44,7 +43,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
   let paymasterContract: TestPaymasterEverythingAcceptedInstance
   let target: string
   let paymaster: string
-  let forwarder: TrustForwarderInstance
+  let forwarder: string
 
   beforeEach(async function () {
     relayHubInstance = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -15,7 +15,6 @@ import {
 } from '../types/truffle-contracts'
 
 const RelayHub = artifacts.require('RelayHub')
-const TrustedForwarder = artifacts.require('TrustedForwarder')
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const TestRecipient = artifacts.require('TestRecipient')
 const TestPaymasterStoreContext = artifacts.require('TestPaymasterStoreContext')
@@ -50,9 +49,8 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
   beforeEach(async function () {
     relayHubInstance = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
     paymasterContract = await TestPaymasterEverythingAccepted.new()
-    const forwarderContract = await TrustedForwarder.new()
-    forwarder = forwarderContract.address
-    recipientContract = await TestRecipient.new(forwarder)
+    recipientContract = await TestRecipient.new()
+    forwarder = await recipientContract.getTrustedForwarder()
 
     target = recipientContract.address
     paymaster = paymasterContract.address

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -8,12 +8,14 @@ import Environments from '../src/js/relayclient/Environments'
 
 import {
   RelayHubInstance,
+  TrustForwarderInstance,
   TestRecipientInstance,
   TestPaymasterEverythingAcceptedInstance,
   TestPaymasterConfigurableMisbehaviorInstance
 } from '../types/truffle-contracts'
 
 const RelayHub = artifacts.require('RelayHub')
+const TrustedForwarder = artifacts.require('TrustedForwarder')
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const TestRecipient = artifacts.require('TestRecipient')
 const TestPaymasterStoreContext = artifacts.require('TestPaymasterStoreContext')
@@ -43,17 +45,19 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
   let paymasterContract: TestPaymasterEverythingAcceptedInstance
   let target: string
   let paymaster: string
+  let forwarder: TrustForwarderInstance
 
   beforeEach(async function () {
     relayHubInstance = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
     paymasterContract = await TestPaymasterEverythingAccepted.new()
-    recipientContract = await TestRecipient.new()
+    const forwarderContract = await TrustedForwarder.new()
+    forwarder = forwarderContract.address
+    recipientContract = await TestRecipient.new(forwarder)
 
     target = recipientContract.address
     paymaster = paymasterContract.address
     relayHub = relayHubInstance.address
 
-    await recipientContract.setHub(relayHub)
     await paymasterContract.setHub(relayHub)
   })
 
@@ -221,7 +225,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
         ({ signature: signatureWithPermissivePaymaster } = await getEip712Signature({
           web3,
           chainId,
-          relayHub,
+          verifier: forwarder,
           relayRequest
         }))
 
@@ -281,7 +285,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           const { signature } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub,
+            verifier: forwarder,
             relayRequest: relayRequestWrongNonce
           })
 
@@ -325,7 +329,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           ({ signature } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub,
+            verifier: forwarder,
             relayRequest: relayRequest
           }))
 
@@ -335,7 +339,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           ({ signature: signatureWithMisbehavingPaymaster } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub,
+            verifier: forwarder,
             relayRequest: relayRequestMisbehavingPaymaster
           }))
 
@@ -344,25 +348,25 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           ({ signature: signatureWithContextPaymaster } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub,
+            verifier: forwarder,
             relayRequest: relayRequestPaymasterWithContext
           }))
         })
 
         it('relayCall executes the transaction and increments sender nonce on hub', async function () {
-          const nonceBefore = await relayHubInstance.getNonce(senderAddress)
+          const nonceBefore = await relayHubInstance.getNonce(target, senderAddress)
 
           const { tx } = await relayHubInstance.relayCall(relayRequest, signatureWithPermissivePaymaster, '0x', {
             from: relayAddress,
             gasPrice
           })
-          const nonceAfter = await relayHubInstance.getNonce(senderAddress)
+          const nonceAfter = await relayHubInstance.getNonce(target, senderAddress)
           assert.equal(nonceBefore.addn(1).toNumber(), nonceAfter.toNumber())
 
           await expectEvent.inTransaction(tx, TestRecipient, 'SampleRecipientEmitted', {
             message,
             realSender: senderAddress,
-            msgSender: relayHub,
+            msgSender: forwarder,
             origin: relayAddress
           })
         })
@@ -375,7 +379,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           ({ signature } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub,
+            verifier: forwarder,
             relayRequest: relayRequestNoCallData
           }))
           const { tx } = await relayHubInstance.relayCall(relayRequestNoCallData, signature, '0x', {
@@ -385,7 +389,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
           await expectEvent.inTransaction(tx, TestRecipient, 'SampleRecipientEmitted', {
             message: messageWithNoParams,
             realSender: senderAddress,
-            msgSender: relayHub,
+            msgSender: forwarder,
             origin: relayAddress
           })
         })
@@ -539,7 +543,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
             ({ signature } = await getEip712Signature({
               web3,
               chainId,
-              relayHub: relayHub,
+              verifier: forwarder,
               relayRequest: relayRequestMisbehavingPaymaster
             }))
           })

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -14,7 +14,6 @@ import {
 } from '../types/truffle-contracts'
 
 const RelayHub = artifacts.require('./RelayHub.sol')
-const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const TestRecipient = artifacts.require('./test/TestRecipient')
 const TestPaymasterVariableGasLimits = artifacts.require('./TestPaymasterVariableGasLimits.sol')
 const TestPaymasterConfigurableMisbehavior = artifacts.require('./test/TestPaymasterConfigurableMisbehavior.sol')
@@ -57,8 +56,8 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
   let forwarder: TrustForwarderInstance
 
   async function prepareForHub (): Promise<void> {
-    forwarder = await TrustedForwarder.new()
-    recipient = await TestRecipient.new(forwarder.address)
+    recipient = await TestRecipient.new()
+    forwarder = await recipient.getTrustedForwarder()
     paymaster = await TestPaymasterVariableGasLimits.new()
     await paymaster.setHub(relayHub.address)
     await relayHub.depositFor(paymaster.address, {
@@ -86,7 +85,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
     ({ signature } = await getEip712Signature({
       web3,
       chainId,
-      verifier: forwarder.address,
+      verifier: forwarder,
       relayRequest
     }))
   }
@@ -166,7 +165,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
       const { signature } = await getEip712Signature({
         web3,
         chainId,
-        verifier: forwarder.address,
+        verifier: forwarder,
         relayRequest: relayRequestMisbehaving
       })
       const maxPossibleGasIrrelevantValue = 8000000
@@ -250,7 +249,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
               const { signature } = await getEip712Signature({
                 web3,
                 chainId,
-                verifier: forwarder.address,
+                verifier: forwarder,
                 relayRequest
               })
               const res = await relayHub.relayCall(relayRequest, signature, '0x', {

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -8,7 +8,6 @@ import RelayRequest from '../src/js/relayclient/EIP712/RelayRequest'
 
 import {
   RelayHubInstance,
-  TrustForwarderInstance,
   TestRecipientInstance,
   TestPaymasterVariableGasLimitsInstance
 } from '../types/truffle-contracts'
@@ -53,7 +52,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
   let encodedFunction
   let signature: string
   let relayRequest: RelayRequest
-  let forwarder: TrustForwarderInstance
+  let forwarder: string
 
   async function prepareForHub (): Promise<void> {
     recipient = await TestRecipient.new()

--- a/test/RelayHubPenalizations.test.js
+++ b/test/RelayHubPenalizations.test.js
@@ -10,7 +10,6 @@ const { getEip712Signature } = require('../src/js/relayclient/utils')
 const Environments = require('../src/js/relayclient/Environments')
 
 const RelayHub = artifacts.require('RelayHub')
-const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const SampleRecipient = artifacts.require('./test/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted')
 
@@ -23,8 +22,9 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relay, otherRelay, 
 
   before(async function () {
     relayHub = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
-    forwarder = await TrustedForwarder.new()
-    recipient = await SampleRecipient.new(forwarder.address)
+    recipient = await SampleRecipient.new()
+    forwarder = await recipient.getTrustedForwarder()
+
     paymaster = await TestPaymasterEverythingAccepted.new()
     await paymaster.setHub(relayHub.address)
   })
@@ -234,7 +234,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relay, otherRelay, 
           const { signature } = await getEip712Signature({
             web3,
             chainId,
-            verifier: forwarder.address,
+            verifier: forwarder,
             relayRequest
           })
           await relayHub.depositFor(paymaster.address, {

--- a/test/RelayHubPenalizations.test.js
+++ b/test/RelayHubPenalizations.test.js
@@ -10,6 +10,7 @@ const { getEip712Signature } = require('../src/js/relayclient/utils')
 const Environments = require('../src/js/relayclient/Environments')
 
 const RelayHub = artifacts.require('RelayHub')
+const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const SampleRecipient = artifacts.require('./test/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted')
 
@@ -18,12 +19,13 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relay, otherRelay, 
   let relayHub
   let recipient
   let paymaster
+  let forwarder
 
   before(async function () {
     relayHub = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
-    recipient = await SampleRecipient.new()
+    forwarder = await TrustedForwarder.new()
+    recipient = await SampleRecipient.new(forwarder.address)
     paymaster = await TestPaymasterEverythingAccepted.new()
-    await recipient.setHub(relayHub.address)
     await paymaster.setHub(relayHub.address)
   })
 
@@ -232,7 +234,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relay, otherRelay, 
           const { signature } = await getEip712Signature({
             web3,
             chainId,
-            relayHub: relayHub.address,
+            verifier: forwarder.address,
             relayRequest
           })
           await relayHub.depositFor(paymaster.address, {

--- a/test/RelayHubStakeManagement.test.js
+++ b/test/RelayHubStakeManagement.test.js
@@ -2,7 +2,6 @@ const { balance, BN, constants, ether, expectEvent, expectRevert, send, time } =
 const { ZERO_ADDRESS } = constants
 
 const TestRecipientUtils = artifacts.require('./TestRecipientUtils.sol')
-const SampleRecipient = artifacts.require('./test/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted')
 const RelayHub = artifacts.require('RelayHub')
 
@@ -11,14 +10,11 @@ const Environments = require('../src/js/relayclient/Environments')
 
 contract('RelayHub Stake Management', function ([_, relayOwner, relay, otherRelay, sender, other, dest]) { // eslint-disable-line no-unused-vars
   let relayHub
-  let recipient
   let paymaster
 
   beforeEach(async function () {
     relayHub = await RelayHub.new(Environments.defEnv.gtxdatanonzero, { gas: 10000000 })
-    recipient = await SampleRecipient.new()
     paymaster = await TestPaymasterEverythingAccepted.new()
-    await recipient.setHub(relayHub.address)
     await paymaster.setHub(relayHub.address)
   })
 

--- a/test/Utils.test.js
+++ b/test/Utils.test.js
@@ -22,7 +22,7 @@ contract('Utils', async function (accounts) {
       const gasPrice = '10000000'
       const gasLimit = '500000'
       const paymaster = accounts[7]
-      const relayHub = accounts[8]
+      const verifier = accounts[8]
       const relayAddress = accounts[9]
 
       const relayRequest = new RelayRequest({
@@ -41,7 +41,7 @@ contract('Utils', async function (accounts) {
       const { signature: sig, data } = await getEip712Signature({
         web3,
         chainId,
-        relayHub,
+        verifier,
         relayRequest
       })
 
@@ -51,7 +51,7 @@ contract('Utils', async function (accounts) {
       })
       assert.strictEqual(senderAddress.toLowerCase(), recoveredAccount.toLowerCase())
 
-      const eip712Sig = await EIP712Sig.new(relayHub)
+      const eip712Sig = await EIP712Sig.new(verifier)
       const verify = await eip712Sig.verify(data.message, sig, { from: senderAddress })
       assert.strictEqual(verify, true)
     })

--- a/test/flows_test.js
+++ b/test/flows_test.js
@@ -6,6 +6,7 @@
 
 var testutils = require('./testutils.js')
 
+const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const SampleRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
 const TestPaymasterPreconfiguredApproval = artifacts.require('tests/TestPaymasterPreconfiguredApproval')
@@ -59,9 +60,8 @@ options.forEach(params => {
         rhub = await RelayHub.deployed()
       }
 
-      sr = await SampleRecipient.new()
+      sr = await SampleRecipient.new((await TrustedForwarder.deployed()).address)
       paymaster = await TestPaymasterEverythingAccepted.new()
-      await sr.setHub(rhub.address)
       await paymaster.setHub(rhub.address)
     })
 

--- a/test/flows_test.js
+++ b/test/flows_test.js
@@ -6,7 +6,6 @@
 
 var testutils = require('./testutils.js')
 
-const TrustedForwarder = artifacts.require('./TrustedForwarder.sol')
 const SampleRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
 const TestPaymasterPreconfiguredApproval = artifacts.require('tests/TestPaymasterPreconfiguredApproval')
@@ -60,7 +59,7 @@ options.forEach(params => {
         rhub = await RelayHub.deployed()
       }
 
-      sr = await SampleRecipient.new((await TrustedForwarder.deployed()).address)
+      sr = await SampleRecipient.new()
       paymaster = await TestPaymasterEverythingAccepted.new()
       await paymaster.setHub(rhub.address)
     })


### PR DESCRIPTION
TrustedForwarder contract
- client recipient has a reference to its trusted forwarder (NOT relayhub)
- probably can be set at the constructor -  less likely to change (still, it might change - e.g. if signature struct changes)
- holds all functionality of nonce, signature verification.