### PR TITLE
Paymaster is payable

### DIFF
--- a/contracts/BasePaymaster.sol
+++ b/contracts/BasePaymaster.sol
@@ -55,6 +55,13 @@ contract BasePaymaster is IPaymaster, Ownable, BaseGsnAware {
         return relayHub.balanceOf(address(this));
     }
 
+    // any money moved into the paymaster is transferred as a deposit.
+    // This way, we don't need to understand the RelayHub API in order to replenish
+    // the paymaster.
+    function() external payable {
+        relayHub.depositFor.value(msg.value)(address(this));
+    }
+
     /// withdraw deposit from relayHub
     function withdrawRelayHubDepositTo(uint amount, address payable target) public onlyOwner {
         relayHub.withdraw(amount, target);

--- a/test/SampleRecipient.test.js
+++ b/test/SampleRecipient.test.js
@@ -37,10 +37,15 @@ contract('SampleRecipient', function (accounts) {
     const rhub = await RelayHub.new(Environments.defaultEnvironment.gtxdatanonzero, stakeManager.address,
       penalizer.address)
     await paymaster.setHub(rhub.address)
-    await rhub.depositFor(paymaster.address, {
+
+    // transfer eth into paymaster (using the normal "transfer" helper, which internally
+    // uses hub.depositFor)
+    await web3.eth.sendTransaction({
       from: accounts[0],
+      to: paymaster.address,
       value: deposit
     })
+
     let depositActual = await rhub.balanceOf(paymaster.address)
     assert.equal(deposit.toString(), depositActual.toString())
     const a0BalanceBefore = await web3.eth.getBalance(accounts[0])


### PR DESCRIPTION
add default payable function to paymaster.
This makes it much easier to replenish it: simply by transfering eth,
without the caller knowing that `RelayHub.depositFor(paymaster)` is
required

(RelayHub has a protection to prevent a deposit of more than 2 eth, which is applied to this transfer too)

NOTES:
Behaviour should be documented since:
- Checking the ***balance*** of the paymaster will always show "zero", even
after eth is transfered into it.
- By default, a paymaster has no way to withdraw its own deposit: You
must inherit it, and add a method that uses the `relayhub.withdraw` (which only the paymaster
itself can call)