### PR TITLE
Use the latest version of the docker image

### DIFF
--- a/jsrelay/.env
+++ b/jsrelay/.env
@@ -11,4 +11,4 @@ BASE_FEE=
 PERCENT_FEE=
 
 #docker image tag
-JSRELAY=0.9.1
+JSRELAY=latest


### PR DESCRIPTION
Currently the version is 0.9.1 which does not exist (see https://hub.docker.com/r/opengsn/jsrelay/tags). I think it will be easier to use `latest` here than to keep this file in sync with the Docker hub.