### PR TITLE
Fix payable default function with getSender()

### DIFF
--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -34,7 +34,7 @@ contract BaseRelayRecipient is IRelayRecipient {
      * should be used in the contract anywhere instead of msg.sender
      */
     function getSender() internal view returns (address) {
-        if (msg.sender == address(getTrustedForwarder())) {
+        if (msg.data.length >= 24 && msg.sender == address(getTrustedForwarder())) {
             // At this point we know that the sender is a trusted forwarder,
             // so we trust that the last bytes of msg.data are the verified sender address.
             // extract sender address from the end of msg.data

--- a/test/regressions/PayableWithEmit.sol
+++ b/test/regressions/PayableWithEmit.sol
@@ -1,0 +1,28 @@
+pragma solidity ^0.5.16;
+import "../../contracts/BaseRelayRecipient.sol";
+import "@0x/contracts-utils/contracts/src/LibBytes.sol";
+
+//make sure that "payable" function that uses getSender() still works
+// (its not required to use getSender(), since the default function
+// will never be called through GSN, but still, if someone uses it,
+// it should work)
+contract PayableWithEmit is BaseRelayRecipient {
+
+  event Received(address sender, uint value, uint gasleft);
+
+  function () external payable {
+
+    emit Received(getSender(), msg.value, gasleft());
+  }
+
+
+  //helper: send value to another contract
+  function doSend(address payable target) public payable {
+
+    uint before = gasleft();
+    bool success = target.send(msg.value);
+    uint gasAfter = gasleft();
+    emit GasUsed(before-gasAfter, success);
+  }
+  event GasUsed(uint gasUsed, bool success);
+}

--- a/test/regressions/PayableWithEmit.test.ts
+++ b/test/regressions/PayableWithEmit.test.ts
@@ -1,0 +1,17 @@
+// import { getLogs } from '../TestUtils'
+const PayableWithEmit = artifacts.require('./PayableWithEmit.sol')
+
+contract('PayableWithEmit', () => {
+  let sender: any
+  let receiver: any
+
+  before(async () => {
+    receiver = await PayableWithEmit.new()
+    sender = await PayableWithEmit.new()
+  })
+  it('payable that uses getSender', async () => {
+    const ret = await sender.doSend(receiver.address, { value: 1e18 })
+    // console.log({ gasUsed: ret.receipt.gasUsed, log: getLogs(ret) })
+    assert.equal(ret.logs.find((e: any) => e.event === 'GasUsed').args.success, true)
+  })
+})


### PR DESCRIPTION
getSender() does SLOAD (to get the Forwarder), and thus (after istanbul
fork) is much more expensive than msg.sender.
If used from the default payable function, it might cause the payable to
revert.

The fix: make sure not to read storage in case the msg.data is shorter,
thus getSender() becomes much less expensive.