### PR TITLE
trustedForwrader member should be public

### DIFF
--- a/contracts/BasePaymaster.sol
+++ b/contracts/BasePaymaster.sol
@@ -19,7 +19,7 @@ import "./forwarder/Forwarder.sol";
 abstract contract BasePaymaster is IPaymaster, Ownable {
 
     IRelayHub internal relayHub;
-    IForwarder internal trustedForwarder;
+    IForwarder public trustedForwarder;
 
     function getHubAddr() public override view returns (address) {
         return address(relayHub);

--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -14,7 +14,7 @@ abstract contract BaseRelayRecipient is IRelayRecipient {
     /*
      * Forwarder singleton we accept calls from
      */
-    address internal trustedForwarder;
+    address public trustedForwarder;
 
     function isTrustedForwarder(address forwarder) public override view returns(bool) {
         return forwarder == trustedForwarder;


### PR DESCRIPTION
like all other contract member fields.