### PR TITLE
OG-14 GsnTestEnvironment is not exported properly for TypeScript depe…

### DIFF
--- a/src/cli/commands/gsn-start.ts
+++ b/src/cli/commands/gsn-start.ts
@@ -1,6 +1,6 @@
 import commander from 'commander'
 import { gsnCommander, saveDeployment, showDeployment } from '../utils'
-import GsnTestEnvironment from '../../relayclient/GsnTestEnvironment'
+import { GsnTestEnvironment } from '../../relayclient/GsnTestEnvironment'
 
 gsnCommander(['n'])
   .option('-w, --workdir <directory>', 'relative work directory (defaults to build/gsn/)', 'build/gsn')

--- a/src/relayclient/GsnTestEnvironment.ts
+++ b/src/relayclient/GsnTestEnvironment.ts
@@ -28,6 +28,7 @@ class GsnTestEnvironmentClass {
    *
    * @param host:
    * @param deployPaymaster - whether to deploy the naive paymaster instance for tests
+   * @param debug
    * @return
    */
   async startGsn (host?: string, deployPaymaster: boolean = true, debug = false): Promise<TestEnvironment> {
@@ -161,5 +162,4 @@ class GsnTestEnvironmentClass {
   }
 }
 
-const GsnTestEnvironment = new GsnTestEnvironmentClass()
-export default GsnTestEnvironment
+export const GsnTestEnvironment = new GsnTestEnvironmentClass()

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -42,7 +42,7 @@ export interface RelayingResult {
   relayingErrors: Map<string, Error>
 }
 
-export default class RelayClient {
+export class RelayClient {
   readonly config: GSNConfig
   private readonly httpClient: HttpClient
   protected contractInteractor: ContractInteractor

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -4,7 +4,7 @@ import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
 import { HttpProvider } from 'web3-core'
 
 import relayHubAbi from '../common/interfaces/IRelayHub.json'
-import RelayClient, { RelayingResult } from './RelayClient'
+import { RelayClient, RelayingResult } from './RelayClient'
 import GsnTransactionDetails from './types/GsnTransactionDetails'
 import { configureGSN, GSNConfig, GSNDependencies } from './GSNConfigurator'
 import { Transaction } from 'ethereumjs-tx'

--- a/test/GsnTestEnvironment.test.ts
+++ b/test/GsnTestEnvironment.test.ts
@@ -1,6 +1,6 @@
-import GsnTestEnvironment, { TestEnvironment } from '../src/relayclient/GsnTestEnvironment'
+import { GsnTestEnvironment, TestEnvironment } from '../src/relayclient/GsnTestEnvironment'
 import { HttpProvider } from 'web3-core'
-import RelayClient from '../src/relayclient/RelayClient'
+import { RelayClient } from '../src/relayclient/RelayClient'
 import { expectEvent } from '@openzeppelin/test-helpers'
 import { TestRecipientInstance } from '../types/truffle-contracts'
 

--- a/test/RelayServer.test.ts
+++ b/test/RelayServer.test.ts
@@ -1,6 +1,6 @@
 /* global artifacts describe */
 import Web3 from 'web3'
-import RelayClient from '../src/relayclient/RelayClient'
+import { RelayClient } from '../src/relayclient/RelayClient'
 import { CreateTransactionDetails, RelayServer, RelayServerParams } from '../src/relayserver/RelayServer'
 import { TxStoreManager } from '../src/relayserver/TxStoreManager'
 import { KeyManager } from '../src/relayserver/KeyManager'

--- a/test/dummies/BadRelayClient.ts
+++ b/test/dummies/BadRelayClient.ts
@@ -1,4 +1,4 @@
-import RelayClient, { RelayingResult } from '../../src/relayclient/RelayClient'
+import { RelayClient, RelayingResult } from '../../src/relayclient/RelayClient'
 import GsnTransactionDetails from '../../src/relayclient/types/GsnTransactionDetails'
 import { GSNConfig } from '../../src/relayclient/GSNConfigurator'
 import { HttpProvider } from 'web3-core'

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -14,7 +14,7 @@ import {
 } from '../../types/truffle-contracts'
 
 import RelayRequest from '../../src/common/EIP712/RelayRequest'
-import RelayClient from '../../src/relayclient/RelayClient'
+import { RelayClient } from '../../src/relayclient/RelayClient'
 import { Address } from '../../src/relayclient/types/Aliases'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { configureGSN, getDependencies, GSNConfig } from '../../src/relayclient/GSNConfigurator'


### PR DESCRIPTION
…ndency

TypeScript/ES6 is missing support for wildcard export of default import.
This means we cannot use default export for the top-level components.