### PR TITLE
OG-129: Patch truffle to simplify Etherscan Verify Source

### DIFF
--- a/patches/truffle+5.1.26.patch
+++ b/patches/truffle+5.1.26.patch
@@ -1,0 +1,12 @@
+diff --git a/node_modules/truffle/build/cli.bundled.js b/node_modules/truffle/build/cli.bundled.js
+index 5991472..eab1676 100755
+--- a/node_modules/truffle/build/cli.bundled.js
++++ b/node_modules/truffle/build/cli.bundled.js
+@@ -199453,6 +199453,7 @@ async function invokeCompiler({ compilerInput, options }) {
+ 
+   // perform compilation
+   const inputString = JSON.stringify(compilerInput);
++  require('fs').writeFileSync('json-input.json', JSON.stringify(compilerInput))
+   const outputString = solc.compile(inputString);
+   const compilerOutput = JSON.parse(outputString);
+ 


### PR DESCRIPTION
truffle to save "json-input.json" file used for compilation.
This file simplifies etherscan verify.
