### PR TITLE
Remove @openzeppelin/test-helpers from relayclient code

### DIFF
--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -8,11 +8,11 @@ import AccountManager from './AccountManager'
 import RelayedTransactionValidator from './RelayedTransactionValidator'
 import HttpWrapper from './HttpWrapper'
 import { EmptyDataCallback, GasPricePingFilter } from './RelayClient'
-import { constants } from '@openzeppelin/test-helpers'
 
 const GAS_PRICE_PERCENT = 20
 const MAX_RELAY_NONCE_GAP = 3
 const DEFAULT_RELAY_TIMEOUT_GRACE_SEC = 1800
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 const defaultGsnConfig: GSNConfig = {
   preferredRelays: [],
@@ -25,10 +25,10 @@ const defaultGsnConfig: GSNConfig = {
   methodSuffix: '',
   jsonStringifyRequest: false,
   chainId: defaultEnvironment.chainId,
-  relayHubAddress: constants.ZERO_ADDRESS,
-  stakeManagerAddress: constants.ZERO_ADDRESS,
-  paymasterAddress: constants.ZERO_ADDRESS,
-  forwarderAddress: constants.ZERO_ADDRESS,
+  relayHubAddress: ZERO_ADDRESS,
+  stakeManagerAddress: ZERO_ADDRESS,
+  paymasterAddress: ZERO_ADDRESS,
+  forwarderAddress: ZERO_ADDRESS,
   verbose: false,
   clientId: '1'
 }

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -1,6 +1,5 @@
 import { PrefixedHexString, Transaction } from 'ethereumjs-tx'
 import { HttpProvider, TransactionReceipt } from 'web3-core'
-import { constants } from '@openzeppelin/test-helpers'
 
 import RelayRequest from '../common/EIP712/RelayRequest'
 import TmpRelayTransactionJsonRequest from './types/TmpRelayTransactionJsonRequest'
@@ -14,6 +13,8 @@ import AccountManager from './AccountManager'
 import RelayedTransactionValidator from './RelayedTransactionValidator'
 import { configureGSN, getDependencies, GSNConfig, GSNDependencies } from './GSNConfigurator'
 import { RelayInfo } from './types/RelayInfo'
+
+const ZERO_ADDRESS = '0x0000000000000000000000000000000000000000'
 
 // generate "approvalData" and "paymasterData" for a request.
 // both are bytes arrays. paymasterData is part of the client request.
@@ -282,7 +283,7 @@ export default class RelayClient {
 
   async resolveForwarder (gsnTransactionDetails: GsnTransactionDetails): Promise<Address> {
     let forwarderAddress = gsnTransactionDetails.forwarder ?? this.config.forwarderAddress
-    if (forwarderAddress !== constants.ZERO_ADDRESS) {
+    if (forwarderAddress !== ZERO_ADDRESS) {
       const isRecipientDeployed = await this.contractInteractor.isContractDeployed(gsnTransactionDetails.to)
       if (!isRecipientDeployed) {
         console.warn(`No IRelayRecipient code at ${gsnTransactionDetails.to}, proceeding without validating 'isTrustedForwarder'!


### PR DESCRIPTION
The @openzeppelin/test-helpers package is not optimized for client-side projects and has many dependencies. The inclusion of this package causes a number of build issues in webpack.

Furthermore, this package is only used for the ZERO_ADDRESS constant. So I've removed this dependency and hardcoded the constant.