### PR TITLE
disable coverage in circleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,25 +23,26 @@ jobs: # a collection of steps
           name: test
           command: yarn test | tee /tmp/test-results.log
 
-      - restore_cache: # special cache for coverage test
-          key: last-coverage
-          paths:
-            - ./coverage
+#coverage is broken (doesn't cover all contracts). disabled for now..
+#      - restore_cache: # special cache for coverage test
+#          key: last-coverage
+#          paths:
+#            - ./coverage
 
-      - run: # run coverage. update "coverage/covsig.txt" if successful run.
-          # use last coverage report if no test/contract was changed.
-          name: coverage
-          command: yarn run coverage-if-changed
+#      - run: # run coverage. update "coverage/covsig.txt" if successful run.
+#          # use last coverage report if no test/contract was changed.
+#          name: coverage
+#          command: yarn run coverage-if-changed
 
-      - save_cache: # special cache for coverage test
-          key: last-coverage
-          paths:
-            - ./coverage
+#      - save_cache: # special cache for coverage test
+#          key: last-coverage
+#          paths:
+#            - ./coverage
 
-      - store_artifacts: # special step to save test results as as artifact
-          path: ./coverage
-      - store_artifacts:
-          path: ./coverage.html
+#      - store_artifacts: # special step to save test results as as artifact
+#          path: ./coverage
+#      - store_artifacts:
+#          path: ./coverage.html
 
       - store_test_results: # special step to upload test results for display in Test Summary
           path: /tmp/test-results.log


### PR DESCRIPTION
coverage is currently broken: it doesn't recognize all contracts.
Until it is fixed, it is disabled.