### PR TITLE
acceptRelayedCall: revert on error

### DIFF
--- a/contracts/interfaces/IPaymaster.sol
+++ b/contracts/interfaces/IPaymaster.sol
@@ -28,12 +28,14 @@ interface IPaymaster {
 
     /**
      * Called by Relay (and RelayHub), to validate if this recipient accepts this call.
+     * revert to signal the paymaster will NOT pay for this call.
      * Note: Accepting this call means paying for the tx whether the relayed call reverted or not.
      *  @param relayRequest - the full relay request structure
      *  @param approvalData - extra dapp-specific data (e.g. signature from trusted party)
      *  @param maxPossibleGas - based on values returned from {@link getGasLimits},
      *         the RelayHub will calculate the maximum possible amount of gas the user may be charged for.
      *         In order to convert this value to wei, the Paymaster has to call "relayHub.calculateCharge()"
+     *  @return a context to be passed to preRelayedCall and postRelayedCall.
      */
     function acceptRelayedCall(
         GSNTypes.RelayRequest calldata relayRequest,
@@ -42,7 +44,7 @@ interface IPaymaster {
     )
     external
     view
-    returns (uint256, bytes memory);
+    returns (bytes memory);
 
     /** this method is called before the actual relayed function call.
      * It may be used to charge the caller before

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -61,7 +61,7 @@ interface IRelayHub {
         address indexed to,
         address paymaster,
         bytes4 selector,
-        uint256 reason);
+        string reason);
 
     // Emitted when a transaction is relayed. Note that the actual encoded function might be reverted: this will be
     // indicated in the status field.
@@ -108,20 +108,6 @@ interface IRelayHub {
         Registered,
         Removed
 
-    }
-
-    /// Preconditions for relaying, checked by canRelay and returned as the corresponding numeric values.
-    /// @param OK - all checks passed, the call can be relayed
-    /// @param WrongSignature - the transaction to relay is not signed by requested sender
-    /// @param WrongNonce - the provided nonce has already been used by the sender
-    /// @param AcceptRelayedCallReverted - the recipient rejected this call via acceptRelayedCall
-    /// @param InvalidRecipientStatusCode - the recipient returned an invalid (reserved) status code
-    enum CanRelayStatus {
-        OK,
-        WrongSignature,
-        WrongNonce,
-        AcceptRelayedCallReverted,
-        InvalidRecipientStatusCode
     }
 
     // Add stake to a relay and sets its unstakeDelay.
@@ -184,7 +170,7 @@ interface IRelayHub {
     //  - all arguments must be signed for by the sender (from)
     //  - the sender's nonce must be the current one
     //  - the recipient must accept this transaction (via acceptRelayedCall)
-    // Returns a CanRelayStatus value (OK when the transaction can be relayed), or a recipient-specific error code if
+    // Returns true on success (and recipient context), or false with error string
     // it returns one in acceptRelayedCall.
     function canRelay(
         GSNTypes.RelayRequest calldata relayRequest,
@@ -195,7 +181,7 @@ interface IRelayHub {
     )
     external
     view
-    returns (uint256 status, bytes memory recipientContext);
+    returns (bool success, string memory returnValue);
 
     /// Relays a transaction. For this to succeed, multiple conditions must be met:
     ///  - canRelay must return CanRelayStatus.OK

--- a/contracts/test/TestPaymasterConfigurableMisbehavior.sol
+++ b/contracts/test/TestPaymasterConfigurableMisbehavior.sol
@@ -39,7 +39,7 @@ contract TestPaymasterConfigurableMisbehavior is TestPaymasterEverythingAccepted
     )
     external
     view
-    returns (uint256, bytes memory) {
+    returns (bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
         if (overspendAcceptGas) {
             uint i = 0;
@@ -48,9 +48,9 @@ contract TestPaymasterConfigurableMisbehavior is TestPaymasterEverythingAccepted
             }
         }
 
-        if (returnInvalidErrorCode) return (10, "");
+        require(!returnInvalidErrorCode, "invalid code");
 
-        return (0, "");
+        return "";
     }
 
     function preRelayedCall(bytes calldata context) external relayHubOnly returns (bytes32) {

--- a/contracts/test/TestPaymasterEverythingAccepted.sol
+++ b/contracts/test/TestPaymasterEverythingAccepted.sol
@@ -15,9 +15,9 @@ contract TestPaymasterEverythingAccepted is BasePaymaster {
     )
     external
     view
-    returns (uint256, bytes memory) {
+    returns (bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
-        return (0, "");
+        return "";
     }
 
     function preRelayedCall(

--- a/contracts/test/TestPaymasterOwnerSignature.sol
+++ b/contracts/test/TestPaymasterOwnerSignature.sol
@@ -18,15 +18,13 @@ contract TestPaymasterOwnerSignature is TestPaymasterEverythingAccepted {
     )
     external
     view
-    returns (uint256, bytes memory) {
+    returns (bytes memory) {
         (maxPossibleCharge);
         address signer =
             keccak256(abi.encodePacked("I approve", relayRequest.relayData.senderAddress))
             .toEthSignedMessageHash()
             .recover(approvalData);
-        if (signer != owner()) {
-            return (13, "test: not approved");
-        }
-        return (0, "");
+        require(signer == owner(), "test: not approved");
+        return "";
     }
 }

--- a/contracts/test/TestPaymasterPreconfiguredApproval.sol
+++ b/contracts/test/TestPaymasterPreconfiguredApproval.sol
@@ -18,13 +18,11 @@ contract TestPaymasterPreconfiguredApproval is TestPaymasterEverythingAccepted {
     )
     external
     view
-    returns (uint256, bytes memory) {
+    returns (bytes memory) {
         (relayRequest, approvalData, maxPossibleCharge);
-        if (keccak256(expectedApprovalData) != keccak256(approvalData)) {
-            return (14,
-            abi.encodePacked(
-                "test: unexpected approvalData: '", approvalData, "' instead of '", expectedApprovalData, "'"));
-        }
-        return (0, "");
+        require(keccak256(expectedApprovalData) == keccak256(approvalData),
+            string(abi.encodePacked(
+                "test: unexpected approvalData: '", approvalData, "' instead of '", expectedApprovalData, "'")));
+        return "";
     }
 }

--- a/contracts/test/TestPaymasterStoreContext.sol
+++ b/contracts/test/TestPaymasterStoreContext.sol
@@ -41,8 +41,8 @@ contract TestPaymasterStoreContext is TestPaymasterEverythingAccepted {
     )
     external
     view
-    returns (uint256, bytes memory) {
-        return (0, abi.encode(
+    returns (bytes memory) {
+        return abi.encode(
             relayRequest.relayData.relayAddress,
             relayRequest.relayData.senderAddress,
             relayRequest.encodedFunction,
@@ -52,7 +52,7 @@ contract TestPaymasterStoreContext is TestPaymasterEverythingAccepted {
             relayRequest.gasData.gasLimit,
             relayRequest.relayData.senderNonce,
             approvalData,
-            maxPossibleGas));
+            maxPossibleGas);
     }
 
     function preRelayedCall(bytes calldata context) external relayHubOnly returns (bytes32) {

--- a/contracts/test/TestPaymasterVariableGasLimits.sol
+++ b/contracts/test/TestPaymasterVariableGasLimits.sol
@@ -23,11 +23,11 @@ contract TestPaymasterVariableGasLimits is TestPaymasterEverythingAccepted {
     )
     external
     view
-    returns (uint256, bytes memory) {
+    returns (bytes memory) {
         (relayRequest, approvalData);
-        return (0, abi.encode(
+        return abi.encode(
             gasleft(),
-            maxPossibleGas));
+            maxPossibleGas);
     }
 
     function preRelayedCall(bytes calldata context) external relayHubOnly returns (bytes32) {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
   },
   "scripts": {
     "test": "yarn extract_abi && yarn generate && yarn tsc && npm run test-js",
+    "test-server": "echo obsolete go server; make test-server",
     "ganache": "ganache-cli --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --allowUnlimitedContractSize",
     "test-js": "run-with-testrpc --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic --allowUnlimitedContractSize 'npx truffle --network npmtest test'",
     "extract_abi": "./scripts/extract_abi.js",

--- a/src/js/relayclient/RelayClient.js
+++ b/src/js/relayclient/RelayClient.js
@@ -36,13 +36,6 @@ const Environments = require('./Environments')
 // default gas price (unless client specifies one): the web3.eth.gasPrice*(100+GASPRICE_PERCENT)/100
 const GASPRICE_PERCENT = 20
 
-const canRelayStatus = {
-  1: '1 WrongSignature', // The transaction to relay is not signed by requested sender
-  2: '2 WrongNonce', // The provided nonce has already been used by the sender
-  3: '3 AcceptRelayedCallReverted', // The recipient rejected this call via acceptRelayedCall
-  4: '4 InvalidRecipientStatusCode' // The recipient returned an invalid (reserved) status code
-}
-
 class RelayClient {
   /**
    * create a RelayClient library object, to force contracts to go through a relay.
@@ -404,11 +397,8 @@ class RelayClient {
         } catch (e) {
           throw new Error('canRelay reverted (should not happen): ' + e)
         }
-        if (res.status !== '0') {
-          // in case of error, the context is an error message.
-          const errorMsg = res.recipientContext ? Buffer.from(res.recipientContext.slice(2), 'hex').toString() : ''
-          const status = canRelayStatus[res.status] || res.status
-          throw new Error('canRelay failed: ' + status + ': ' + errorMsg)
+        if (!res.success) {
+          throw new Error('canRelay failed: ' + res.returnValue)
         }
       }
       try {

--- a/src/js/relayserver/RelayServer.js
+++ b/src/js/relayserver/RelayServer.js
@@ -235,7 +235,12 @@ class RelayServer extends EventEmitter {
     }
     console.log(`Estimated max charge of relayed tx: ${maxCharge}, GasLimit of relayed tx: ${requiredGas}`)
     const { signedTx } = await this._sendTransaction(
-      { method, destination: relayHubAddress, gasLimit: requiredGas, gasPrice })
+      {
+        method,
+        destination: relayHubAddress,
+        gasLimit: requiredGas,
+        gasPrice
+      })
     return signedTx
   }
 
@@ -375,7 +380,10 @@ class RelayServer extends EventEmitter {
     // register on chain
     const registerMethod = this.relayHubContract.methods.registerRelay(this.baseRelayFee, this.pctRelayFee, this.url)
     const { receipt } = await this._sendTransaction(
-      { method: registerMethod, destination: this.relayHubContract.options.address })
+      {
+        method: registerMethod,
+        destination: this.relayHubContract.options.address
+      })
     console.log(`Relay ${this.address} registered on hub ${this.relayHubContract.options.address}. `)
     return receipt
   }
@@ -415,7 +423,8 @@ class RelayServer extends EventEmitter {
     const confirmedBlock = blockHeader.number - confirmationsNeeded
     let nonce = await this.web3.eth.getTransactionCount(this.address, confirmedBlock)
     debug(
-      `Removing confirmed txs until nonce ${nonce - 1}. confirmedBlock: ${confirmedBlock}. block number: ${blockHeader.number}`)
+      `Removing confirmed txs until nonce ${nonce -
+      1}. confirmedBlock: ${confirmedBlock}. block number: ${blockHeader.number}`)
     // Clear out all confirmed transactions (ie txs with nonce less than the account nonce at confirmationsNeeded blocks ago)
     await this.txStoreManager.removeTxsUntilNonce({ nonce: nonce - 1 })
 
@@ -487,7 +496,10 @@ class RelayServer extends EventEmitter {
     if (receipt.transactionHash.toLowerCase() !== storedTx.txId.toLowerCase()) {
       throw new Error(`txhash mismatch: from receipt: ${receipt.transactionHash} from txstore:${storedTx.txId}`)
     }
-    return { receipt, signedTx }
+    return {
+      receipt,
+      signedTx
+    }
   }
 
   async _resendTransaction ({ tx }) {
@@ -530,7 +542,10 @@ class RelayServer extends EventEmitter {
     if (receipt.transactionHash.toLowerCase() !== storedTx.txId.toLowerCase()) {
       throw new Error(`txhash mismatch: from receipt: ${receipt.transactionHash} from txstore:${storedTx.txId}`)
     }
-    return { receipt, signedTx }
+    return {
+      receipt,
+      signedTx
+    }
   }
 
   async _pollNonce () {

--- a/src/js/relayserver/RelayServer.js
+++ b/src/js/relayserver/RelayServer.js
@@ -193,7 +193,6 @@ class RelayServer extends EventEmitter {
       }
       throw new Error(`unknown paymaster error: ${e.message}`)
     }
-
     const hubOverhead = parseInt(await this.relayHubContract.methods.getHubOverhead().call())
     const maxPossibleGas = utils.calculateTransactionMaxPossibleGas({
       gasLimits,
@@ -215,11 +214,8 @@ class RelayServer extends EventEmitter {
     } catch (e) {
       errorMessage = e.message
     }
-    if (!canRelayRet || canRelayRet.status !== '0') {
-      const message = canRelayRet ? `status: ${canRelayRet.status} description: ${Buffer.from(
-        utils.removeHexPrefix(canRelayRet.recipientContext), 'hex').toString('utf8')}`
-        : 'jsonrpc call failed: ' + errorMessage
-      throw new Error('canRelay failed in server: ' + message)
+    if (!canRelayRet.success) {
+      throw new Error('canRelay failed in server: ' + canRelayRet.returnValue)
     }
     // Send relayed transaction
     const method = this.relayHubContract.methods.relayCall(signedData.message, signature, approvalData)

--- a/src/js/relayserver/RelayServer.js
+++ b/src/js/relayserver/RelayServer.js
@@ -214,8 +214,8 @@ class RelayServer extends EventEmitter {
     } catch (e) {
       errorMessage = e.message
     }
-    if (!canRelayRet.success) {
-      throw new Error('canRelay failed in server: ' + canRelayRet.returnValue)
+    if (!canRelayRet || !canRelayRet.success) {
+      throw new Error('canRelay failed in server: ' + (errorMessage || canRelayRet.returnValue))
     }
     // Send relayed transaction
     const method = this.relayHubContract.methods.relayCall(signedData.message, signature, approvalData)

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -29,13 +29,6 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
     RecipientBalanceChanged: new BN('4')
   }
 
-  const CanRelayStatus = {
-    OK: new BN('0'),
-    WrongSignature: new BN('1'),
-    WrongNonce: new BN('2'),
-    AcceptRelayedCallReverted: new BN('3'),
-    InvalidRecipientStatusCode: new BN('4')
-  }
   const chainId = Environments.defEnv.chainId
 
   let relayHub: string
@@ -263,25 +256,25 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
             acceptRelayedCallGasLimit,
             signatureWithPermissivePaymaster, '0x')
           // @ts-ignore (again, typechain does not know names of return values)
-          assert.equal(0, canRelay.status.valueOf())
+          assert.equal(canRelay.success, true)
         })
 
-        it('should get \'1\' (Wrong Signature) from \'canRelay\' for a transaction with a wrong signature',
-          async function () {
-            const wrongSig = '0xaaaa6ad4b4fab03bb2feaea2d54c690206e40036e4baa930760e72479da0cc5575779f9db9ef801e144b5e6af48542107f2f094649334b030e2bb44f054429b451'
-            const canRelay = await relayHubInstance.canRelay(relayRequest,
-              maxPossibleGas,
-              acceptRelayedCallGasLimit,
-              wrongSig, '0x')
-            // @ts-ignore (again, typechain does not know names of return values)
-            assert.equal(1, canRelay.status.valueOf())
-          })
+        it('should get "Wrong Signature" from \'canRelay\' for a transaction with a wrong signature', async function () {
+          const wrongSig = '0xaaaa6ad4b4fab03bb2feaea2d54c690206e40036e4baa930760e72479da0cc5575779f9db9ef801e144b5e6af48542107f2f094649334b030e2bb44f054429b451'
+          const canRelay = await relayHubInstance.canRelay(relayRequest,
+            maxPossibleGas,
+            acceptRelayedCallGasLimit,
+            wrongSig, '0x')
+          assert.equal(canRelay[0], false)
+          assert.include(canRelay[1], 'signature')
+        })
 
-        it('should get \'2\' (Wrong Nonce) from \'canRelay\' for a transaction with a wrong nonce', async function () {
+        it('should get "Wrong Nonce" from \'canRelay\' for a transaction with a wrong nonce', async function () {
           const wrongNonce = '777'
 
           const relayRequestWrongNonce = relayRequest.clone()
           relayRequestWrongNonce.relayData.senderNonce = wrongNonce
+
           const dataToSign = await getDataToSign({
             chainId,
             verifier: forwarder,
@@ -298,8 +291,8 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
             acceptRelayedCallGasLimit,
             signature,
             '0x')
-          // @ts-ignore (again, typechain does not know names of return values)
-          assert.equal(2, canRelay.status.valueOf())
+          assert.equal(canRelay[0], false)
+          assert.include(canRelay[1], 'nonce')
         })
       })
 
@@ -457,7 +450,7 @@ contract('RelayHub', function ([_, relayOwner, relayAddress, __, senderAddress, 
               gasPrice
             })
 
-          expectEvent.inLogs(logs, 'CanRelayFailed', { reason: CanRelayStatus.InvalidRecipientStatusCode })
+          expectEvent.inLogs(logs, 'CanRelayFailed', { reason: 'invalid code' })
         })
 
         it('should not accept relay requests if gas limit is too low for a relayed transaction', async function () {

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -42,7 +42,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
   const gasLimit = new BN('1000000')
   const senderNonce = new BN('0')
   const magicNumbers = {
-    arc: 805,
+    arc: 805 - 6,
     pre: 1861,
     post: 2080
   }
@@ -158,7 +158,6 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
       const misbehavingPaymaster = await TestPaymasterConfigurableMisbehavior.new()
       await misbehavingPaymaster.setHub(relayHub.address)
       await misbehavingPaymaster.deposit({ value: 1e17 })
-      const AcceptRelayedCallReverted = 3
       await misbehavingPaymaster.setOverspendAcceptGas(true)
 
       const senderNonce = (await relayHub.getNonce(recipient.address, senderAddress)).toString()
@@ -177,8 +176,8 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
       const maxPossibleGasIrrelevantValue = 8000000
       const acceptRelayedCallGasLimit = 50000
       const canRelayResponse = await relayHub.canRelay(relayRequestMisbehaving, maxPossibleGasIrrelevantValue, acceptRelayedCallGasLimit, signature, '0x')
-      // @ts-ignore
-      assert.equal(AcceptRelayedCallReverted, canRelayResponse.status)
+      assert.equal(canRelayResponse[0], false)
+      assert.equal(canRelayResponse[1], '') // no revert string on out-of-gas
 
       const res = await relayHub.relayCall(relayRequestMisbehaving, signature, '0x', {
         from: relayAddress,
@@ -186,7 +185,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayAddress, __
       })
 
       assert.equal('CanRelayFailed', res.logs[0].event)
-      assert.equal(AcceptRelayedCallReverted, res.logs[0].args.reason)
+      assert.equal(res.logs[0].args.reason, '')
     })
   })
 

--- a/test/TokenPaymaster.test.js
+++ b/test/TokenPaymaster.test.js
@@ -24,7 +24,7 @@ async function revertReason (func) {
   }
 }
 
-contract.only('TokenPaymaster', ([from, relay, relayOwner]) => {
+contract('TokenPaymaster', ([from, relay, relayOwner]) => {
   let paymaster, uniswap, token, recipient, hub, forwarder
   let sharedRelayRequestData
 

--- a/test/TokenPaymaster.test.js
+++ b/test/TokenPaymaster.test.js
@@ -15,17 +15,16 @@ const { getEip712Signature } = require('../src/js/common/utils')
 
 const RelayRequest = require('../src/js/common/EIP712/RelayRequest')
 
-async function retcode (func) {
-  const ret = await func
-  const code = ret[0].toNumber()
-  const msg = code === 0 ? '' : ret[1] ? Buffer.from(ret[1].slice(2), 'hex').toString() : null
-  return {
-    code,
-    msg
+async function revertReason (func) {
+  try {
+    await func
+    return 'ok' // no revert
+  } catch (e) {
+    return e.message.replace(/.*revert /, '')
   }
 }
 
-contract('TokenPaymaster', ([from, relay, relayOwner]) => {
+contract.only('TokenPaymaster', ([from, relay, relayOwner]) => {
   let paymaster, uniswap, token, recipient, hub, forwarder
   let sharedRelayRequestData
 
@@ -75,10 +74,7 @@ contract('TokenPaymaster', ([from, relay, relayOwner]) => {
       const relayRequest = new RelayRequest({
         ...sharedRelayRequestData
       })
-      assert.deepEqual(await retcode(paymaster.acceptRelayedCall(relayRequest, '0x', 1e6)), {
-        code: 99,
-        msg: 'balance too low'
-      })
+      assert.equal(await revertReason(paymaster.acceptRelayedCall(relayRequest, '0x', 1e6)), 'balance too low')
     })
 
     it('should fund recipient', async () => {
@@ -90,10 +86,7 @@ contract('TokenPaymaster', ([from, relay, relayOwner]) => {
       const relayRequest = new RelayRequest({
         ...sharedRelayRequestData
       })
-      assert.deepEqual(await retcode(paymaster.acceptRelayedCall(relayRequest, '0x', 1e6)), {
-        code: 99,
-        msg: 'allowance too low'
-      })
+      assert.include(await revertReason(paymaster.acceptRelayedCall(relayRequest, '0x', 1e6)), 'allowance too low')
     })
 
     it('should recipient.approve', async () => {
@@ -104,8 +97,7 @@ contract('TokenPaymaster', ([from, relay, relayOwner]) => {
       const relayRequest = new RelayRequest({
         ...sharedRelayRequestData
       })
-      const ret = await retcode(paymaster.acceptRelayedCall(relayRequest, '0x', 1e6))
-      assert.equal(ret.code, 0, ret)
+      await paymaster.acceptRelayedCall(relayRequest, '0x', 1e6)
     })
   })
 
@@ -148,14 +140,13 @@ contract('TokenPaymaster', ([from, relay, relayOwner]) => {
       const maxGas = 1e6
       const arcGasLimit = 1e6
 
-      // not really required.
-      assert.deepEqual(await retcode(hub.canRelay(relayRequest, maxGas, arcGasLimit, signature, '0x', {
+      // not really required: verify there's no revert
+      const canRelayRet = await hub.canRelay(relayRequest, maxGas, arcGasLimit, signature, '0x', {
         from: relay,
         gasPrice: 1
-      })), {
-        code: 0,
-        msg: ''
       })
+      assert.equal(canRelayRet[0], true)
+
       const preBalance = await hub.balanceOf(paymaster.address)
 
       const ret = await hub.relayCall(relayRequest, signature, '0x', {

--- a/test/relay_client_test.js
+++ b/test/relay_client_test.js
@@ -161,7 +161,7 @@ contract('RelayClient', function (accounts) {
       await approvalPaymaster.setHub(rhub.address)
       await rhub.depositFor(approvalPaymaster.address, { value: 1e18 })
 
-      const expectedError = 13
+      const expectedError = 'test: not approved'
       const encoded = sr.contract.methods.emitMessage('hello world').encodeABI()
       const to = sr.address
       const options = {
@@ -189,10 +189,10 @@ contract('RelayClient', function (accounts) {
       } catch (error) {
         if (validateCanRelay) {
           // error checked by relayTransaction:
-          assert.equal('Error: canRelay failed: 13: test: not approved', error.toString())
+          assert.equal('Error: canRelay failed: test: not approved', error.toString())
         } else {
           // error checked by relay:
-          assert.include(error.otherErrors[0], 'canRelay failed in server: status: ' + expectedError)
+          assert.include(error.otherErrors[0], 'canRelay failed in server: ' + expectedError)
         }
       }
     }))


### PR DESCRIPTION
acceptRelayedCall now reverts on error, 
- can use simple "require" to validate things..
- the return value is the context.
- CanRelayStatus removed
- CanRelayFailed reports the reason of the revert failure.