### PR TITLE
RelayServer separate worker and manager

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,19 +3,19 @@ jobs: # a collection of steps
   build: # runs not using Workflows must have a `build` job as entry point
     working_directory: ~/gls # directory where steps will run
     docker: # run the steps with Docker
-      - image: tabookey/eth-tools:1.2
+      - image: circleci/node:13.11.0
 
     steps: # a collection of executable commands
       - checkout # special step to check out source code to working directory
 
       - restore_cache: # special step to restore the dependency cache
-          key: dependency-cache-{{ checksum "package.json" }}-yarn1
+          key: dependency-cache-{{ checksum "package.json" }}-yarn2
       - run:
           name: yarn-install
           command: yarn
 
       - save_cache: # special step to save the dependency cache
-          key: dependency-cache-{{ checksum "package.json" }}-yarn1
+          key: dependency-cache-{{ checksum "package.json" }}-yarn2
           paths:
             - ./node_modules
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 /build/
 .DS_Store
-/node_modules/
+node_modules
 /.vscode/settings.json
 /.idea/*
 !/.idea/dictionaries/

--- a/buidler.config.js
+++ b/buidler.config.js
@@ -5,6 +5,7 @@
 //   import "nomiclabs/buidler/console.log";
 //   console.log("a=%s addr=%s", 1, this);
 
+require( 'ts-node/register')
 // eslint-disable-next-line no-undef
 usePlugin('@nomiclabs/buidler-truffle5')
 

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,12 +1,9 @@
 var RelayHub = artifacts.require('./RelayHub.sol')
-var RLPReader = artifacts.require('./RLPReader.sol')
 var StakeManager = artifacts.require('./StakeManager.sol')
 var Penalizer = artifacts.require('./Penalizer.sol')
 
-module.exports = function (deployer) {
-  deployer.deploy(RLPReader)
-  deployer.link(RLPReader, RelayHub)
-  deployer.deploy(RelayHub, 16, '0x0000000000000000000000000000000000000000', '0x0000000000000000000000000000000000000000')
-  deployer.deploy(StakeManager)
-  deployer.deploy(Penalizer)
+module.exports = async function (deployer) {
+  await deployer.deploy(StakeManager)
+  await deployer.deploy(Penalizer)
+  await deployer.deploy(RelayHub, 16, StakeManager.address, Penalizer.address)
 }

--- a/src/relayclient/DevRelayClient.ts
+++ b/src/relayclient/DevRelayClient.ts
@@ -17,8 +17,7 @@ import net from 'net'
 
 import KeyManager = require('../relayserver/KeyManager')
 
-const dayInSec = 24 * 60 * 60
-const weekInSec = dayInSec * 7
+const unstakeDelay = 2000
 
 import TruffleContract = require('@truffle/contract')
 import Contract = Truffle.Contract
@@ -52,7 +51,7 @@ export function runServer (
   relayHub: string,
   devConfig: DevGSNConfig
 ): RunServerReturn {
-  const keyManager = new KeyManager({ ecdsaKeyPair: KeyManager.newKeypair(), workdir: devConfig.relayWorkdir })
+  const keyManager = new KeyManager({ count: 2, workdir: devConfig.relayWorkdir })
   const txStoreManager = new TxStoreManager({ inMemory: true })
 
   // @ts-ignore
@@ -208,17 +207,19 @@ export class DevRelayClient extends RelayClient {
 
     const stakeManager = await IStakeManagerContract.at(stakeManagerAddress)
 
-    await stakeManager.stakeForAddress(relayServer.address, weekInSec, {
-      from: this.devConfig.relayOwner,
-      value: ether('1')
-      // gas: estim
-    })
-    this.debug('== sending balance to relayServer', relayServer.address)
-    await stakeManager.authorizeHub(relayServer.address, this.config.relayHubAddress, { from: this.devConfig.relayOwner })
+    await stakeManager.contract.methods.stakeForAddress(relayServer.getManagerAddress(), unstakeDelay).send({ from: this.devConfig.relayOwner, value: ether('1') })
+    // not sure why: the line below started to crash on: Number can only safely store up to 53 bits
+    // (and its not relayed - its a direct call)
+    // await stakeManager.stakeForAddress(relayServer.getManagerAddress(), unstakeDelay, {
+    //   from: this.devConfig.relayOwner,
+    //   value: ether('1'),
+    // })
+    this.debug('== sending balance to relayServer', relayServer.getManagerAddress())
+    await stakeManager.authorizeHub(relayServer.getManagerAddress(), this.config.relayHubAddress, { from: this.devConfig.relayOwner })
     await this.contractInteractor.getWeb3().eth.sendTransaction({
       from: this.devConfig.relayOwner,
-      to: relayServer.address,
-      value: 1e18
+      to: relayServer.getManagerAddress(),
+      value: ether('1')
     })
     this.debug('== waiting for relay')
     // @ts-ignore

--- a/src/relayclient/DevRelayClient.ts
+++ b/src/relayclient/DevRelayClient.ts
@@ -214,14 +214,12 @@ export class DevRelayClient extends RelayClient {
     //   from: this.devConfig.relayOwner,
     //   value: ether('1'),
     // })
-    this.debug('== sending balance to relayServer', relayServer.getManagerAddress())
     await stakeManager.authorizeHub(relayServer.getManagerAddress(), this.config.relayHubAddress, { from: this.devConfig.relayOwner })
     await this.contractInteractor.getWeb3().eth.sendTransaction({
       from: this.devConfig.relayOwner,
       to: relayServer.getManagerAddress(),
       value: ether('1')
     })
-    this.debug('== waiting for relay')
     // @ts-ignore
     const relayInfo = await waitForRelay(relayServer.url as string + '/getaddr', 5000, (res) => {
       if (res?.data?.Ready === true) {
@@ -237,8 +235,6 @@ export class DevRelayClient extends RelayClient {
 
     const devRelays = this.knownRelaysManager as DevKnownRelays
     devRelays.devRelay = relayInfo
-
-    this.debug('== relay ready')
   }
 
   debug (...args: any): void {

--- a/src/relayclient/DevRelayClient.ts
+++ b/src/relayclient/DevRelayClient.ts
@@ -17,7 +17,8 @@ import net from 'net'
 
 import KeyManager = require('../relayserver/KeyManager')
 
-const unstakeDelay = 2000
+const dayInSec = 24 * 60 * 60
+const weekInSec = dayInSec * 7
 
 import TruffleContract = require('@truffle/contract')
 import Contract = Truffle.Contract
@@ -207,19 +208,17 @@ export class DevRelayClient extends RelayClient {
 
     const stakeManager = await IStakeManagerContract.at(stakeManagerAddress)
 
-    await stakeManager.contract.methods.stakeForAddress(relayServer.address, unstakeDelay).send({ from: this.devConfig.relayOwner, value: ether('1') })
-    // not sure why: the line below started to crash on: Number can only safely store up to 53 bits
-    // (and its not relayed - its a direct call)
-    // await stakeManager.stakeForAddress(relayServer.address, unstakeDelay, {
-    //   from: this.devConfig.relayOwner,
-    //   value: ether('1'),
-    // })
+    await stakeManager.stakeForAddress(relayServer.address, weekInSec, {
+      from: this.devConfig.relayOwner,
+      value: ether('1')
+      // gas: estim
+    })
     this.debug('== sending balance to relayServer', relayServer.address)
     await stakeManager.authorizeHub(relayServer.address, this.config.relayHubAddress, { from: this.devConfig.relayOwner })
     await this.contractInteractor.getWeb3().eth.sendTransaction({
       from: this.devConfig.relayOwner,
       to: relayServer.address,
-      value: ether('1')
+      value: 1e18
     })
     this.debug('== waiting for relay')
     // @ts-ignore

--- a/src/relayclient/RelayedTransactionValidator.ts
+++ b/src/relayclient/RelayedTransactionValidator.ts
@@ -58,7 +58,8 @@ export default class RelayedTransactionValidator {
         console.log('validateRelayResponse - valid transaction response')
       }
 
-      const receivedNonce = transaction.nonce.readUIntBE(0, transaction.nonce.byteLength)
+      // TODO: the relayServer encoder returns zero-length buffer for nonce=0.`
+      const receivedNonce = transaction.nonce.length === 0 ? 0 : transaction.nonce.readUIntBE(0, transaction.nonce.byteLength)
       if (receivedNonce > transactionJsonRequest.relayMaxNonce) {
         // TODO: need to validate that client retries the same request and doesn't double-spend.
         // Note that this transaction is totally valid from the EVM's point of view

--- a/src/relayserver/HttpServer.js
+++ b/src/relayserver/HttpServer.js
@@ -72,14 +72,7 @@ class HttpServer {
   }
 
   async pingHandler (req, res) {
-    const pingResponse = {
-      RelayServerAddress: this.backend.address,
-      RelayManagerAddress: this.backend.address,
-      RelayHubAddress: this.backend.relayHubContract.options.address,
-      MinGasPrice: this.backend.getMinGasPrice(),
-      Ready: this.backend.isReady(),
-      Version: this.backend.VERSION
-    }
+    const pingResponse = this.backend.pingHandler()
     res.send(pingResponse)
     console.log(`address ${this.backend.address} sent. ready: ${this.backend.isReady()}`)
   }

--- a/src/relayserver/HttpServer.js
+++ b/src/relayserver/HttpServer.js
@@ -74,7 +74,7 @@ class HttpServer {
   async pingHandler (req, res) {
     const pingResponse = this.backend.pingHandler()
     res.send(pingResponse)
-    console.log(`address ${this.backend.address} sent. ready: ${this.backend.isReady()}`)
+    console.log(`address ${pingResponse.RelayServerAddress} sent. ready: ${pingResponse.Ready}`)
   }
 
   async relayHandler (req, res) {

--- a/src/relayserver/HttpServer.js
+++ b/src/relayserver/HttpServer.js
@@ -74,6 +74,8 @@ class HttpServer {
   async pingHandler (req, res) {
     const pingResponse = {
       RelayServerAddress: this.backend.address,
+      RelayManagerAddress: this.backend.address,
+      RelayHubAddress: this.backend.relayHubContract.options.address,
       MinGasPrice: this.backend.getMinGasPrice(),
       Ready: this.backend.isReady(),
       Version: this.backend.VERSION

--- a/src/relayserver/KeyManager.js
+++ b/src/relayserver/KeyManager.js
@@ -1,8 +1,6 @@
 const Wallet = require('ethereumjs-wallet')
 const HDKey = require('ethereumjs-wallet/hdkey')
-const abi = require('ethereumjs-abi')
 const fs = require('fs')
-const ethUtils = require('ethereumjs-util')
 const ow = require('ow')
 
 class KeyManager {
@@ -59,20 +57,6 @@ class KeyManager {
 
   getAddresses () {
     return Object.keys(this._privateKeys)
-  }
-
-  ecSignWithPrefix ({ signer, hash }) {
-    const prefixedHash = abi.soliditySHA3(['string', 'bytes32'], ['\x19Ethereum Signed Message:\n32', hash])
-    return this.ecSignNoPrefix({ signer, hash: prefixedHash })
-  }
-
-  ecSignNoPrefix ({ signer, hash }) {
-    ow(signer, ow.string)
-    ow(hash, ow.string)
-    const privateKey = this._privateKeys[signer]
-    if (privateKey === undefined) { throw new Error(`Can't sign: from=${signer} is not managed`) }
-    const sig = ethUtils.ecsign(hash, privateKey)
-    return Buffer.concat([sig.r, sig.s, Buffer.from(sig.v.toString(16), 'hex')])
   }
 
   signTransaction (signer, tx) {

--- a/src/relayserver/KeyManager.js
+++ b/src/relayserver/KeyManager.js
@@ -6,8 +6,12 @@ const ethUtils = require('ethereumjs-util')
 const ow = require('ow')
 
 class KeyManager {
-  // workdir - read seed from keystore file (or generate one and write it)
-  // seed - if working in memory (no workdir), you can specify a seed - or use randomly generated one.
+
+  /**
+   * @param count - # of addresses managed by this manager
+   * @param workdir - read seed from keystore file (or generate one and write it)
+   * @param seed - if working in memory (no workdir), you can specify a seed - or use randomly generated one.
+   */
   constructor ({ count, workdir = null, seed = null }) {
     ow(count, ow.number)
     if (seed && workdir) { throw new Error('Can\'t specify both seed and workdir') }

--- a/src/relayserver/KeyManager.js
+++ b/src/relayserver/KeyManager.js
@@ -6,7 +6,6 @@ const ethUtils = require('ethereumjs-util')
 const ow = require('ow')
 
 class KeyManager {
-
   /**
    * @param count - # of addresses managed by this manager
    * @param workdir - read seed from keystore file (or generate one and write it)

--- a/src/relayserver/RelayServer.js
+++ b/src/relayserver/RelayServer.js
@@ -1,3 +1,5 @@
+const ow = require('ow')
+
 const EventEmitter = require('events')
 const Web3 = require('web3')
 const abiDecoder = require('abi-decoder')
@@ -24,6 +26,8 @@ abiDecoder.addABI(StakeManagerABI)
 
 const VERSION = '0.0.1' // eslint-disable-line no-unused-vars
 const minimumRelayBalance = 1e17 // 0.1 eth
+const defaultWorkerMinBalance = 0.01e18
+const defaultWorkerTargetBalance = 0.3e18
 const confirmationsNeeded = 12
 const pendingTransactionTimeout = 5 * 60 * 1000 // 5 minutes in milliseconds
 const maxGasPrice = 100e9
@@ -31,6 +35,8 @@ const GAS_RESERVE = 100000
 const retryGasPriceFactor = 1.2
 const DEBUG = false
 const SPAM = false
+
+const toBN = Web3.utils.toBN
 
 function debug () {
   if (DEBUG) console.log(...arguments)
@@ -54,6 +60,8 @@ class RelayServer extends EventEmitter {
       pctRelayFee,
       gasPriceFactor,
       web3provider,
+      workerMinBalance = defaultWorkerMinBalance,
+      workerTargetBalance = defaultWorkerTargetBalance,
       devMode
     }) {
     super()
@@ -71,19 +79,36 @@ class RelayServer extends EventEmitter {
         pctRelayFee,
         gasPriceFactor,
         web3provider,
+        workerMinBalance,
+        workerTargetBalance,
         devMode
       })
     this.web3 = new Web3(web3provider)
-    this.address = keyManager.address()
     this.relayHubContract = new this.web3.eth.Contract(RelayHubABI, hubAddress)
 
     this.paymasterContract = new this.web3.eth.Contract(PayMasterABI)
     this.lastScannedBlock = 0
     this.ready = false
     this.removed = false
-    this.nonce = 0
     this.nonceMutex = new Mutex()
+
+    // todo: initialize nonces for all signers (currently one manager, one worker)
+    this.nonces = { 0: 0, 1: 0 }
+
+    this.keyManager.generateKeys(2)
+    this.managerAddress = keyManager.getAddress(0)
+
     debug('gasPriceFactor', gasPriceFactor)
+  }
+
+  getManagerAddress () {
+    return this.managerAddress
+  }
+
+  // index zero is not a worker, but the manager.
+  getAddress (index) {
+    ow(index, ow.number)
+    return this.keyManager.getAddress(index)
   }
 
   getMinGasPrice () {
@@ -92,6 +117,17 @@ class RelayServer extends EventEmitter {
 
   isReady () {
     return this.ready && !this.removed
+  }
+
+  pingHandler () {
+    return {
+      RelayServerAddress: this.getAddress(1),
+      RelayManagerAddress: this.managerAddress,
+      RelayHubAddress: this.relayHubContract.options.address,
+      MinGasPrice: this.getMinGasPrice(),
+      Ready: this.isReady(),
+      Version: this.VERSION
+    }
   }
 
   async createRelayTransaction (
@@ -142,8 +178,14 @@ class RelayServer extends EventEmitter {
       throw new Error(`Unacceptable gasPrice: relayServer's gasPrice:${this.gasPrice} request's gasPrice: ${gasPrice}`)
     }
 
+    // TODO: currently we hard-code a single worker. should find a "free" one to use from a pool
+    const workerIndex = 1
+
+    // TODO: should replenish earlier, so client can validate the worker has funds to pay for the tx
+    await this.replenishWorker(1)
+
     // Check that max nonce is valid
-    const nonce = await this._pollNonce()
+    const nonce = await this._pollNonce(workerIndex)
     if (nonce > relayMaxNonce) {
       throw new Error(`Unacceptable relayMaxNonce: ${relayMaxNonce}. current nonce: ${nonce}`)
     }
@@ -159,7 +201,7 @@ class RelayServer extends EventEmitter {
       gasPrice: gasPrice.toString(),
       gasLimit: gasLimit.toString(),
       paymaster: paymaster,
-      relayWorker: this.address
+      relayWorker: this.getAddress(1)
     })
     // TODO: should not use signedData at all. only the relayRequest.
     const signedData = getDataToSign({
@@ -199,7 +241,7 @@ class RelayServer extends EventEmitter {
       maxPossibleGas,
       gasLimits.acceptRelayedCallGasLimit,
       signature,
-      approvalData).call()
+      approvalData).call({ from: this.getAddress(workerIndex) })
     debug('canRelayRet', canRelayRet)
     if (!canRelayRet) {
       canRelayRet = {}
@@ -223,11 +265,14 @@ class RelayServer extends EventEmitter {
     debug(`Estimated max charge of relayed tx: ${maxCharge}, GasLimit of relayed tx: ${maxPossibleGas}`)
     const { signedTx } = await this._sendTransaction(
       {
+        signerIndex: workerIndex,
         method,
         destination: relayHubAddress,
         gasLimit: maxPossibleGas,
         gasPrice
       })
+    // after sending a transaction is a good time to check the worker's balance, and replenish it.
+    await this.replenishWorker(1)
     return signedTx
   }
 
@@ -273,7 +318,7 @@ class RelayServer extends EventEmitter {
 
   async _init () {
     const relayHubAddress = this.relayHubContract.options.address
-    console.log('Server address', this.address)
+    console.log('Server address', this.managerAddress)
     const code = await this.web3.eth.getCode(relayHubAddress)
     if (code.length < 10) {
       this.fatal(`No RelayHub deployed at address ${relayHubAddress}.`)
@@ -285,7 +330,7 @@ class RelayServer extends EventEmitter {
     const stakeManagerAddress = await this.relayHubContract.methods.getStakeManager().call()
     this.stakeManagerContract = new this.web3.eth.Contract(StakeManagerABI, stakeManagerAddress)
     const stakeManagerTopics = [Object.keys(this.stakeManagerContract.events).filter(x => (x.includes('0x')))]
-    this.topics = stakeManagerTopics.concat([['0x' + '0'.repeat(24) + this.address.slice(2)]])
+    this.topics = stakeManagerTopics.concat([['0x' + '0'.repeat(24) + this.managerAddress.slice(2)]])
 
     this.chainId = await this.web3.eth.getChainId()
     this.networkId = await this.web3.eth.net.getId()
@@ -293,8 +338,28 @@ class RelayServer extends EventEmitter {
       console.log('Don\'t use real network\'s chainId & networkId while in devMode.')
       process.exit(-1)
     }
-
     this.initialized = true
+  }
+
+  async replenishWorker (workerIndex) {
+    const workerAddress = this.getAddress(workerIndex)
+    const workerBalance = toBN(await this.web3.eth.getBalance(workerAddress))
+    if (workerBalance.lt(toBN(this.workerMinBalance))) {
+      const refill = toBN(this.workerTargetBalance).sub(workerBalance)
+      console.log(`== replenishWorker(${workerIndex}): mgr balance=${this.balance.toString() / 1e18} worker balance=${workerBalance.toString() / 1e18} refill=${refill.toString() / 1e18}`)
+      if (refill.lt(this.balance.sub(toBN(minimumRelayBalance)))) {
+        await this._sendTransaction({
+          signerIndex: 0,
+          destination: workerAddress,
+          value: refill,
+          gasLimit: 300000
+          // gasPrice:1
+        })
+        this.balance = this.balance.sub(refill)
+      } else {
+        console.log(`== replenishWorker: can't replenish: mgr balance too low ${this.balance.toString() / 1e18} refil=${refill.toString() / 1e18}`)
+      }
+    }
   }
 
   async _worker (blockHeader) {
@@ -308,7 +373,7 @@ class RelayServer extends EventEmitter {
         throw new StateError('Could not get gasPrice from node')
       }
       await this.refreshBalance()
-      if (!this.balance || this.balance < minimumRelayBalance) {
+      if (!this.balance || this.balance.lt(toBN(minimumRelayBalance))) {
         throw new StateError(
           `Server's balance too low ( ${this.balance}, required ${minimumRelayBalance}). Waiting for funding...`)
       }
@@ -340,8 +405,6 @@ class RelayServer extends EventEmitter {
           case 'StakeUnlocked':
             receipt = await this._handleUnstakedEvent(dlog)
             break
-          default:
-            console.log('=== not handling event: ', dlog.name)
         }
       }
 
@@ -355,7 +418,7 @@ class RelayServer extends EventEmitter {
       }
       this.lastScannedBlock = parseInt(blockHeader.number)
       if (!this.state) {
-        console.log('State is Ready.')
+        console.log('Relay is Ready.')
       }
       this.ready = true
       delete this.lastError
@@ -370,13 +433,13 @@ class RelayServer extends EventEmitter {
         }
       } else {
         this.emit('error', e)
-        console.error('error in worker:', e.message)
+        console.error('error in worker:', e)
       }
     }
   }
 
   async refreshBalance () {
-    this.balance = parseInt(await this.web3.eth.getBalance(this.address))
+    this.balance = toBN(await this.web3.eth.getBalance(this.managerAddress))
     return this.balance
   }
 
@@ -384,7 +447,7 @@ class RelayServer extends EventEmitter {
     if (!this.initialized) {
       await this._init()
     }
-    const stakeInfo = await this.stakeManagerContract.methods.getStakeInfo(this.address).call()
+    const stakeInfo = await this.stakeManagerContract.methods.getStakeInfo(this.managerAddress).call()
     this.stake = parseInt(stakeInfo.stake)
     if (!this.stake) {
       return 0
@@ -403,7 +466,7 @@ class RelayServer extends EventEmitter {
     // todo
     console.log('handle RelayRemoved event')
     // sanity checks
-    if (dlog.name !== 'RelayRemoved' || dlog.args.relay.toLowerCase() !== this.address.toLowerCase()) {
+    if (dlog.name !== 'RelayRemoved' || dlog.args.relay.toLowerCase() !== this.managerAddress.toLowerCase()) {
       throw new Error(`PANIC: handling wrong event ${dlog.name} or wrong event relay ${dlog.args.relay}`)
     }
     this.removed = true
@@ -411,7 +474,7 @@ class RelayServer extends EventEmitter {
   }
 
   async _handleHubAuthorizedEvent (dlog) {
-    if (dlog.name !== 'HubAuthorized' || dlog.args.relayManager.toLowerCase() !== this.address.toLowerCase()) {
+    if (dlog.name !== 'HubAuthorized' || dlog.args.relayManager.toLowerCase() !== this.managerAddress.toLowerCase()) {
       throw new Error(`PANIC: handling wrong event ${dlog.name} or wrong event relay ${dlog.args.relay}`)
     }
     if (dlog.args.relayHub.toLowerCase() === this.relayHubContract.options.address.toLowerCase()) {
@@ -424,7 +487,7 @@ class RelayServer extends EventEmitter {
   async _handleStakedEvent (dlog) {
     // todo
     // sanity checks
-    if (dlog.name !== 'StakeAdded' || dlog.args.relayManager.toLowerCase() !== this.address.toLowerCase()) {
+    if (dlog.name !== 'StakeAdded' || dlog.args.relayManager.toLowerCase() !== this.managerAddress.toLowerCase()) {
       throw new Error(`PANIC: handling wrong event ${dlog.name} or wrong event relay ${dlog.args.relay}`)
     }
     await this.refreshStake()
@@ -440,15 +503,16 @@ class RelayServer extends EventEmitter {
 
     const workersAddedEvents = await this.relayHubContract.getPastEvents('RelayWorkersAdded', {
       fromBlock: 1,
-      filter: { relayManager: this.address }
+      filter: { relayManager: this.managerAddress }
     })
 
     // add worker only if not already added
-    if (!workersAddedEvents.find(e => e.returnValues.newRelayWorkers.map(a => a.toLowerCase()).includes(this.address.toLowerCase()))) {
+    if (!workersAddedEvents.find(e => e.returnValues.newRelayWorkers.map(a => a.toLowerCase()).includes(this.managerAddress.toLowerCase()))) {
       // register on chain
-      const addRelayWorkerMethod = this.relayHubContract.methods.addRelayWorkers([this.address])
+      const addRelayWorkerMethod = this.relayHubContract.methods.addRelayWorkers([this.getAddress(1)])
       await this._sendTransaction(
         {
+          signerIndex: 0,
           method: addRelayWorkerMethod,
           destination: this.relayHubContract.options.address
         })
@@ -457,10 +521,12 @@ class RelayServer extends EventEmitter {
       this.url)
     const { receipt } = await this._sendTransaction(
       {
+        signerIndex: 0,
         method: registerMethod,
         destination: this.relayHubContract.options.address
       })
-    debug(`Relay ${this.address} registered on hub ${this.relayHubContract.options.address}. `)
+    debug(`Relay ${this.managerAddress} registered on hub ${this.relayHubContract.options.address}. `)
+
     this.isAddressAdded = true
     return receipt
   }
@@ -469,10 +535,10 @@ class RelayServer extends EventEmitter {
     // todo: send balance to owner
     console.log('handle Unstaked event', dlog)
     // sanity checks
-    if (dlog.name !== 'StakeUnlocked' || dlog.args.relayManager.toLowerCase() !== this.address.toLowerCase()) {
+    if (dlog.name !== 'StakeUnlocked' || dlog.args.relayManager.toLowerCase() !== this.managerAddress.toLowerCase()) {
       throw new Error(`PANIC: handling wrong event ${dlog.name} or wrong event relay ${dlog.args.relay}`)
     }
-    this.balance = await this.web3.eth.getBalance(this.address)
+    this.balance = toBN(await this.web3.eth.getBalance(this.managerAddress))
     const gasPrice = await this.web3.eth.getGasPrice()
     const gasLimit = 21000
     console.log(`Sending balance ${this.balance} to owner`)
@@ -480,40 +546,55 @@ class RelayServer extends EventEmitter {
       throw new Error(`balance too low: ${this.balance}, tx cost: ${gasLimit * gasPrice}`)
     }
     const { receipt } = await this._sendTransaction({
+      signerIndex: 0,
       destination: this.owner,
       gasLimit,
       gasPrice,
-      value: this.balance - gasLimit * gasPrice
+      value: this.balance.sub(toBN(gasLimit * gasPrice))
     })
     this.emit('unstaked')
     return receipt
   }
 
+  // resend Txs of all signers (manager, workers)
+  // return the receipt from the first request
   async _resendUnconfirmedTransactions (blockHeader) {
+    // repeat separately for each signer (manager, all workers)
+    let receipt;
+    [0, 1].forEach(signerIndex => {
+      const ret = this._resendUnconfirmedTransactionsForSigner(blockHeader, signerIndex)
+      if (ret) {
+        receipt = ret
+      }
+    })
+    return receipt
+  }
+
+  async _resendUnconfirmedTransactionsForSigner (blockHeader, signerIndex) {
+    const signer = this.getAddress(signerIndex)
     // Load unconfirmed transactions from store, and bail if there are none
-    let sortedTxs = await this.txStoreManager.getAll()
+    let sortedTxs = await this.txStoreManager.getAllBySigner(signer)
     if (sortedTxs.length === 0) {
       return
     }
     debug('resending unconfirmed transactions')
     // Get nonce at confirmationsNeeded blocks ago
     const confirmedBlock = blockHeader.number - confirmationsNeeded
-    let nonce = await this.web3.eth.getTransactionCount(this.address, confirmedBlock)
+    let nonce = await this.web3.eth.getTransactionCount(signer, confirmedBlock)
     debug(
-      `Removing confirmed txs until nonce ${nonce - 1}. confirmedBlock: ${confirmedBlock}. block number: ${blockHeader.number}`)
+      `resend ${signerIndex}: Removing confirmed txs until nonce ${nonce - 1}. confirmedBlock: ${confirmedBlock}. block number: ${blockHeader.number}`)
     // Clear out all confirmed transactions (ie txs with nonce less than the account nonce at confirmationsNeeded blocks ago)
-    await this.txStoreManager.removeTxsUntilNonce({ nonce: nonce - 1 })
+    await this.txStoreManager.removeTxsUntilNonce({ signer, nonce: nonce - 1 })
 
     // Load unconfirmed transactions from store again
-    sortedTxs = await this.txStoreManager.getAll()
+    sortedTxs = await this.txStoreManager.getAllBySigner(signer)
     if (sortedTxs.length === 0) {
       return
     }
-
     // Check if the tx was mined by comparing its nonce against the latest one
-    nonce = await this.web3.eth.getTransactionCount(this.address)
+    nonce = await this.web3.eth.getTransactionCount(signer)
     if (sortedTxs[0].nonce < nonce) {
-      debug('awaiting confirmations for next mined transaction', nonce, sortedTxs[0].nonce, sortedTxs[0].txId)
+      debug('resend', signerIndex, ': awaiting confirmations for next mined transaction', nonce, sortedTxs[0].nonce, sortedTxs[0].txId)
       return
     }
 
@@ -521,35 +602,37 @@ class RelayServer extends EventEmitter {
     if (Date.now() - (new Date(sortedTxs[0].createdAt)).getTime() < pendingTransactionTimeout) {
       spam(Date.now(), (new Date()), (new Date()).getTime())
       spam(sortedTxs[0].createdAt, (new Date(sortedTxs[0].createdAt)), (new Date(sortedTxs[0].createdAt)).getTime())
-      debug('awaiting transaction', sortedTxs[0].txId, 'to be mined. nonce:', nonce)
+      debug('resend', signerIndex, ': awaiting transaction', sortedTxs[0].txId, 'to be mined. nonce:', nonce)
       return
     }
     const { receipt, signedTx } = await this._resendTransaction({ tx: sortedTxs[0] })
     debug('resent transaction', sortedTxs[0].nonce, sortedTxs[0].txId, 'as',
       receipt.transactionHash)
     if (sortedTxs[0].attempts > 2) {
-      debug(`Sent tx ${sortedTxs[0].attempts} times already`)
+      debug(`resend ${signerIndex}: Sent tx ${sortedTxs[0].attempts} times already`)
     }
     return signedTx
   }
 
-  async _sendTransaction ({ method, destination, value, gasLimit, gasPrice }) {
+  // signerIndex is the index into addresses array. zero is relayManager, the rest are workers
+  async _sendTransaction ({ signerIndex, method, destination, value, gasLimit, gasPrice }) {
     const encodedCall = method && method.encodeABI ? method.encodeABI() : ''
     gasPrice = gasPrice || await this.web3.eth.getGasPrice()
     gasPrice = parseInt(gasPrice)
     debug('gasPrice', gasPrice)
-    const gas = (gasLimit && parseInt(gasLimit)) || await method.estimateGas({ from: this.address }) + 21000
+    const gas = (gasLimit && parseInt(gasLimit)) || (method && await method.estimateGas({ from: this.managerAddress }))
     debug('gasLimit', gas)
     debug('nonceMutex locked?', this.nonceMutex.isLocked())
     const releaseMutex = await this.nonceMutex.acquire()
     let signedTx
     let storedTx
     try {
-      const nonce = await this._pollNonce()
+      const nonce = await this._pollNonce(signerIndex)
       debug('nonce', nonce)
       // TODO: change to eip155 chainID
+      const signer = this.getAddress(signerIndex)
       const txToSign = new Transaction({
-        from: this.address,
+        from: signer,
         to: destination,
         value: value || 0,
         gas,
@@ -558,7 +641,7 @@ class RelayServer extends EventEmitter {
         nonce
       })
       spam('txToSign', txToSign)
-      signedTx = this.keyManager.signTransaction(txToSign)
+      signedTx = this.keyManager.signTransaction(signer, txToSign)
       storedTx = new StoredTx({
         from: txToSign.from,
         to: txToSign.to,
@@ -570,7 +653,7 @@ class RelayServer extends EventEmitter {
         txId: ethUtils.bufferToHex(txToSign.hash()),
         attempts: 1
       })
-      this.nonce++
+      this.nonces[signerIndex]++
       await this.txStoreManager.putTx({ tx: storedTx })
     } finally {
       releaseMutex()
@@ -606,7 +689,7 @@ class RelayServer extends EventEmitter {
     })
     spam('txToSign', txToSign)
     // TODO: change to eip155 chainID
-    const signedTx = this.keyManager.signTransaction(txToSign)
+    const signedTx = this.keyManager.signTransaction(tx.from, txToSign)
     const storedTx = new StoredTx({
       from: txToSign.from,
       to: txToSign.to,
@@ -619,8 +702,9 @@ class RelayServer extends EventEmitter {
       attempts: tx.attempts + 1
     })
     await this.txStoreManager.putTx({ tx: storedTx, updateExisting: true })
-    debug('resending tx with nonce', txToSign.nonce)
-    debug('account nonce', await this.web3.eth.getTransactionCount(this.address))
+
+    debug('resending tx with nonce', txToSign.nonce, 'from', tx.from)
+    debug('account nonce', await this.web3.eth.getTransactionCount(tx.from))
     const receipt = await this.web3.eth.sendSignedTransaction(signedTx)
     console.log('\ntxhash is', receipt.transactionHash)
     if (receipt.transactionHash.toLowerCase() !== storedTx.txId.toLowerCase()) {
@@ -632,13 +716,14 @@ class RelayServer extends EventEmitter {
     }
   }
 
-  async _pollNonce () {
-    const nonce = await this.web3.eth.getTransactionCount(this.address, 'pending')
-    if (nonce > this.nonce) {
-      debug('NONCE FIX', nonce, this.nonce)
-      this.nonce = nonce
+  async _pollNonce (signerIndex) {
+    const signer = this.getAddress(signerIndex)
+    const nonce = await this.web3.eth.getTransactionCount(signer, 'pending')
+    if (nonce > this.nonces[signerIndex]) {
+      debug('NONCE FIX for index=', signerIndex, 'signer=', signer, ': nonce=', nonce, this.nonces[signerIndex])
+      this.nonces[signerIndex] = nonce
     }
-    return this.nonce
+    return nonce
   }
 
   _parseEvent (event) {

--- a/src/relayserver/RelayServer.js
+++ b/src/relayserver/RelayServer.js
@@ -355,7 +355,7 @@ class RelayServer extends EventEmitter {
           gasLimit: 300000
           // gasPrice:1
         })
-        this.balance = this.balance.sub(refill)
+        this.refreshBalance()
       } else {
         console.log(`== replenishWorker: can't replenish: mgr balance too low ${this.balance.toString() / 1e18} refil=${refill.toString() / 1e18}`)
       }

--- a/src/relayserver/RelayServer.js
+++ b/src/relayserver/RelayServer.js
@@ -556,8 +556,10 @@ class RelayServer extends EventEmitter {
     return receipt
   }
 
-  // resend Txs of all signers (manager, workers)
-  // return the receipt from the first request
+  /**
+   * resend Txs of all signers (manager, workers)
+   * @return the receipt from the first request
+   */
   async _resendUnconfirmedTransactions (blockHeader) {
     // repeat separately for each signer (manager, all workers)
     let receipt;

--- a/src/relayserver/runServer.js
+++ b/src/relayserver/runServer.js
@@ -51,7 +51,7 @@ if (devMode) {
   }
 }
 
-const keyManager = new KeyManager({ count:2, workdir })
+const keyManager = new KeyManager({ count: 2, workdir })
 const txStoreManager = new TxStoreManager({ workdir })
 const web3provider = new Web3.providers.WebsocketProvider(ethereumNodeUrl)
 const gasPriceFactor = (parseInt(gasPricePercent) + 100) / 100

--- a/src/relayserver/runServer.js
+++ b/src/relayserver/runServer.js
@@ -51,7 +51,7 @@ if (devMode) {
   }
 }
 
-const keyManager = new KeyManager({ workdir })
+const keyManager = new KeyManager({ count:2, workdir })
 const txStoreManager = new TxStoreManager({ workdir })
 const web3provider = new Web3.providers.WebsocketProvider(ethereumNodeUrl)
 const gasPriceFactor = (parseInt(gasPricePercent) + 100) / 100

--- a/src/relayserver/runServer.js
+++ b/src/relayserver/runServer.js
@@ -50,15 +50,8 @@ if (devMode) {
     fs.unlinkSync(`${workdir}/${TXSTORE_FILENAME}`)
   }
 }
-let keypair
-try {
-  keypair = JSON.parse(fs.readFileSync(`${workdir}/keystore`)).ecdsaKeyPair
-  keypair.privateKey = Buffer.from(keypair.privateKey)
-  console.log('Using saved keypair')
-} catch (e) {
-  keypair = KeyManager.newKeypair()
-}
-const keyManager = new KeyManager({ ecdsaKeyPair: keypair, workdir })
+
+const keyManager = new KeyManager({ workdir })
 const txStoreManager = new TxStoreManager({ workdir })
 const web3provider = new Web3.providers.WebsocketProvider(ethereumNodeUrl)
 const gasPriceFactor = (parseInt(gasPricePercent) + 100) / 100

--- a/test/KeyManager.test.js
+++ b/test/KeyManager.test.js
@@ -6,7 +6,7 @@ const KEYSTORE_FILENAME = 'keystore'
 
 // NOTICE: this dir is removed in 'after', do not use this in any other test
 const workdir = '/tmp/gsn/test/key_manager'
-const keyStoreFilePath = workdir+"/"+KEYSTORE_FILENAME
+const keyStoreFilePath = workdir + '/' + KEYSTORE_FILENAME
 
 function cleanFolder () {
   if (fs.existsSync(keyStoreFilePath)) {
@@ -63,6 +63,6 @@ contract('KeyManager', function (accounts) {
       assert.equal(fkmA._privateKeys[addrA10].toString('hex'), fkmB._privateKeys[addrB10].toString('hex'))
     })
 
-    after('remove keystore',  cleanFolder)
+    after('remove keystore', cleanFolder)
   })
 })

--- a/test/KeyManager.test.js
+++ b/test/KeyManager.test.js
@@ -6,6 +6,16 @@ const KEYSTORE_FILENAME = 'keystore'
 
 // NOTICE: this dir is removed in 'after', do not use this in any other test
 const workdir = '/tmp/gsn/test/key_manager'
+const keyStoreFilePath = workdir+"/"+KEYSTORE_FILENAME
+
+function cleanFolder () {
+  if (fs.existsSync(keyStoreFilePath)) {
+    fs.unlinkSync(keyStoreFilePath)
+  }
+  if (fs.existsSync(workdir)) {
+    fs.rmdirSync(workdir)
+  }
+}
 
 contract('KeyManager', function (accounts) {
   describe('in-memory', () => {
@@ -29,8 +39,7 @@ contract('KeyManager', function (accounts) {
     let fkmA
 
     before('create key manager', async function () {
-      fs.rmdirSync(workdir, { recursive: true })
-      assert.isFalse(fs.existsSync(workdir), 'test keystore dir should not exist yet')
+      cleanFolder()
       fkmA = new KeyManager({ count: 20, workdir })
       assert.isTrue(fs.existsSync(workdir), 'test keystore dir should exist already')
     })
@@ -54,9 +63,6 @@ contract('KeyManager', function (accounts) {
       assert.equal(fkmA._privateKeys[addrA10].toString('hex'), fkmB._privateKeys[addrB10].toString('hex'))
     })
 
-    after('remove keystore', async function () {
-      fs.unlinkSync(`${workdir}/${KEYSTORE_FILENAME}`)
-      fs.rmdirSync(workdir)
-    })
+    after('remove keystore',  cleanFolder)
   })
 })

--- a/test/KeyManager.test.js
+++ b/test/KeyManager.test.js
@@ -8,29 +8,55 @@ const KEYSTORE_FILENAME = 'keystore'
 const workdir = '/tmp/gsn/test/key_manager'
 
 contract('KeyManager', function (accounts) {
-  let keyManager, keyPair
-
-  before('create key manager', async function () {
-    assert.isFalse(fs.existsSync(workdir), 'test keystore dir should not exist yet')
-    keyPair = {
-      privateKey: Buffer.from(
-        '4ec7b757b3be2f3f5251da530ac66eb3e76f15b64af9caa0da43dafa80568f15', 'hex'),
-      address: '0x792d6d01c45b720c942f4552dc7fcc6ca631b349'
-    }
-
-    keyManager = new KeyManager({ ecdsaKeyPair: keyPair, workdir })
-    assert.ok(keyManager, 'keyManager uninitialized')
-    assert.isTrue(fs.existsSync(workdir), 'test keystore dir should exist already')
+  describe('in-memory', () => {
+    let mkm
+    before(() => {
+      mkm = new KeyManager({ count: 10, seed: 'seed1234' })
+    })
+    it('should return key', () => {
+      // for a given seed, the addresses and privkeys are known..
+      const k0 = mkm.getAddress(0)
+      assert.deepEqual(mkm._privateKeys[k0].toString('hex'), '98bd175008b68dfd5a6aca0584d5a040032f2469656569d5d428161b776d27ff')
+      assert.equal(k0, '0x56558253d657baa29cfe9f0a808b7d19d5d80b9c')
+    })
+    it('should return another key for different index', () => {
+      const k1 = mkm.getAddress(1)
+      assert.equal(mkm._privateKeys[k1].toString('hex'), 'e52f32d373b0b38be3800ec9070af883a63c4fd2857c5b0f249180a2c303eb7e')
+      assert.equal(k1, '0xe2ceef58b3e5a8816c52b00067830b8e1afd82da')
+    })
   })
+  describe('file-based KeyManager', () => {
+    let fkmA
 
-  it('should create key pair', async function () {
-    const ephemeral = KeyManager.newKeypair()
-    assert.isTrue(web3.utils.isAddress(ephemeral.address))
-    assert.equal(ephemeral.privateKey.length, 32)
-  })
+    before('create key manager', async function () {
+      fs.rmdirSync(workdir, { recursive: true })
+      assert.isFalse(fs.existsSync(workdir), 'test keystore dir should not exist yet')
+      fkmA = new KeyManager({ count: 20, workdir })
+      assert.isTrue(fs.existsSync(workdir), 'test keystore dir should exist already')
+    })
 
-  after('remove keystore', async function () {
-    fs.unlinkSync(`${workdir}/${KEYSTORE_FILENAME}`)
-    fs.rmdirSync(workdir)
+    it('should get key pair', async function () {
+      const key = fkmA.getAddress(1)
+      assert.isTrue(web3.utils.isAddress(key))
+      assert.equal(fkmA._privateKeys[key].length, 32)
+    })
+
+    it('should get the same key when reloading', () => {
+      const addrA = fkmA.getAddress(0)
+      const addrA10 = fkmA.getAddress(10)
+      const fkmB = new KeyManager({ workdir, count: 20 })
+      const addrB = fkmB.getAddress(0)
+      assert.equal(addrA, addrB)
+      assert.equal(fkmA._privateKeys[addrA].toString('hex'), fkmB._privateKeys[addrB].toString('hex'))
+
+      const addrB10 = fkmB.getAddress(10)
+      assert.equal(addrA10, addrB10)
+      assert.equal(fkmA._privateKeys[addrA10].toString('hex'), fkmB._privateKeys[addrB10].toString('hex'))
+    })
+
+    after('remove keystore', async function () {
+      fs.unlinkSync(`${workdir}/${KEYSTORE_FILENAME}`)
+      fs.rmdirSync(workdir)
+    })
   })
 })

--- a/test/RelayServer.test.js
+++ b/test/RelayServer.test.js
@@ -91,10 +91,9 @@ contract('RelayServer', function (accounts) {
     relayServer.on('error', (e) => {
       console.log('error event', e.message)
     })
-    console.log('Relay Server Address', relayServer.getManagerAddress())
+    console.log('Relay Manager=', relayServer.getManagerAddress(), 'Worker=', relayServer.getAddress(1))
 
     encodedFunction = sr.contract.methods.emitMessage('hello world').encodeABI()
-    console.log('server address', relayServer.getManagerAddress())
     const relayClientConfig = {
       relayUrl: localhostOne,
       relayAddress: relayServer.getManagerAddress(),
@@ -554,7 +553,6 @@ contract('RelayServer', function (accounts) {
     })
 
     it('should resend multiple unconfirmed transactions', async function () {
-      console.log('==== start')
       // First clear db
       await relayServer.txStoreManager.clearAll()
       assert.deepEqual([], await relayServer.txStoreManager.getAll())

--- a/test/RelayServer.test.js
+++ b/test/RelayServer.test.js
@@ -116,7 +116,7 @@ contract('RelayServer', function (accounts) {
     }
   })
 
-  beforeEach(async function () {
+  before(async function () {
     await relayServer?.txStoreManager.clearAll()
   })
 

--- a/test/RelayServer.test.js
+++ b/test/RelayServer.test.js
@@ -56,7 +56,7 @@ contract('RelayServer', function (accounts) {
   let keyManager
 
   before(async function () {
-    ethereumNodeUrl = web3.currentProvider.host || 'http://localhost:8545'
+    ethereumNodeUrl = web3.currentProvider.host
     serverWeb3provider = new Web3.providers.WebsocketProvider(ethereumNodeUrl)
     _web3 = new Web3(new Web3.providers.HttpProvider(ethereumNodeUrl))
 

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -6,6 +6,7 @@ import { RelayHubInstance, StakeManagerInstance } from '../types/truffle-contrac
 import HttpWrapper from '../src/relayclient/HttpWrapper'
 import HttpClient from '../src/relayclient/HttpClient'
 import { configureGSN } from '../src/relayclient/GSNConfigurator'
+import { ether } from '@openzeppelin/test-helpers'
 
 const localhostOne = 'http://localhost:8090'
 
@@ -85,19 +86,18 @@ export async function startRelay (
   assert.ok(res, 'can\'t ping server')
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   assert.ok(res.RelayServerAddress, `server returned unknown response ${res.toString()}`)
-  const relayManagerAddress = res.RelayServerAddress
+  const relayManagerAddress = res.RelayManagerAddress
   console.log('Relay Server Address', relayManagerAddress)
   // @ts-ignore
   await web3.eth.sendTransaction({
     to: relayManagerAddress,
     from: options.relayOwner,
-    // @ts-ignore
-    value: web3.utils.toWei('2', 'ether')
+    value: ether('2')
   })
 
-  await stakeManager.stakeForAddress(relayManagerAddress, options.delay || 3600, {
+  await stakeManager.stakeForAddress(relayManagerAddress, options.delay || 2000, {
     from: options.relayOwner,
-    value: options.stake
+    value: options.stake || ether('1')
   })
   await stakeManager.authorizeHub(relayManagerAddress, relayHubAddress, {
     from: options.relayOwner

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -11,21 +11,6 @@ import fs from 'fs'
 
 const localhostOne = 'http://localhost:8090'
 
-// from: https://stackoverflow.com/questions/18052762/remove-directory-which-is-not-empty
-export function cleanFolder (folder: string): void {
-  if (fs.existsSync(folder)) {
-    fs.readdirSync(folder).forEach((file, index) => {
-      const curPath = path.join(folder, file)
-      if (fs.lstatSync(curPath).isDirectory()) { // recurse
-        cleanFolder(curPath)
-      } else { // delete file
-        fs.unlinkSync(curPath)
-      }
-    })
-    fs.rmdirSync(folder)
-  }
-}
-
 // start a background relay process.
 // rhub - relay hub contract
 // options:
@@ -39,7 +24,7 @@ export async function startRelay (
 
   const serverWorkDir = '/tmp/gsn/test/server'
 
-  cleanFolder(serverWorkDir)
+  fs.rmdirSync(serverWorkDir, { recursive: true })
   args.push('--Workdir', serverWorkDir)
   args.push('--DevMode')
   args.push('--RelayHubAddress', relayHubAddress)


### PR DESCRIPTION
- RelayServer separation of manager from worker (initial support for multiple workers, though only 1 is currently implemented)
- added support for hdkeys in KeyManager
- TxStorage now support unique **(nonce,signer)**
other changes:
- better handling of startup errors
- handling of intermediate states (waiting for fund/register) not as errors
- TxStorage, KeyManager now support in-memory state