### PR TITLE
OG-122 Protect client fetching too many transactions in the "lookup window"

### DIFF
--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -13,12 +13,13 @@ import { constants } from '../common/Constants'
 const GAS_PRICE_PERCENT = 20
 const MAX_RELAY_NONCE_GAP = 3
 const DEFAULT_RELAY_TIMEOUT_GRACE_SEC = 1800
+const BLOCKS_PER_MONTH = 30 * 24 * 60 * 6 // 259200, assuming 10 seconds block time
 
 const defaultGsnConfig: GSNConfig = {
   preferredRelays: [],
-  relayLookupWindowBlocks: 6000,
+  relayLookupWindowSliceSize: BLOCKS_PER_MONTH,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
-  lookupWindowsMaxCount: 3,
+  lookupWindowSliceCount: 1,
   minGasPrice: 0,
   maxRelayNonceGap: MAX_RELAY_NONCE_GAP,
   sliceSize: 3,
@@ -73,8 +74,8 @@ export async function resolveConfigurationGSN (provider: provider, partialConfig
  */
 export interface GSNConfig {
   preferredRelays: string[]
-  relayLookupWindowBlocks: number
-  lookupWindowsMaxCount: number
+  relayLookupWindowSliceSize: number
+  lookupWindowSliceCount: number
   methodSuffix: string
   jsonStringifyRequest: boolean
   relayTimeoutGrace: number

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -18,6 +18,7 @@ const defaultGsnConfig: GSNConfig = {
   preferredRelays: [],
   relayLookupWindowBlocks: 6000,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
+  lookupWindowsMaxCount: 3,
   minGasPrice: 0,
   maxRelayNonceGap: MAX_RELAY_NONCE_GAP,
   sliceSize: 3,
@@ -73,6 +74,7 @@ export async function resolveConfigurationGSN (provider: provider, partialConfig
 export interface GSNConfig {
   preferredRelays: string[]
   relayLookupWindowBlocks: number
+  lookupWindowsMaxCount: number
   methodSuffix: string
   jsonStringifyRequest: boolean
   relayTimeoutGrace: number

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -138,6 +138,15 @@ contract('KnownRelaysManager', function (
       assert.equal(actual[2], activeTransactionRelayed)
       assert.equal(actual[3], activePaymasterRejected)
     })
+
+    it('should contain relay managers from older blocks if none found in the latest window', async function () {
+      await evmMineMany(relayLookupWindowBlocks * 2)
+      const knownRelaysManager = new KnownRelaysManager(contractInteractor, config)
+      const res = await knownRelaysManager._fetchRecentlyActiveRelayManagers()
+      const actual = Array.from(res.values())
+      assert.equal(actual.length, 1)
+      assert.equal(actual[0], activePaymasterRejected)
+    })
   })
 })
 


### PR DESCRIPTION
The current client logic for finding active relays:
look for all events in the "lookup window" (one month's worth of Transactions), and treat all relays found there as "active".
However, if there are too many transactions in that window, the client request may fail.

The mitigation for that should be to query the window in smaller chunks, so that a provider-imposed limit on # of returned events is not hit.
Note that the fix doesn't change the client's logic on the window size, and "active relay" definition is the same, regardless of network load.