### PR TITLE
OG-124 Make all RelayHub constants constructor parameters

### DIFF
--- a/contracts/BasePaymaster.sol
+++ b/contracts/BasePaymaster.sol
@@ -22,8 +22,6 @@ abstract contract BasePaymaster is IPaymaster, Ownable {
     IRelayHub internal relayHub;
     IForwarder internal trustedForwarder;
 
-    bytes32 public domainSeparator;
-
     function getHubAddr() public override view returns (address) {
         return address(relayHub);
     }
@@ -75,7 +73,6 @@ abstract contract BasePaymaster is IPaymaster, Ownable {
 
     function setTrustedForwarder(IForwarder forwarder) public onlyOwner {
         trustedForwarder = forwarder;
-        domainSeparator = GsnEip712Library.domainSeparator(address(forwarder));
     }
 
     /// check current deposit on relay hub.

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -16,14 +16,6 @@ abstract contract BaseRelayRecipient is IRelayRecipient {
      */
     address internal trustedForwarder;
 
-    /*
-     * require a function to be called through GSN only
-     */
-    modifier trustedForwarderOnly() {
-        require(msg.sender == address(trustedForwarder), "Function can only be called through the trusted Forwarder");
-        _;
-    }
-
     function isTrustedForwarder(address forwarder) public override view returns(bool) {
         return forwarder == trustedForwarder;
     }

--- a/contracts/BatchForwarder.sol
+++ b/contracts/BatchForwarder.sol
@@ -8,7 +8,7 @@ import "./utils/GsnUtils.sol";
 
 /**
  * batch forwarder support calling a method sendBatch in the forwarder itself.
- * NOTE: the "target" of the request should be the BatcherForwarder itself
+ * NOTE: the "target" of the request should be the BatchForwarder itself
  */
 contract BatchForwarder is Forwarder, BaseRelayRecipient {
 

--- a/contracts/interfaces/GsnTypes.sol
+++ b/contracts/interfaces/GsnTypes.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier:MIT
 pragma solidity ^0.6.2;
 
-import "../forwarder/Forwarder.sol";
+import "../forwarder/IForwarder.sol";
 
 interface GsnTypes {
     struct RelayData {

--- a/contracts/utils/GsnUtils.sol
+++ b/contracts/utils/GsnUtils.sol
@@ -5,15 +5,6 @@ pragma solidity ^0.6.2;
 import "../0x/LibBytesV06.sol";
 
 library GsnUtils {
-
-    function getChainID() internal pure returns (uint256) {
-        uint256 id;
-        assembly {
-            id := chainid()
-        }
-        return id;
-    }
-
     /**
      * extract error string from revert bytes
      */
@@ -40,29 +31,5 @@ library GsnUtils {
      */
     function getParam(bytes memory msgData, uint index) internal pure returns (uint) {
         return LibBytesV06.readUint256(msgData, 4 + index * 32);
-    }
-
-    function getAddressParam(bytes memory msgData, uint index) internal pure returns (address) {
-        return address(getParam(msgData, index));
-    }
-
-    function getBytes32Param(bytes memory msgData, uint index) internal pure returns (bytes32) {
-        return bytes32(getParam(msgData, index));
-    }
-
-    /**
-     * extract dynamic-sized (string/bytes) parameter.
-     * we assume that there ARE dynamic parameters, hence getBytesParam(0) is the offset to the first
-     * dynamic param
-     * https://solidity.readthedocs.io/en/develop/abi-spec.html#use-of-dynamic-types
-     */
-    function getBytesParam(bytes memory msgData, uint index) internal pure returns (bytes memory ret) {
-        uint ofs = getParam(msgData, index) + 4;
-        uint len = LibBytesV06.readUint256(msgData, ofs);
-        ret = LibBytesV06.slice(msgData, ofs + 32, ofs + 32 + len);
-    }
-
-    function getStringParam(bytes memory msgData, uint index) internal pure returns (string memory) {
-        return string(getBytesParam(msgData, index));
     }
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -1,13 +1,13 @@
-var RelayHub = artifacts.require('./RelayHub.sol')
-var StakeManager = artifacts.require('./StakeManager.sol')
-var Penalizer = artifacts.require('./Penalizer.sol')
-var SampleRecipient = artifacts.require('./test/TestRecipient.sol')
-var Forwarder = artifacts.require('Forwarder')
+const RelayHub = artifacts.require('RelayHub')
+const StakeManager = artifacts.require('StakeManager')
+const Penalizer = artifacts.require('Penalizer')
+const SampleRecipient = artifacts.require('TestRecipient')
+const Forwarder = artifacts.require('Forwarder')
 
 module.exports = async function (deployer) {
   await deployer.deploy(StakeManager)
   await deployer.deploy(Penalizer)
-  await deployer.deploy(RelayHub, StakeManager.address, Penalizer.address)
+  await deployer.deploy(RelayHub, StakeManager.address, Penalizer.address, 0, 0, 0, 0, 0, 0, 0, 0)
   await deployer.deploy(Forwarder)
   await deployer.deploy(SampleRecipient, Forwarder.address)
 }

--- a/src/cli/StatusLogic.ts
+++ b/src/cli/StatusLogic.ts
@@ -38,7 +38,7 @@ export default class StatusLogic {
     const fromBlock = Math.max(1, curBlockNumber - this.config.blockHistoryCount)
 
     const r = await this.contractInteractor._createRelayHub(this.config.relayHubAddress)
-    const stakeManager = await r.getStakeManager()
+    const stakeManager = await r.stakeManager()
     const totalStakesByRelays = await this.contractInteractor.getBalance(stakeManager)
 
     const relayRegisteredEventsData =

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -1,0 +1,9 @@
+import BN from 'bn.js'
+
+export const constants = {
+  ZERO_ADDRESS: '0x0000000000000000000000000000000000000000',
+  ZERO_BYTES32: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  MAX_UINT256: new BN('2').pow(new BN('256')).sub(new BN('1')),
+  MAX_INT256: new BN('2').pow(new BN('255')).sub(new BN('1')),
+  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1')),
+}

--- a/src/common/Constants.ts
+++ b/src/common/Constants.ts
@@ -5,5 +5,5 @@ export const constants = {
   ZERO_BYTES32: '0x0000000000000000000000000000000000000000000000000000000000000000',
   MAX_UINT256: new BN('2').pow(new BN('256')).sub(new BN('1')),
   MAX_INT256: new BN('2').pow(new BN('255')).sub(new BN('1')),
-  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1')),
+  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1'))
 }

--- a/src/common/Environments.ts
+++ b/src/common/Environments.ts
@@ -25,4 +25,15 @@ export const environments = {
   })
 }
 
+export const relayHubConfiguration = {
+  GAS_OVERHEAD: 34936 + 12,
+  POST_OVERHEAD: 9959 + 825,
+  GAS_RESERVE: 100000,
+  MAX_WORKER_COUNT: 10,
+  MINIMUM_STAKE: 1e18.toString(),
+  MINIMUM_UNSTAKE_DELAY: 1000,
+  MINIMUM_RELAY_BALANCE: 1e17.toString(),
+  MAXIMUM_RECIPIENT_DEPOSIT: 2e18.toString()
+}
+
 export const defaultEnvironment = environments.istanbul

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -136,14 +136,6 @@ export function ether (n: string): BN {
   return new BN(toWei(n, 'ether'))
 }
 
-export const constants = {
-  ZERO_ADDRESS: '0x0000000000000000000000000000000000000000',
-  ZERO_BYTES32: '0x0000000000000000000000000000000000000000000000000000000000000000',
-  MAX_UINT256: new BN('2').pow(new BN('256')).sub(new BN('1')),
-  MAX_INT256: new BN('2').pow(new BN('255')).sub(new BN('1')),
-  MIN_INT256: new BN('2').pow(new BN('255')).mul(new BN('-1'))
-}
-
 /**
  * @param gasLimits
  * @param hubOverhead

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -11,7 +11,7 @@ import stakeManagerAbi from '../common/interfaces/IStakeManager.json'
 import gsnRecipientAbi from '../common/interfaces/IRelayRecipient.json'
 import knowForwarderAddressAbi from '../common/interfaces/IKnowForwarderAddress.json'
 
-import { constants, event2topic } from '../common/Utils'
+import { event2topic } from '../common/Utils'
 import replaceErrors from '../common/ErrorReplacerJSON'
 import VersionsManager from '../common/VersionsManager'
 import {
@@ -33,6 +33,7 @@ import Common from 'ethereumjs-common'
 // Truffle Contract typings seem to be completely out of their minds
 import TruffleContract = require('@truffle/contract')
 import Contract = Truffle.Contract
+import { constants } from '../common/Constants'
 
 type EventName = string
 

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -12,6 +12,7 @@ import gsnRecipientAbi from '../common/interfaces/IRelayRecipient.json'
 import knowForwarderAddressAbi from '../common/interfaces/IKnowForwarderAddress.json'
 
 import { event2topic } from '../common/Utils'
+import { constants } from '../common/Constants'
 import replaceErrors from '../common/ErrorReplacerJSON'
 import VersionsManager from '../common/VersionsManager'
 import {
@@ -33,7 +34,6 @@ import Common from 'ethereumjs-common'
 // Truffle Contract typings seem to be completely out of their minds
 import TruffleContract = require('@truffle/contract')
 import Contract = Truffle.Contract
-import { constants } from '../common/Constants'
 
 type EventName = string
 

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -1,6 +1,6 @@
 import { HttpProvider } from 'web3-core'
 import { Address, AsyncDataCallback, AsyncScoreCalculator, IntString, PingFilter, RelayFilter } from './types/Aliases'
-import { defaultEnvironment } from './types/Environments'
+import { defaultEnvironment } from '../common/Environments'
 import HttpClient from './HttpClient'
 import ContractInteractor from './ContractInteractor'
 import KnownRelaysManager, { DefaultRelayScore, EmptyFilter, IKnownRelaysManager } from './KnownRelaysManager'
@@ -8,7 +8,7 @@ import AccountManager from './AccountManager'
 import RelayedTransactionValidator from './RelayedTransactionValidator'
 import HttpWrapper from './HttpWrapper'
 import { EmptyDataCallback, GasPricePingFilter } from './RelayClient'
-import { constants } from '../common/Utils'
+import { constants } from '../common/Constants'
 
 const GAS_PRICE_PERCENT = 20
 const MAX_RELAY_NONCE_GAP = 3

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -1,6 +1,6 @@
 import { PrefixedHexString, Transaction } from 'ethereumjs-tx'
 import { HttpProvider, TransactionReceipt } from 'web3-core'
-import { constants } from '../common/Utils'
+import { constants } from '../common/Constants'
 
 import RelayRequest from '../common/EIP712/RelayRequest'
 import TmpRelayTransactionJsonRequest from './types/TmpRelayTransactionJsonRequest'

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -21,7 +21,7 @@ import { IPaymasterInstance, IRelayHubInstance, IStakeManagerInstance } from '..
 import { BlockHeader } from 'web3-eth'
 import { TransactionReceipt } from 'web3-core'
 import { toBN, toHex } from 'web3-utils'
-import { defaultEnvironment } from '../relayclient/types/Environments'
+import { defaultEnvironment } from '../common/Environments'
 import VersionsManager from '../common/VersionsManager'
 import { calculateTransactionMaxPossibleGas } from '../common/Utils'
 
@@ -275,7 +275,7 @@ export class RelayServer extends EventEmitter {
       throw new Error(`unknown paymaster error: ${e.message}`)
     }
 
-    const hubOverhead = (await this.relayHubContract.getHubOverhead()).toNumber()
+    const hubOverhead = (await this.relayHubContract.gasOverhead()).toNumber()
     // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
     const maxPossibleGas = GAS_RESERVE + calculateTransactionMaxPossibleGas({
       gasLimits,
@@ -407,7 +407,7 @@ export class RelayServer extends EventEmitter {
     if (!this.versionManager.isMinorSameOrNewer(version)) {
       this.fatal(`Not a valid RelayHub at ${relayHubAddress}: version: ${version}`)
     }
-    const stakeManagerAddress = await this.relayHubContract.getStakeManager()
+    const stakeManagerAddress = await this.relayHubContract.stakeManager()
     this.stakeManagerContract = await this.contractInteractor._createStakeManager(stakeManagerAddress)
     const stakeManagerTopics = [Object.keys(this.stakeManagerContract.contract.events).filter(x => (x.includes('0x')))]
     this.topics = stakeManagerTopics.concat([['0x' + '0'.repeat(24) + this.managerAddress.slice(2)]])
@@ -420,8 +420,7 @@ export class RelayServer extends EventEmitter {
     }
     this.rawTxOptions = this.contractInteractor.getRawTxOptions()
 
-    // todo: fix typo AND fix metacoin
-    debug('intialized', this.chainId, this.networkId, this.rawTxOptions)
+    debug('initialized', this.chainId, this.networkId, this.rawTxOptions)
     this.initialized = true
   }
 

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -16,6 +16,7 @@ import { ChildProcessWithoutNullStreams } from 'child_process'
 import { GSNConfig } from '../src/relayclient/GSNConfigurator'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import { relayHubConfiguration } from '../src/common/Environments'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
@@ -56,7 +57,18 @@ options.forEach(params => {
 
       sm = await StakeManager.new()
       const p = await Penalizer.new()
-      rhub = await RelayHub.new(sm.address, p.address, { gas: 10000000 })
+      rhub = await RelayHub.new(
+        sm.address,
+        p.address,
+        relayHubConfiguration.MAX_WORKER_COUNT,
+        relayHubConfiguration.GAS_RESERVE,
+        relayHubConfiguration.POST_OVERHEAD,
+        relayHubConfiguration.GAS_OVERHEAD,
+        relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+        relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+        relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+        relayHubConfiguration.MINIMUM_STAKE,
+        { gas: 10000000 })
       if (params.relay) {
         relayproc = await startRelay(rhub.address, sm, {
           stake: 1e18,

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai'
 
 import { getEip712Signature } from '../src/common/Utils'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
-import { defaultEnvironment } from '../src/relayclient/types/Environments'
+import { defaultEnvironment, relayHubConfiguration } from '../src/common/Environments'
 import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
 
 import {
@@ -51,7 +51,18 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
   beforeEach(async function () {
     stakeManager = await StakeManager.new()
     penalizer = await Penalizer.new()
-    relayHubInstance = await RelayHub.new(stakeManager.address, penalizer.address, { gas: 10000000 })
+    relayHubInstance = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE,
+      { gas: 10000000 })
     paymasterContract = await TestPaymasterEverythingAccepted.new()
     forwarderInstance = await Forwarder.new()
     forwarder = forwarderInstance.address

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -11,7 +11,7 @@ import { expect } from 'chai'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
 import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
-import { defaultEnvironment } from '../src/relayclient/types/Environments'
+import { defaultEnvironment, relayHubConfiguration } from '../src/common/Environments'
 import {
   PenalizerInstance,
   RelayHubInstance, StakeManagerInstance,
@@ -44,7 +44,18 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
   before(async function () {
     stakeManager = await StakeManager.new()
     penalizer = await Penalizer.new()
-    relayHub = await RelayHub.new(stakeManager.address, penalizer.address, { gas: 10000000 })
+    relayHub = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE,
+      { gas: 10000000 })
     const forwarderInstance = await Forwarder.new()
     forwarder = forwarderInstance.address
     recipient = await TestRecipient.new(forwarder)

--- a/test/RelayHubRegistrationsManagement.test.ts
+++ b/test/RelayHubRegistrationsManagement.test.ts
@@ -7,6 +7,7 @@ import {
   StakeManagerInstance,
   TestPaymasterEverythingAcceptedInstance
 } from '../types/truffle-contracts'
+import { relayHubConfiguration } from '../src/common/Environments'
 
 const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
@@ -26,7 +27,18 @@ contract('RelayHub Relay Management', function ([_, relayOwner, relayManager, re
   beforeEach(async function () {
     stakeManager = await StakeManager.new()
     penalizer = await Penalizer.new()
-    relayHub = await RelayHub.new(stakeManager.address, penalizer.address, { gas: 10000000 })
+    relayHub = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE,
+      { gas: 10000000 })
     paymaster = await TestPaymasterEverythingAccepted.new()
     await paymaster.setRelayHub(relayHub.address)
   })

--- a/test/RelayServer.test.ts
+++ b/test/RelayServer.test.ts
@@ -8,7 +8,7 @@ import { KeyManager } from '../src/relayserver/KeyManager'
 import RelayHubABI from '../src/common/interfaces/IRelayHub.json'
 import StakeManagerABI from '../src/common/interfaces/IStakeManager.json'
 import PayMasterABI from '../src/common/interfaces/IPaymaster.json'
-import { defaultEnvironment } from '../src/relayclient/types/Environments'
+import { defaultEnvironment, relayHubConfiguration } from '../src/common/Environments'
 import * as ethUtils from 'ethereumjs-util'
 import { PrefixedHexString, Transaction } from 'ethereumjs-tx'
 // @ts-ignore
@@ -40,19 +40,21 @@ import Mutex from 'async-mutex/lib/Mutex'
 import { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
 import ContractInteractor from '../src/relayclient/ContractInteractor'
 
-const RelayHub = artifacts.require('./RelayHub.sol')
-const TestRecipient = artifacts.require('./test/TestRecipient.sol')
+const RelayHub = artifacts.require('RelayHub')
+const TestRecipient = artifacts.require('TestRecipient')
 const Forwarder = artifacts.require('Forwarder')
-const StakeManager = artifacts.require('./StakeManager.sol')
-const Penalizer = artifacts.require('./Penalizer.sol')
-const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted.sol')
+const StakeManager = artifacts.require('StakeManager')
+const Penalizer = artifacts.require('Penalizer')
+const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 
 const { expect } = require('chai').use(chaiAsPromised).use(sinonChai)
 
 abiDecoder.addABI(RelayHubABI)
 abiDecoder.addABI(StakeManagerABI)
 abiDecoder.addABI(PayMasterABI)
+// @ts-ignore
 abiDecoder.addABI(TestRecipient.abi)
+// @ts-ignore
 abiDecoder.addABI(TestPaymasterEverythingAccepted.abi)
 
 const localhostOne = 'http://localhost:8090'
@@ -143,7 +145,17 @@ contract('RelayServer', function (accounts) {
 
     stakeManager = await StakeManager.new()
     penalizer = await Penalizer.new()
-    rhub = await RelayHub.new(stakeManager.address, penalizer.address)
+    rhub = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE)
     forwarder = await Forwarder.new()
     const forwarderAddress = forwarder.address
     sr = await TestRecipient.new(forwarderAddress)

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -6,11 +6,13 @@ import {
 import BN from 'bn.js'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import { relayHubConfiguration } from '../src/common/Environments'
+
 const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
 const TestRecipient = artifacts.require('TestRecipient')
-const TestPaymasterEverythingAccepted = artifacts.require('./test/TestPaymasterEverythingAccepted.sol')
+const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const Forwarder = artifacts.require('Forwarder')
 
 contract('SampleRecipient', function (accounts) {
@@ -44,7 +46,17 @@ contract('SampleRecipient', function (accounts) {
     const deposit = new BN('100000000000000000')
     const stakeManager = await StakeManager.new()
     const penalizer = await Penalizer.new()
-    const rhub = await RelayHub.new(stakeManager.address, penalizer.address)
+    const rhub = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE)
     await paymaster.setRelayHub(rhub.address)
     await forwarderInstance.registerRequestType(
       GsnRequestType.typeName,

--- a/test/TestBatchForwarder.test.ts
+++ b/test/TestBatchForwarder.test.ts
@@ -6,7 +6,7 @@ import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequ
 
 import { getEip712Signature } from '../src/common/Utils'
 
-import { defaultEnvironment } from '../src/relayclient/types/Environments'
+import { defaultEnvironment, relayHubConfiguration } from '../src/common/Environments'
 import {
   RelayHubInstance,
   TestPaymasterEverythingAcceptedInstance,
@@ -15,11 +15,11 @@ import {
 } from '../types/truffle-contracts'
 
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted.sol')
-const RelayHub = artifacts.require('RelayHub.sol')
+const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
-const BatchForwarder = artifacts.require('./BatchForwarder.sol')
-const TestRecipient = artifacts.require('TestRecipient.sol')
+const BatchForwarder = artifacts.require('BatchForwarder')
+const TestRecipient = artifacts.require('TestRecipient')
 
 contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
   let paymaster: TestPaymasterEverythingAcceptedInstance
@@ -34,7 +34,18 @@ contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
 
     const stakeManager = await StakeManager.new()
     const penalizer = await Penalizer.new()
-    hub = await RelayHub.new(stakeManager.address, penalizer.address, { gas: 10000000 })
+    hub = await RelayHub.new(
+      stakeManager.address,
+      penalizer.address,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE,
+      { gas: 10000000 })
     const relayHub = hub
     await stakeManager.stakeForAddress(relayManager, 2000, {
       value: ether('2'),

--- a/test/relayclient/AccountManager.test.ts
+++ b/test/relayclient/AccountManager.test.ts
@@ -1,5 +1,5 @@
 import AccountManager from '../../src/relayclient/AccountManager'
-import { defaultEnvironment } from '../../src/relayclient/types/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 import { HttpProvider } from 'web3-core'
 import RelayRequest from '../../src/common/EIP712/RelayRequest'
 import { constants } from '@openzeppelin/test-helpers'

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -16,6 +16,7 @@ import sinon from 'sinon'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { RelayRegisteredEventInfo } from '../../src/relayclient/types/RelayRegisteredEventInfo'
 import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import { relayHubConfiguration } from '../../src/common/Environments'
 
 const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
@@ -67,7 +68,17 @@ contract('KnownRelaysManager', function (
       workerRelayServerRegistered = await web3.eth.personal.newAccount('password')
       workerNotActive = await web3.eth.personal.newAccount('password')
       stakeManager = await StakeManager.new()
-      relayHub = await RelayHub.new(stakeManager.address, constants.ZERO_ADDRESS)
+      relayHub = await RelayHub.new(
+        stakeManager.address,
+        constants.ZERO_ADDRESS,
+        relayHubConfiguration.MAX_WORKER_COUNT,
+        relayHubConfiguration.GAS_RESERVE,
+        relayHubConfiguration.POST_OVERHEAD,
+        relayHubConfiguration.GAS_OVERHEAD,
+        relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+        relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+        relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+        relayHubConfiguration.MINIMUM_STAKE)
       config = configureGSN({
         relayHubAddress: relayHub.address,
         relayLookupWindowBlocks
@@ -163,7 +174,17 @@ contract('KnownRelaysManager 2', function (accounts) {
 
     before(async function () {
       stakeManager = await StakeManager.new()
-      relayHub = await RelayHub.new(stakeManager.address, constants.ZERO_ADDRESS)
+      relayHub = await RelayHub.new(
+        stakeManager.address,
+        constants.ZERO_ADDRESS,
+        relayHubConfiguration.MAX_WORKER_COUNT,
+        relayHubConfiguration.GAS_RESERVE,
+        relayHubConfiguration.POST_OVERHEAD,
+        relayHubConfiguration.GAS_OVERHEAD,
+        relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+        relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+        relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+        relayHubConfiguration.MINIMUM_STAKE)
       config = configureGSN({
         preferredRelays: ['http://localhost:8090'],
         relayHubAddress: relayHub.address,

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -29,6 +29,7 @@ import { constants } from '@openzeppelin/test-helpers'
 import { RelayInfo } from '../../src/relayclient/types/RelayInfo'
 import PingResponse from '../../src/common/PingResponse'
 import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import { relayHubConfiguration } from '../../src/common/Environments'
 
 const RelayHub = artifacts.require('RelayHub')
 const StakeManager = artifacts.require('StakeManager')
@@ -62,7 +63,17 @@ contract('RelayClient', function (accounts) {
   before(async function () {
     web3 = new Web3(underlyingProvider)
     stakeManager = await StakeManager.new()
-    relayHub = await RelayHub.new(stakeManager.address, constants.ZERO_ADDRESS)
+    relayHub = await RelayHub.new(
+      stakeManager.address,
+      constants.ZERO_ADDRESS,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE)
     const forwarderInstance = await Forwarder.new()
     forwarderAddress = forwarderInstance.address
     testRecipient = await TestRecipient.new(forwarderAddress)
@@ -280,7 +291,10 @@ contract('RelayClient', function (accounts) {
 
       it('should use provided approval function', async function () {
         const relayClient =
-          new RelayClient(underlyingProvider, gsnConfig, { asyncApprovalData, asyncPaymasterData })
+          new RelayClient(underlyingProvider, gsnConfig, {
+            asyncApprovalData,
+            asyncPaymasterData
+          })
         const { httpRequest } = await relayClient._prepareRelayHttpRequest(relayInfo, optionsWithGas)
         assert.equal(httpRequest.approvalData, '0x1234567890')
         assert.equal(httpRequest.paymasterData, '0xabcd')

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -17,7 +17,7 @@ import {
   TestRecipientInstance
 } from '../../types/truffle-contracts'
 import { Address } from '../../src/relayclient/types/Aliases'
-import { defaultEnvironment } from '../../src/relayclient/types/Environments'
+import { defaultEnvironment, relayHubConfiguration } from '../../src/common/Environments'
 import { startRelay, stopRelay } from '../TestUtils'
 import BadRelayClient from '../dummies/BadRelayClient'
 
@@ -94,7 +94,17 @@ contract('RelayProvider', function (accounts) {
     web3 = new Web3(underlyingProvider)
     gasLess = await web3.eth.personal.newAccount('password')
     stakeManager = await StakeManager.new()
-    relayHub = await RelayHub.new(stakeManager.address, constants.ZERO_ADDRESS)
+    relayHub = await RelayHub.new(
+      stakeManager.address,
+      constants.ZERO_ADDRESS,
+      relayHubConfiguration.MAX_WORKER_COUNT,
+      relayHubConfiguration.GAS_RESERVE,
+      relayHubConfiguration.POST_OVERHEAD,
+      relayHubConfiguration.GAS_OVERHEAD,
+      relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+      relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+      relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+      relayHubConfiguration.MINIMUM_STAKE)
     const forwarderInstance = await Forwarder.new()
     forwarderAddress = forwarderInstance.address
     await forwarderInstance.registerRequestType(

--- a/test/relayclient/RelaySelectionManager.test.ts
+++ b/test/relayclient/RelaySelectionManager.test.ts
@@ -10,6 +10,7 @@ import { PartialRelayInfo } from '../../src/relayclient/types/RelayInfo'
 import { constants } from '@openzeppelin/test-helpers'
 import { register, stake } from './KnownRelaysManager.test'
 import PingResponse from '../../src/common/PingResponse'
+import { relayHubConfiguration } from '../../src/common/Environments'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
 
@@ -96,7 +97,17 @@ contract('RelaySelectionManager', function (accounts) {
         const RelayHub = artifacts.require('RelayHub')
         const StakeManager = artifacts.require('StakeManager')
         const stakeManager = await StakeManager.new()
-        relayHub = await RelayHub.new(stakeManager.address, constants.ZERO_ADDRESS)
+        relayHub = await RelayHub.new(
+          stakeManager.address,
+          constants.ZERO_ADDRESS,
+          relayHubConfiguration.MAX_WORKER_COUNT,
+          relayHubConfiguration.GAS_RESERVE,
+          relayHubConfiguration.POST_OVERHEAD,
+          relayHubConfiguration.GAS_OVERHEAD,
+          relayHubConfiguration.MAXIMUM_RECIPIENT_DEPOSIT,
+          relayHubConfiguration.MINIMUM_RELAY_BALANCE,
+          relayHubConfiguration.MINIMUM_UNSTAKE_DELAY,
+          relayHubConfiguration.MINIMUM_STAKE)
         await stake(stakeManager, relayHub, relayManager, accounts[0])
         await register(relayHub, relayManager, accounts[2], preferredRelayUrl, '666', '777')
 


### PR DESCRIPTION
It makes sense that these will be different across different chains.
Will be problematic if we will need code change in order to change them.

Extra changes:
- remove 'domainSeparator' from base paymaster storage
- remove 'trustedForwarderOnly' modifier from base recipient
- remove unused code from GsnUtils
- finally fix typo ('intialized' instead of 'initialized')