### PR TITLE
Rename getSender to _msgSender

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,10 +158,10 @@ contract MyContract is RelayRecipient {
 
     // This is a sample contract method. 
     // note that when receiving a request from a relay, the msg.sender is always a RelayHub.
-    // You must change your contract to use getSender() to get the real sender.
-    // (its OK if someone calls this method directly: if no relay is involved, getSender() returns msg.sender)
+    // You must change your contract to use _msgSender() to get the real sender.
+    // (its OK if someone calls this method directly: if no relay is involved, _msgSender() returns msg.sender)
     function my_method() {
-        require ( my_users[ getSender() ] );
+        require ( my_users[ _msgSender() ] );
         ...
     }
 }

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -6,8 +6,8 @@ import "./BaseGsnAware.sol";
 import "./interfaces/IRelayRecipient.sol";
 
 /**
- * A base class to be inherited by a concrete Relay Recipient
- * A subclass must use "getSender()" instead of "msg.sender"
+ * A base contract to be inherited by any contract that want to receive relayed transactions
+ * A subclass must use "_msgSender()" instead of "msg.sender"
  */
 contract BaseRelayRecipient is IRelayRecipient {
 
@@ -30,10 +30,10 @@ contract BaseRelayRecipient is IRelayRecipient {
     /**
      * return the sender of this call.
      * if the call came through our trusted forwarder, return the original sender.
-     * otherwise, return `msg.sender`
+     * otherwise, return `msg.sender`.
      * should be used in the contract anywhere instead of msg.sender
      */
-    function getSender() internal view returns (address) {
+    function _msgSender() internal view returns (address) {
         if (msg.data.length >= 24 && msg.sender == address(getTrustedForwarder())) {
             // At this point we know that the sender is a trusted forwarder,
             // so we trust that the last bytes of msg.data are the verified sender address.

--- a/contracts/interfaces/IRelayRecipient.sol
+++ b/contracts/interfaces/IRelayRecipient.sol
@@ -20,5 +20,5 @@ contract IRelayRecipient {
      * otherwise, return `msg.sender`
      * should be used in the contract anywhere instead of msg.sender
      */
-    function getSender() internal view returns (address);
+    function _msgSender() internal view returns (address);
 }

--- a/contracts/test/TestProxy.sol
+++ b/contracts/test/TestProxy.sol
@@ -11,13 +11,13 @@ contract TestProxy is Ownable, BaseRelayRecipient {
     }
 
     function isOwner() public view returns (bool) {
-        return getSender() == owner();
+        return _msgSender() == owner();
     }
 
-    event Test(address getSender, address msg_sender);
+    event Test(address _msgSender, address msg_sender);
     //not a proxy method; just for testing.
     function test() public {
-        emit Test(getSender(), msg.sender);
+        emit Test(_msgSender(), msg.sender);
     }
 
     function execute(address target, bytes calldata func) external onlyOwner {

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -35,7 +35,7 @@ contract TestRecipient is BaseRelayRecipient {
             withdrawAllBalance();
         }
 
-        emit SampleRecipientEmitted(message, getSender(), msg.sender, tx.origin);
+        emit SampleRecipientEmitted(message, _msgSender(), msg.sender, tx.origin);
     }
 
     function withdrawAllBalance() public {
@@ -46,6 +46,6 @@ contract TestRecipient is BaseRelayRecipient {
     function dontEmitMessage(string memory message) public {}
 
     function emitMessageNoParams() public {
-        emit SampleRecipientEmitted("Method with no parameters", getSender(), msg.sender, tx.origin);
+        emit SampleRecipientEmitted("Method with no parameters", _msgSender(), msg.sender, tx.origin);
     }
 }

--- a/test/regressions/PayableWithEmit.sol
+++ b/test/regressions/PayableWithEmit.sol
@@ -2,8 +2,8 @@ pragma solidity ^0.5.16;
 import "../../contracts/BaseRelayRecipient.sol";
 import "@0x/contracts-utils/contracts/src/LibBytes.sol";
 
-//make sure that "payable" function that uses getSender() still works
-// (its not required to use getSender(), since the default function
+//make sure that "payable" function that uses _msgSender() still works
+// (its not required to use _msgSender(), since the default function
 // will never be called through GSN, but still, if someone uses it,
 // it should work)
 contract PayableWithEmit is BaseRelayRecipient {
@@ -12,7 +12,7 @@ contract PayableWithEmit is BaseRelayRecipient {
 
   function () external payable {
 
-    emit Received(getSender(), msg.value, gasleft());
+    emit Received(_msgSender(), msg.value, gasleft());
   }
 
 

--- a/test/regressions/PayableWithEmit.test.ts
+++ b/test/regressions/PayableWithEmit.test.ts
@@ -9,7 +9,7 @@ contract('PayableWithEmit', () => {
     receiver = await PayableWithEmit.new()
     sender = await PayableWithEmit.new()
   })
-  it('payable that uses getSender', async () => {
+  it('payable that uses _msgSender()', async () => {
     const ret = await sender.doSend(receiver.address, { value: 1e18 })
     // console.log({ gasUsed: ret.receipt.gasUsed, log: getLogs(ret) })
     assert.equal(ret.logs.find((e: any) => e.event === 'GasUsed').args.success, true)


### PR DESCRIPTION
This will reduce changes to OpenZeppelin - based subclasses. Note that some changes are still required, bacause:
- sender is  no longer depends on relayHub, but on trustedForwarder
- payments works differently (by separate paymaster, not by each recipient)
