### PR TITLE
Fix prepack-postpack-generate

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "bin": {
     "gsn": "dist/src/cli/commands/gsn.js"
   },
-  "prepublish": "npm run prepare",
   "scripts": {
     "test": "yarn run lint && yarn generate && yarn tsc && npm run test-js",
     "ganache": "ganache-cli --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --keepAliveTimeout 2147483647",
@@ -45,8 +44,8 @@
     "generate": "rm -rf ./build/contracts && npx truffle compile && typechain --target trufflehotfix './build/contracts/**/*.json' && yarn run extract_abi",
     "tsc": "tsc --noEmit",
     "postinstall": "patch-package",
-    "postpack": "./scripts/postpack",
-    "prepare": "./scripts/prepublish"
+    "prepack": "./scripts/prepack",
+    "postpack": "./scripts/postpack"
   },
   "dependencies": {
     "@openeth/truffle-typings": "0.0.6",

--- a/scripts/prepack
+++ b/scripts/prepack
@@ -1,8 +1,6 @@
 #!/bin/bash -e
 
 rm -rf ./dist/
-yarn truffle-compile
-yarn extract_abi
 yarn generate
 
 mkdir -p src/cli/compiled/
@@ -23,5 +21,7 @@ for c in RelayProvider RelayClient GSNConfigurator GsnTestEnvironment; do
 done
 
 tsc
+#we have in our package.json: "bin": { "gsn": "dist/src/cli/commands/gsn.js" }
+chmod a+rx dist/src/cli/commands/gsn.js
 
 cp -r types dist/


### PR DESCRIPTION
the `prepublish` scripts runs also after each "yarn install", which is excessive.
instead, we use now `prepack`/`postpack`, which run only on "pack" and "publish", as expected.
also: `generate` is now a script that now does all preparation (compiles contracts, extract ABIs and cli-required contracts, generate types)