### PR TITLE
startGsn cleanup

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "lint:fix": "yarn run lint:js:fix",
     "lint:js": "eslint --ext .js,.ts --cache -f unix --ignore-path .gitignore src test scripts",
     "lint:sol": "solhint -f unix \"contracts/**/*.sol\" --max-warnings 0",
-    "lint:js:fix": "eslint --ext .js,.ts --cache  -f unix --ignore-path .gitignore src test scripts helpers --fix",
+    "lint:js:fix": "eslint --ext .js,.ts --cache  -f unix --ignore-path .gitignore src test scripts --fix",
     "web": "./restart-relay.sh web",
     "trace": "MODE=trace truffle test",
     "coverage": "yarn generate && ./scripts/run-coverage",

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "tsc": "tsc --noEmit",
     "postinstall": "patch-package",
     "coverage-if-changed": "./scripts/run-coverage-if-changed.sh npm run coverage",
+    "postpack": "./scripts/postpack",
     "prepare": "./scripts/prepublish"
   },
   "dependencies": {

--- a/scripts/postpack
+++ b/scripts/postpack
@@ -1,0 +1,8 @@
+#!/bin/bash -e
+
+#these files were created for packing only (see "prepack")
+for c in RelayProvider RelayClient GSNConfigurator GsnTestEnvironment; do
+  echo del ./$c.ts:
+  rm $c.ts
+done
+

--- a/scripts/prepublish
+++ b/scripts/prepublish
@@ -15,7 +15,8 @@ for c in $CONTRACTS; do
 done
 
 
-for c in RelayProvider RelayClient GSNConfigurator; do
+#these files are created for packing only (removed by "postpack")
+for c in RelayProvider RelayClient GSNConfigurator GsnTestEnvironment; do
   echo gen ./$c.ts:
   (echo "// generated during pack";echo "export * from './src/relayclient/$c'") > $c.ts
 done

--- a/src/cli/commands/gsn-deploy.ts
+++ b/src/cli/commands/gsn-deploy.ts
@@ -1,7 +1,7 @@
 import commander from 'commander'
 import CommandsLogic from '../CommandsLogic'
 import { configureGSN } from '../../relayclient/GSNConfigurator'
-import { getNetworkUrl, gsnCommander } from '../utils'
+import { getNetworkUrl, gsnCommander, saveDeployment, showDeployment } from '../utils'
 
 // TODO: support deploying custom paymasters by passing bytecode, ABI and constructor params
 gsnCommander(['n', 'f'])
@@ -18,20 +18,8 @@ gsnCommander(['n', 'f'])
   const deploymentResult = await logic.deployGsnContracts(from)
   const paymasterName = 'Default'
 
-  console.log(
-    `Deployed GSN to network: ${network}
-  RelayHub: ${deploymentResult.relayHubAddress}
-  StakeManager: ${deploymentResult.stakeManagerAddress}
-  Penalizer: ${deploymentResult.penalizerAddress}
-  TrustedForwarder: ${deploymentResult.forwarderAddress}
-  Paymaster (${paymasterName}): ${deploymentResult.paymasterAddress}
-  `)
-
-  logic.saveContractToFile(deploymentResult.stakeManagerAddress, commander.workdir, 'StakeManager.json')
-  logic.saveContractToFile(deploymentResult.penalizerAddress, commander.workdir, 'Penalizer.json')
-  logic.saveContractToFile(deploymentResult.relayHubAddress, commander.workdir, 'RelayHub.json')
-  logic.saveContractToFile(deploymentResult.paymasterAddress, commander.workdir, 'Paymaster.json')
-  logic.saveContractToFile(deploymentResult.forwarderAddress, commander.workdir, 'Forwarder.json')
+  showDeployment(deploymentResult, `Deployed GSN to network: ${network}`, paymasterName)
+  saveDeployment(deploymentResult, commander.workdir)
 })().catch(
   reason => {
     console.error(reason)

--- a/src/cli/commands/gsn-start.ts
+++ b/src/cli/commands/gsn-start.ts
@@ -1,0 +1,25 @@
+import commander from 'commander'
+import { gsnCommander, saveDeployment, showDeployment } from '../utils'
+import GsnTestEnvironment from '../../relayclient/GsnTestEnvironment'
+
+gsnCommander(['n'])
+  .option('-w, --workdir <directory>', 'relative work directory (defaults to build/gsn/)', 'build/gsn')
+  .parse(process.argv);
+
+(async () => {
+  try {
+    const network: string = commander.network
+    const env = await GsnTestEnvironment.startGsn(network)
+    saveDeployment(env.deploymentResult, commander.workdir)
+    showDeployment(env.deploymentResult, 'GSN started')
+
+    console.log(`Relay is active, URL = ${env.relayUrl} . Press Ctrl-C to abort`)
+  } catch (e) {
+    console.error(e)
+  }
+})().catch(
+  reason => {
+    console.error(reason)
+    process.exit(1)
+  }
+)

--- a/src/cli/commands/gsn.ts
+++ b/src/cli/commands/gsn.ts
@@ -3,7 +3,8 @@
 import commander from 'commander'
 
 commander
-  .version('0.0.1')
+  .version('0.0.2')
+  .command('start', 'all-on-one: deploy all contracts, start relay')
   .command('deploy', 'deploy RelayHub and other GSN contracts instances')
   .command('relayer-register', 'stake for a relayer and fund it')
   .command('relayer-run', 'launch a relayer server')

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -11,8 +11,12 @@ export const networks = new Map<string, string>([
   ['mainnet', 'https://mainnet.infura.io/v3/c3422181d0594697a38defe7706a1e5b']
 ])
 
-export function getNetworkUrl (network: string): string {
-  const match = network.match(/^(https?:.*)?/) ?? []
+export function supportedNetworks (): string[] {
+  return Array.from(networks.keys())
+}
+
+export function getNetworkUrl(network = ''): string {
+  const match = network.match(/^(https?:\/\/.*)/) ?? []
   return networks.get(network) ?? match[0]
 }
 

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -1,6 +1,9 @@
 // TODO: allow reading network URLs from 'truffle-config.js'
 import commander, { CommanderStatic } from 'commander'
 import fs from 'fs'
+import { Address } from '../relayclient/types/Aliases'
+import path from 'path'
+import { DeploymentResult } from './CommandsLogic'
 
 export const networks = new Map<string, string>([
   ['localhost', 'http://127.0.0.1:8545'],
@@ -36,6 +39,46 @@ function getAddressFromFile (path: string, input?: string): string | undefined {
     }
   }
   return input
+}
+
+function saveContractToFile (address: Address, workdir: string, filename: string): void {
+  fs.mkdirSync(workdir, { recursive: true })
+  fs.writeFileSync(path.join(workdir, filename), `{ "address": "${address}" }`)
+}
+
+export function saveDeployment (deploymentResult: DeploymentResult, workdir: string): void {
+  saveContractToFile(deploymentResult.stakeManagerAddress, workdir, 'StakeManager.json')
+  saveContractToFile(deploymentResult.penalizerAddress, workdir, 'Penalizer.json')
+  saveContractToFile(deploymentResult.relayHubAddress, workdir, 'RelayHub.json')
+  saveContractToFile(deploymentResult.paymasterAddress, workdir, 'Paymaster.json')
+  saveContractToFile(deploymentResult.forwarderAddress, workdir, 'Forwarder.json')
+}
+
+export function showDeployment (deploymentResult: DeploymentResult, title: string | undefined, paymasterTitle: string| undefined = undefined): void {
+  if (title != null) {
+    console.log(title)
+  }
+  console.log(`
+  RelayHub: ${deploymentResult.relayHubAddress}
+  StakeManager: ${deploymentResult.stakeManagerAddress}
+  Penalizer: ${deploymentResult.penalizerAddress}
+  TrustedForwarder: ${deploymentResult.forwarderAddress}
+  Paymaster ${paymasterTitle != null ? '(' + paymasterTitle + ')' : ''}: ${deploymentResult.paymasterAddress}`)
+}
+
+export function loadDeployment (workdir: string): DeploymentResult {
+  function getAddress (name: string): string {
+    const address = getAddressFromFile(path.join(workdir, name + '.json'))
+    if (address != null) { return address }
+    throw new Error('no address for ' + name)
+  }
+  return {
+    relayHubAddress: getAddress('RelayHub'),
+    stakeManagerAddress: getAddress('StakeManager'),
+    penalizerAddress: getAddress('Penalizer.json'),
+    forwarderAddress: getAddress('Forwarder.json'),
+    paymasterAddress: getAddress('Paymaster.json')
+  }
 }
 
 type GsnOption = 'n' | 'f' | 'h'

--- a/src/cli/utils.ts
+++ b/src/cli/utils.ts
@@ -15,7 +15,7 @@ export function supportedNetworks (): string[] {
   return Array.from(networks.keys())
 }
 
-export function getNetworkUrl(network = ''): string {
+export function getNetworkUrl (network = ''): string {
   const match = network.match(/^(https?:\/\/.*)/) ?? []
   return networks.get(network) ?? match[0]
 }

--- a/src/relayclient/GsnTestEnvironment.ts
+++ b/src/relayclient/GsnTestEnvironment.ts
@@ -5,7 +5,7 @@ import CommandsLogic, { DeploymentResult } from '../cli/CommandsLogic'
 import KeyManager from '../relayserver/KeyManager'
 
 import { configureGSN } from './GSNConfigurator'
-import {getNetworkUrl, networks, supportedNetworks} from '../cli/utils'
+import { getNetworkUrl, supportedNetworks } from '../cli/utils'
 import { TxStoreManager } from '../relayserver/TxStoreManager'
 import RelayServer from '../relayserver/RelayServer'
 import HttpServer from '../relayserver/HttpServer'
@@ -32,7 +32,7 @@ class GsnTestEnvironmentClass {
   async startGsn (host?: string, paymaster?: any): Promise<TestEnvironment> {
     await this.stopGsn()
     const _host: string = getNetworkUrl(host)
-    console.log( '_host=', _host)
+    console.log('_host=', _host)
     if (_host == null) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
       throw new Error(`startGsn: expected network (${supportedNetworks().join('|')}) or url`)

--- a/src/relayclient/GsnTestEnvironment.ts
+++ b/src/relayclient/GsnTestEnvironment.ts
@@ -5,7 +5,7 @@ import CommandsLogic, { DeploymentResult } from '../cli/CommandsLogic'
 import KeyManager from '../relayserver/KeyManager'
 
 import { configureGSN } from './GSNConfigurator'
-import { getNetworkUrl } from '../cli/utils'
+import {getNetworkUrl, networks, supportedNetworks} from '../cli/utils'
 import { TxStoreManager } from '../relayserver/TxStoreManager'
 import RelayServer from '../relayserver/RelayServer'
 import HttpServer from '../relayserver/HttpServer'
@@ -29,11 +29,13 @@ class GsnTestEnvironmentClass {
    * @param paymaster TODO: will allow using custom paymaster (need to provide ABI file contents)
    * @return
    */
-  async startGsn (host: string, paymaster?: any): Promise<TestEnvironment> {
+  async startGsn (host?: string, paymaster?: any): Promise<TestEnvironment> {
     await this.stopGsn()
     const _host: string = getNetworkUrl(host)
+    console.log( '_host=', _host)
     if (_host == null) {
-      throw new Error(`Failed to connect to ${host}`)
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      throw new Error(`startGsn: expected network (${supportedNetworks().join('|')}) or url`)
     }
     const commandsLogic = new CommandsLogic(_host, configureGSN({}))
     const from = await commandsLogic.findWealthyAccount()
@@ -44,7 +46,7 @@ class GsnTestEnvironmentClass {
     const balance = await commandsLogic.fundPaymaster(from, deploymentResult.paymasterAddress, ether('1'))
     console.log('Sample Paymaster successfully funded, balance:', Web3.utils.fromWei(balance))
 
-    await this._runServer(host, deploymentResult, from)
+    await this._runServer(_host, deploymentResult, from)
     if (this.httpServer == null) {
       throw new Error('Failed to run a local Relay Server')
     }
@@ -70,6 +72,7 @@ class GsnTestEnvironmentClass {
     })
 
     const relayProvider = new RelayProvider(new Web3.providers.HttpProvider(_host), config)
+    console.error('== startGSN: ready.')
     return {
       deploymentResult,
       relayProvider,

--- a/src/relayserver/RelayServer.js
+++ b/src/relayserver/RelayServer.js
@@ -288,9 +288,16 @@ class RelayServer extends EventEmitter {
         console.error('web3 subscription:', error)
       }
     }).on('data', this._workerSemaphore.bind(this)).on('error', (e) => { console.error('worker:', e) })
-    const handler = () => { this.web3.eth.getBlockNumber().then(blockNumber => this._workerSemaphore.bind(this)({ number: blockNumber })) }
+    const handler = () => {
+      this.web3.eth.getBlockNumber()
+        .then(blockNumber => {
+          if (blockNumber !== this.lastScannedBlock) {
+            this._workerSemaphore.bind(this)({ number: blockNumber })
+          }
+        })
+    }
     if (this.devMode) {
-      this.workerInterval = setInterval(handler, 8000)
+      this.workerInterval = setInterval(handler, 1000)
     }
     setTimeout(handler, 1)
   }


### PR DESCRIPTION
1.  export GsnTestEnvironment. can be used as
    ```javascript
    env = require( '@opengsn/gsn/dist/GsnTestEnvironment').default
    env.startGsn('local')
    ```
2. now report an error on null, unknown network or non-url