### PR TITLE
Fix external gas limit bug

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-alpha.3-patch.1",
+  "version": "2.0.0-alpha.3-patch.2",
   "description": "Open Gas Stations Network",
   "name": "@opengsn/gsn",
   "license": "MIT",

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -185,14 +185,18 @@ export default class ContractInteractor {
     return nonce.toString()
   }
 
+  async _getBlockGasLimit (): Promise<number> {
+    const latestBlock = await this.web3.eth.getBlock('latest')
+    return latestBlock.gasLimit
+  }
+
   async validateAcceptRelayCall (
     relayRequest: RelayRequest,
     signature: PrefixedHexString,
     approvalData: PrefixedHexString): Promise<{ paymasterAccepted: boolean, returnValue: string, reverted: boolean }> {
     const relayHub = await this._createRelayHub(this.config.relayHubAddress)
     try {
-      // not really needed in client view call. only need to be large enough.
-      const externalGasLimit = 10e6
+      const externalGasLimit = await this._getBlockGasLimit()
 
       const res = await relayHub.contract.methods.relayCall(
         relayRequest,


### PR DESCRIPTION
We had a hard-coded 10 million gas as a limit for the view-only call.
The issue arises when using a library on a network with block gas limit
lower then that.