### PR TITLE
Forwarder supports "value"

### DIFF
--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -43,10 +43,10 @@ contract RelayHub is IRelayHub {
     */
 
     // Gas cost of all relayCall() instructions after actual 'calculateCharge()'
-    uint256 constant private GAS_OVERHEAD = 35214;
+    uint256 constant private GAS_OVERHEAD = 35215;
 
     //gas overhead to calculate gasUseWithoutPost
-    uint256 constant private POST_OVERHEAD = 8518;
+    uint256 constant private POST_OVERHEAD = 8644;
 
     function getHubOverhead() external override view returns (uint256) {
         return GAS_OVERHEAD;

--- a/contracts/forwarder/IForwarder.sol
+++ b/contracts/forwarder/IForwarder.sol
@@ -7,6 +7,7 @@ interface IForwarder {
     struct ForwardRequest {
         address to;
         bytes data;
+        uint256 value;
         address from;
         uint256 nonce;
         uint256 gas;
@@ -49,7 +50,7 @@ interface IForwarder {
         bytes calldata suffixData,
         bytes calldata signature
     )
-    external
+    external payable
     returns (bool success, bytes memory ret);
 
     /**

--- a/contracts/forwarder/test/TestEip712Forwarder.sol
+++ b/contracts/forwarder/test/TestEip712Forwarder.sol
@@ -7,8 +7,8 @@ import "../Eip712Forwarder.sol";
 // helper class for testing the forwarder.
 contract TestEip712Forwarder {
     function callExecute(Eip712Forwarder forwarder, Eip712Forwarder.ForwardRequest memory req,
-        bytes32 domainSeparator, bytes32 requestTypeHash, bytes memory suffixData, bytes memory sig) public {
-        (bool success, bytes memory error) = forwarder.execute(req, domainSeparator, requestTypeHash, suffixData, sig);
+        bytes32 domainSeparator, bytes32 requestTypeHash, bytes memory suffixData, bytes memory sig) public payable {
+        (bool success, bytes memory error) = forwarder.execute{value:msg.value}(req, domainSeparator, requestTypeHash, suffixData, sig);
         emit Result(success, success ? "" : this.decodeErrorMessage(error));
     }
 

--- a/contracts/forwarder/test/TestForwarderTarget.sol
+++ b/contracts/forwarder/test/TestForwarderTarget.sol
@@ -22,6 +22,10 @@ contract TestForwarderTarget is BaseRelayRecipient {
         emit TestForwarderMessage(message, _msgSender(), msg.sender, tx.origin);
     }
 
+    function mustReceiveEth(uint value) public payable {
+        require( msg.value == value, "didn't receive value");
+    }
+
     event Reverting(string message);
 
     function testRevert() public {

--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -39,14 +39,14 @@ contract TestRecipient is BaseRelayRecipient, IKnowForwarderAddress {
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
 
-    event SampleRecipientEmitted(string message, address realSender, address msgSender, address origin);
+    event SampleRecipientEmitted(string message, address realSender, address msgSender, address origin, uint256 value);
 
-    function emitMessage(string memory message) public {
+    function emitMessage(string memory message) public payable {
         if (paymaster != address(0)) {
             withdrawAllBalance();
         }
 
-        emit SampleRecipientEmitted(message, _msgSender(), msg.sender, tx.origin);
+        emit SampleRecipientEmitted(message, _msgSender(), msg.sender, tx.origin, address(this).balance);
     }
 
     function withdrawAllBalance() public {
@@ -57,6 +57,6 @@ contract TestRecipient is BaseRelayRecipient, IKnowForwarderAddress {
     function dontEmitMessage(string memory message) public {}
 
     function emitMessageNoParams() public {
-        emit SampleRecipientEmitted("Method with no parameters", _msgSender(), msg.sender, tx.origin);
+        emit SampleRecipientEmitted("Method with no parameters", _msgSender(), msg.sender, tx.origin, address(this).balance);
     }
 }

--- a/contracts/utils/GsnEip712Library.sol
+++ b/contracts/utils/GsnEip712Library.sol
@@ -12,7 +12,7 @@ import "../forwarder/Eip712Forwarder.sol";
 library GsnEip712Library {
 
     //copied from Eip712Forwarder (can't reference string constants even from another library)
-    string public constant GENERIC_PARAMS = "address to,bytes data,address from,uint256 nonce,uint256 gas";
+    string public constant GENERIC_PARAMS = "address to,bytes data,uint256 value,address from,uint256 nonce,uint256 gas";
 
     bytes public constant RELAYDATA_TYPE = "RelayData(uint256 gasPrice,uint256 pctRelayFee,uint256 baseRelayFee,address relayWorker,address paymaster)";
 
@@ -49,6 +49,7 @@ library GsnEip712Library {
         forwardRequest = IForwarder.ForwardRequest(
             req.request.to,
             req.request.data,
+            req.request.value,
             req.request.from,
             req.request.nonce,
             req.request.gas
@@ -71,7 +72,7 @@ library GsnEip712Library {
     function verifySignature(GsnTypes.RelayRequest calldata relayRequest, bytes calldata signature) internal view {
         (Eip712Forwarder.ForwardRequest memory forwardRequest, bytes memory suffixData) = splitRequest(relayRequest);
         bytes32 domainSeparator = domainSeparator(relayRequest.relayData.forwarder);
-        Eip712Forwarder forwarder = Eip712Forwarder(relayRequest.relayData.forwarder);
+        Eip712Forwarder forwarder = Eip712Forwarder(payable(relayRequest.relayData.forwarder));
         forwarder.verify(forwardRequest, domainSeparator, RELAY_REQUEST_TYPEHASH, suffixData, signature);
     }
 

--- a/src/common/EIP712/ForwardRequest.ts
+++ b/src/common/EIP712/ForwardRequest.ts
@@ -2,9 +2,10 @@ import { Address, IntString } from '../../relayclient/types/Aliases'
 import { PrefixedHexString } from 'ethereumjs-tx'
 
 export default interface ForwardRequest {
+  from: Address
   to: Address
   data: PrefixedHexString
-  from: Address
+  value: IntString
   nonce: IntString
   gas: IntString
 }

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -21,12 +21,12 @@ const RelayDataType = [
 ]
 
 const ForwardRequestType = [
-  { name: 'from', type: 'address' },
   { name: 'to', type: 'address' },
   { name: 'data', type: 'bytes' },
   { name: 'value', type: 'uint256' },
-  { name: 'gas', type: 'uint256' },
-  { name: 'nonce', type: 'uint256' }
+  { name: 'from', type: 'address' },
+  { name: 'nonce', type: 'uint256' },
+  { name: 'gas', type: 'uint256' }
 ]
 
 const RelayRequestType = [

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -21,11 +21,12 @@ const RelayDataType = [
 ]
 
 const ForwardRequestType = [
+  { name: 'from', type: 'address' },
   { name: 'to', type: 'address' },
   { name: 'data', type: 'bytes' },
-  { name: 'from', type: 'address' },
-  { name: 'nonce', type: 'uint256' },
-  { name: 'gas', type: 'uint256' }
+  { name: 'value', type: 'uint256' },
+  { name: 'gas', type: 'uint256' },
+  { name: 'nonce', type: 'uint256' }
 ]
 
 const RelayRequestType = [

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -217,6 +217,7 @@ export default class RelayClient {
         to: gsnTransactionDetails.to,
         data: gsnTransactionDetails.data,
         from: gsnTransactionDetails.from,
+        value: '0',
         nonce: senderNonce,
         gas: gasLimit
       },

--- a/src/relayclient/RelayedTransactionValidator.ts
+++ b/src/relayclient/RelayedTransactionValidator.ts
@@ -39,7 +39,8 @@ export default class RelayedTransactionValidator {
         data: transactionJsonRequest.data,
         gas: transactionJsonRequest.gasLimit,
         from: transactionJsonRequest.from,
-        nonce: transactionJsonRequest.senderNonce
+        nonce: transactionJsonRequest.senderNonce,
+        value: '0'
       },
       relayData: {
         gasPrice: transactionJsonRequest.gasPrice,

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -254,7 +254,8 @@ export class RelayServer extends EventEmitter {
         data: req.data,
         from: req.from,
         nonce: req.senderNonce,
-        gas: req.gasLimit
+        gas: req.gasLimit,
+        value: '0'
       },
       relayData: {
         baseRelayFee: req.baseRelayFee,

--- a/test/Eip712Forwarder.test.ts
+++ b/test/Eip712Forwarder.test.ts
@@ -375,7 +375,7 @@ contract('Eip712Forwarder', ([from]) => {
         assert.equal(ret.logs[0].args.success, false)
       })
 
-      it.skip('should fail to forward request if value specified but not enough not provided', async () => {
+      it('should fail to forward request if value specified but not enough not provided', async () => {
         const value = ether('1')
         const func = recipient.contract.methods.mustReceiveEth(value.toString()).encodeABI()
 
@@ -416,6 +416,9 @@ contract('Eip712Forwarder', ([from]) => {
       })
 
       it('should forward all funds left in forwarder to "from" address', async () => {
+        const senderPrivateKey = toBuffer(bytes32(2))
+        const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
+
         const value = ether('1')
         const func = recipient.contract.methods.mustReceiveEth(value.toString()).encodeABI()
 

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -181,6 +181,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
           data: '',
           from: senderAddress,
           nonce: senderNonce,
+          value: '0',
           gas: gasLimit
         },
         relayData: {

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -35,9 +35,9 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
 
   const senderNonce = new BN('0')
   const magicNumbers = {
-    arc: 907,
-    pre: 1486,
-    post: 1613
+    arc: 907+21,
+    pre: 1486+66,
+    post: 1613-22
   }
 
   let relayHub: RelayHubInstance
@@ -85,6 +85,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
         data: encodedFunction,
         from: senderAddress,
         nonce: senderNonce.toString(),
+        value: '0',
         gas: gasLimit.toString()
       },
       relayData: {
@@ -95,6 +96,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
         forwarder,
         paymaster: paymaster.address
       }
+
     }
     const dataToSign = new TypedRequestData(
       chainId,
@@ -273,6 +275,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
                   data: encodedFunction,
                   from: senderAddress,
                   nonce: senderNonce,
+                  value: '0',
                   gas: gasLimit.toString()
                 },
                 relayData: {

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -86,6 +86,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
         data: txData,
         from: sender,
         nonce: '0',
+        value: '0',
         gas: gasLimit.toString()
       },
       relayData: {
@@ -328,6 +329,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
               data: txData,
               from: sender,
               nonce: senderNonce.toString(),
+              value: '0',
               gas: gasLimit.toString()
             },
             relayData: {
@@ -429,6 +431,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
             data: encodedCallArgs.data,
             from: encodedCallArgs.sender,
             nonce: encodedCallArgs.nonce.toString(),
+            value: '0',
             gas: encodedCallArgs.gasLimit.toString()
           },
           relayData: {

--- a/test/TestBatchForwarder.test.ts
+++ b/test/TestBatchForwarder.test.ts
@@ -64,6 +64,7 @@ contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
         data: '',
         from,
         nonce: '1',
+        value: '0',
         gas: 1e6.toString()
       },
       relayData: {

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -60,6 +60,7 @@ contract('Utils', function (accounts) {
           data: encodedFunction,
           from: senderAddress,
           nonce: senderNonce,
+          value: '0',
           gas: gasLimit
         },
         relayData: {
@@ -101,6 +102,7 @@ contract('Utils', function (accounts) {
     })
 
     it('should use same domainSeparator on-chain and off-chain', async () => {
+
       assert.equal(getDomainSeparatorHash(forwarder, chainId), await testUtil.libDomainSeparator(forwarder))
     })
 

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -49,10 +49,12 @@ contract('Utils', function (accounts) {
       const paymaster = accounts[7]
       const relayWorker = accounts[9]
 
-      await forwarderInstance.registerRequestType(
+      const res = await forwarderInstance.registerRequestType(
         GsnRequestType.typeName,
         GsnRequestType.typeSuffix
       )
+
+      const typeName = res.logs[0].args.typeStr
 
       relayRequest = {
         request: {
@@ -72,6 +74,12 @@ contract('Utils', function (accounts) {
           paymaster
         }
       }
+      const dataToSign = new TypedRequestData(
+        chainId,
+        forwarder,
+        relayRequest
+      )
+      assert.equal(typeName, TypedDataUtils.encodeType(dataToSign.primaryType, dataToSign.types))
     })
 
     it('#_getEncoded should extract data exactly as local encoded data', async () => {

--- a/test/relayclient/AccountManager.test.ts
+++ b/test/relayclient/AccountManager.test.ts
@@ -67,6 +67,7 @@ contract('AccountManager', function (accounts) {
         data: '0x123',
         from: '',
         nonce: '1',
+        value: '0',
         gas: '1'
       },
       relayData: {

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -118,7 +118,7 @@ contract('RelayClient', function (accounts) {
       const res = await web3.eth.getTransactionReceipt(txHash)
 
       // validate we've got the "SampleRecipientEmitted" event
-      const topic: string = web3.utils.sha3('SampleRecipientEmitted(string,address,address,address)') ?? ''
+      const topic: string = web3.utils.sha3('SampleRecipientEmitted(string,address,address,address,uint256)') ?? ''
       assert(res.logs.find(log => log.topics.includes(topic)))
 
       const destination: string = validTransaction.to.toString('hex')

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -46,6 +46,7 @@ export async function prepareTransaction (testRecipient: TestRecipientInstance, 
       data: testRecipient.contract.methods.emitMessage('hello world').encodeABI(),
       from: account,
       nonce: senderNonce,
+      value: '0',
       gas: '10000'
     },
     relayData: {


### PR DESCRIPTION
forwarder now has a "value" parameter, which is the amount of ether to
send with the transaction.
The {{execute()}} function is now payable, to be able to receive
this value.
Note that it is possible to pass the value into the forwarder in a call
just before execute (still, under the same transaction)

The {{execute}} would fail the request if it is given a value
parameter, but doesn't have enough value to fulfill it.