### PR TITLE
Re-introduce re-registration test

### DIFF
--- a/src/relayserver/TransactionManager.ts
+++ b/src/relayserver/TransactionManager.ts
@@ -6,7 +6,6 @@ import { StoredTx, transactionToStoredTx, TxStoreManager } from './TxStoreManage
 import ContractInteractor from '../relayclient/ContractInteractor'
 import { Mutex } from 'async-mutex'
 import { KeyManager } from './KeyManager'
-import { BlockHeader } from 'web3-eth'
 import { ServerDependencies } from './ServerConfigParams'
 import log from 'loglevel'
 
@@ -148,7 +147,7 @@ export class TransactionManager {
     return nonce
   }
 
-  async resendUnconfirmedTransactionsForSigner (blockHeader: BlockHeader, signer: string): Promise<PrefixedHexString | null> {
+  async resendUnconfirmedTransactionsForSigner (blockNumber: number, signer: string): Promise<PrefixedHexString | null> {
     // Load unconfirmed transactions from store, and bail if there are none
     let sortedTxs = await this.txStoreManager.getAllBySigner(signer)
     if (sortedTxs.length === 0) {
@@ -167,7 +166,7 @@ export class TransactionManager {
         throw new Error(`invalid block number in receipt ${receipt.toString()}`)
       }
       const txBlockNumber = receipt.blockNumber
-      const confirmations = blockHeader.number - txBlockNumber
+      const confirmations = blockNumber - txBlockNumber
       if (confirmations >= confirmationsNeeded) {
         // Clear out all confirmed transactions (ie txs with nonce less than the account nonce at confirmationsNeeded blocks ago)
         log.debug(`removing tx number ${receipt.nonce} sent by ${receipt.from} with ${confirmations} confirmations`)

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -44,6 +44,7 @@ contract('RegistrationManager', function (accounts) {
   let _web3: Web3
   let id: string
   let newRelayParams: NewRelayParams
+  let partialConfig: Partial<GSNConfig>
 
   // TODO: move to the 'before'
   const ethereumNodeUrl = (web3.currentProvider as HttpProvider).host
@@ -54,6 +55,10 @@ contract('RegistrationManager', function (accounts) {
     stakeManager = await StakeManager.new()
     const penalizer = await Penalizer.new()
     rhub = await deployHub(stakeManager.address, penalizer.address)
+    partialConfig = {
+      relayHubAddress: rhub.address,
+      stakeManagerAddress: stakeManager.address
+    }
     newRelayParams = {
       alertedBlockDelay: 0,
       workdir,
@@ -96,9 +101,9 @@ contract('RegistrationManager', function (accounts) {
   // When running server before staking/funding it, or when balance gets too low
   describe('multi-step server initialization', function () {
     it('should wait for balance', async function () {
-      let header = await _web3.eth.getBlock('latest')
+      let latestBlock = await _web3.eth.getBlock('latest')
       await expect(
-        relayServer._worker(header)
+        relayServer._worker(latestBlock.number)
       ).to.be.eventually.rejectedWith('Balance too low - actual:')
       const expectedBalance = _web3.utils.toWei('2', 'ether')
       assert.notEqual((await relayServer.getManagerBalance()).cmp(toBN(expectedBalance)), 0)
@@ -107,18 +112,18 @@ contract('RegistrationManager', function (accounts) {
         from: relayOwner,
         value: expectedBalance
       })
-      header = await _web3.eth.getBlock('latest')
+      latestBlock = await _web3.eth.getBlock('latest')
       await expect(
-        relayServer._worker(header)
+        relayServer._worker(latestBlock.number)
       ).to.be.eventually.rejectedWith('Stake too low - actual:')
       assert.equal(relayServer.ready, false, 'relay should not be ready yet')
       assert.equal((await relayServer.getManagerBalance()).cmp(toBN(expectedBalance)), 0)
     })
 
     it('should wait for stake, register and fund workers', async function () {
-      let header = await _web3.eth.getBlock('latest')
+      let latestBlock = await _web3.eth.getBlock('latest')
       await expect(
-        relayServer._worker(header)
+        relayServer._worker(latestBlock.number)
       ).to.be.eventually.rejectedWith('Stake too low - actual:')
       assert.equal(relayServer.ready, false, 'relay should not be ready yet')
       const res = await stakeManager.stakeForAddress(relayServer.managerAddress, weekInSec, {
@@ -130,11 +135,11 @@ contract('RegistrationManager', function (accounts) {
       assert.ok(res2.receipt.status, 'authorize hub failed')
       const workerBalanceBefore = await relayServer.getWorkerBalance(workerIndex)
       assert.equal(workerBalanceBefore.toString(), '0')
-      header = await _web3.eth.getBlock('latest')
-      const receipts = await relayServer._worker(header)
+      latestBlock = await _web3.eth.getBlock('latest')
+      const receipts = await relayServer._worker(latestBlock.number)
       const workerBalanceAfter = await relayServer.getWorkerBalance(workerIndex)
       assert.equal(relayServer.lastError, null)
-      assert.equal(relayServer.lastScannedBlock, header.number)
+      assert.equal(relayServer.lastScannedBlock, latestBlock.number)
       assert.deepEqual(relayServer.registrationManager.stakeRequired.currentValue, oneEther)
       assert.equal(relayServer.registrationManager.ownerAddress, relayOwner)
       assert.equal(workerBalanceAfter.toString(), relayServer.config.workerTargetBalance.toString())
@@ -169,7 +174,8 @@ contract('RegistrationManager', function (accounts) {
       }
       const newRelayServer = new RelayServer(params, serverDependencies)
       await newRelayServer.init()
-      await newRelayServer._worker(await _web3.eth.getBlock('latest'))
+      const latestBlock = await _web3.eth.getBlock('latest')
+      await newRelayServer._worker(latestBlock.number)
       assert.equal(relayServer.ready, true, 'relay not ready?')
     })
   })
@@ -199,7 +205,8 @@ contract('RegistrationManager', function (accounts) {
       assert.equal(newServer.lastScannedBlock, 0)
       const workerBalanceBefore = await newServer.getWorkerBalance(workerIndex)
       assert.equal(workerBalanceBefore.toString(), '0')
-      const receipts = await newServer._worker(await _web3.eth.getBlock('latest'))
+      const latestBlock = await _web3.eth.getBlock('latest')
+      const receipts = await newServer._worker(latestBlock.number)
       assert.equal(newServer.lastScannedBlock, expectedLastScannedBlock)
       assert.equal(newServer.gasPrice, expectedGasPrice)
       assert.equal(newServer.ready, true, 'relay no ready?')
@@ -216,6 +223,35 @@ contract('RegistrationManager', function (accounts) {
     })
   })
 
+  describe('configuration change', function () {
+    let relayServer: RelayServer
+
+    before(async function () {
+      relayServer = await bringUpNewRelay(newRelayParams, partialConfig)
+    })
+
+    it('should re-register server with new configuration', async function () {
+      const latestBlock = await _web3.eth.getBlock('latest')
+      const receipts = await relayServer._worker(latestBlock.number)
+      assertRelayAdded(receipts, relayServer)
+
+      let pastEventsResult = await relayServer.registrationManager.handlePastEvents(latestBlock.number, false)
+      assert.equal(pastEventsResult.receipts.length, 0, 'should not re-register if already registered')
+
+      relayServer.config.baseRelayFee = (parseInt(relayServer.config.baseRelayFee) + 1).toString()
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents(latestBlock.number, false)
+      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+
+      relayServer.config.pctRelayFee++
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents(latestBlock.number, false)
+      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+
+      relayServer.config.url = 'fakeUrl'
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents(latestBlock.number, false)
+      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+    })
+  })
+
   describe('event handlers', function () {
     describe('Unstaked event', function () {
       async function assertSendBalancesToOwner (
@@ -228,7 +264,8 @@ contract('RegistrationManager', function (accounts) {
         assert.equal(newServer.registrationManager.stakeRequired.currentValue.toString(), oneEther.toString())
         // TODO: assert on withdrawal block?
         // assert.equal(newServer.config.withdrawBlock?.toString(), '0')
-        const receipts = await newServer._worker(await _web3.eth.getBlock('latest'))
+        const latestBlock = await _web3.eth.getBlock('latest')
+        const receipts = await newServer._worker(latestBlock.number)
         const totalTxCosts = getTotalTxCosts(receipts, gasPrice)
         const ownerBalanceAfter = toBN(await _web3.eth.getBalance(newServer.registrationManager.ownerAddress!))
         assert.equal(
@@ -252,12 +289,9 @@ contract('RegistrationManager', function (accounts) {
       let newServer: RelayServer
       beforeEach(async function () {
         id = (await snapshot()).result
-        const partialConfig: Partial<GSNConfig> = {
-          relayHubAddress: rhub.address,
-          stakeManagerAddress: stakeManager.address
-        }
         newServer = await bringUpNewRelay(newRelayParams, partialConfig)
-        await newServer._worker(await _web3.eth.getBlock('latest'))
+        const latestBlock = await _web3.eth.getBlock('latest')
+        await newServer._worker(latestBlock.number)
 
         await rhub.depositFor(newServer.managerAddress, { value: 1e18.toString() })
         await stakeManager.unlockStake(newServer.managerAddress, { from: relayOwner })
@@ -306,7 +340,8 @@ contract('RegistrationManager', function (accounts) {
         await revert(id)
       })
       it('set hubAuthorized', async function () {
-        await newServer._worker(await _web3.eth.getBlock('latest'))
+        const latestBlock = await _web3.eth.getBlock('latest')
+        await newServer._worker(latestBlock.number)
         assert.isTrue(newServer.registrationManager.isHubAuthorized, 'Hub should be authorized in server')
       })
     })
@@ -320,7 +355,8 @@ contract('RegistrationManager', function (accounts) {
           stakeManagerAddress: stakeManager.address
         }
         newServer = await bringUpNewRelay(newRelayParams, partialConfig)
-        await newServer._worker(await _web3.eth.getBlock('latest'))
+        const latestBlck = await _web3.eth.getBlock('latest')
+        await newServer._worker(latestBlck.number)
         await rhub.depositFor(newServer.managerAddress, { value: 1e18.toString() })
       })
       afterEach(async function () {
@@ -337,7 +373,8 @@ contract('RegistrationManager', function (accounts) {
         assert.isTrue(workerBalanceBefore.gtn(0))
         const ownerBalanceBefore = toBN(await _web3.eth.getBalance(relayOwner))
         assert.isTrue(newServer.registrationManager.isHubAuthorized, 'Hub should be authorized in server')
-        const receipts = await newServer._worker(await _web3.eth.getBlock('latest'))
+        const latestBlock = await _web3.eth.getBlock('latest')
+        const receipts = await newServer._worker(latestBlock.number)
         assert.isFalse(newServer.registrationManager.isHubAuthorized, 'Hub should not be authorized in server')
         const gasPrice = await _web3.eth.getGasPrice()
         // TODO: these two hard-coded indexes are dependent on the order of operations in 'withdrawAllFunds'

--- a/test/relayserver/RelayServer.test.ts
+++ b/test/relayserver/RelayServer.test.ts
@@ -690,7 +690,7 @@ contract('RelayServer', function (accounts) {
       await rejectingPaymaster.deposit({ value: _web3.utils.toWei('1', 'ether') })
       await rejectingPaymaster.setGreedyAcceptanceBudget(true)
       newServer = await bringUpNewRelay(newRelayParams, partialConfig, { trustedPaymasters: [rejectingPaymaster.address] })
-      let latestBlock = await _web3.eth.getBlock('latest')
+      const latestBlock = await _web3.eth.getBlock('latest')
       await newServer._worker(latestBlock.number)
       relayTransactionParams2 = {
         ...relayTransactionParams,
@@ -704,7 +704,7 @@ contract('RelayServer', function (accounts) {
     it('should reject a transaction from paymaster returning above configured max exposure', async function () {
       try {
         const scepticServer = await bringUpNewRelay(newRelayParams, partialConfig)
-        let latestBlock = await _web3.eth.getBlock('latest')
+        const latestBlock = await _web3.eth.getBlock('latest')
         await scepticServer._worker(latestBlock.number)
         await relayTransaction({ ...relayTransactionParams2, relayServer: scepticServer }, options,
           { paymaster: rejectingPaymaster.address })

--- a/test/relayserver/RelayServer.test.ts
+++ b/test/relayserver/RelayServer.test.ts
@@ -71,7 +71,6 @@ contract('RelayServer', function (accounts) {
   const paymasterData = '0x'
   const clientId = '0'
 
-  let partialConfig: Partial<GSNConfig>
   let relayTransactionParams: RelayTransactionParams
   let rhub: RelayHubInstance
   let forwarder: ForwarderInstance
@@ -691,7 +690,8 @@ contract('RelayServer', function (accounts) {
       await rejectingPaymaster.deposit({ value: _web3.utils.toWei('1', 'ether') })
       await rejectingPaymaster.setGreedyAcceptanceBudget(true)
       newServer = await bringUpNewRelay(newRelayParams, partialConfig, { trustedPaymasters: [rejectingPaymaster.address] })
-      await newServer._worker(await _web3.eth.getBlock('latest'))
+      let latestBlock = await _web3.eth.getBlock('latest')
+      await newServer._worker(latestBlock.number)
       relayTransactionParams2 = {
         ...relayTransactionParams,
         paymasterAddress: rejectingPaymaster.address,
@@ -704,7 +704,8 @@ contract('RelayServer', function (accounts) {
     it('should reject a transaction from paymaster returning above configured max exposure', async function () {
       try {
         const scepticServer = await bringUpNewRelay(newRelayParams, partialConfig)
-        await scepticServer._worker(await _web3.eth.getBlock('latest'))
+        let latestBlock = await _web3.eth.getBlock('latest')
+        await scepticServer._worker(latestBlock.number)
         await relayTransaction({ ...relayTransactionParams2, relayServer: scepticServer }, options,
           { paymaster: rejectingPaymaster.address })
         assert.fail()

--- a/test/relayserver/TransactionManager.test.ts
+++ b/test/relayserver/TransactionManager.test.ts
@@ -77,7 +77,8 @@ contract('TransactionManager', function (accounts) {
     relayServer = await bringUpNewRelay(newRelayParams, partialConfig)
 
     // initialize server - gas price, stake, owner, etc, whatever
-    await relayServer._worker(await _web3.eth.getBlock('latest'))
+    const latestBlock = await _web3.eth.getBlock('latest')
+    await relayServer._worker(latestBlock.number)
 
     paymaster = await TestPaymasterEverythingAccepted.new({ gas: 1e7 })
 
@@ -205,7 +206,8 @@ contract('TransactionManager', function (accounts) {
       // Should not do anything, as not enough time has passed
       let sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.equal(sortedTxs[0].txId, parsedTxHash)
-      let resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+      let latestBlock = await _web3.eth.getBlock('latest')
+      let resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
       assert.equal(null, resentTx)
       sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.equal(sortedTxs[0].txId, parsedTxHash)
@@ -220,7 +222,8 @@ contract('TransactionManager', function (accounts) {
           return Date.origNow() + pendingTransactionTimeout
         }
         // Resend tx, now should be ok
-        resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+        latestBlock = await _web3.eth.getBlock('latest')
+        resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
         parsedTxHash = ethUtils.bufferToHex((new Transaction(resentTx, relayServer.transactionManager.rawTxOptions)).hash())
 
         // Validate relayed tx with increased gasPrice
@@ -234,13 +237,15 @@ contract('TransactionManager', function (accounts) {
         Date.now = Date.origNow
       }
       // Check the tx is removed from the store only after enough blocks
-      resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+      latestBlock = await _web3.eth.getBlock('latest')
+      resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
       assert.equal(null, resentTx)
       sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.equal(sortedTxs[0].txId, parsedTxHash)
       const confirmationsNeeded = 12
       await evmMineMany(confirmationsNeeded)
-      resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+      latestBlock = await _web3.eth.getBlock('latest')
+      resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
       assert.equal(null, resentTx)
       sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.deepEqual([], sortedTxs)
@@ -292,7 +297,8 @@ contract('TransactionManager', function (accounts) {
         let sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
         // console.log('times:', sortedTxs[0].createdAt, sortedTxs[1].createdAt, sortedTxs[2].createdAt )
         assert.equal(sortedTxs[0].txId, parsedTxHash1)
-        let resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+        let latestBlock = await _web3.eth.getBlock('latest')
+        let resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
         assert.equal(null, resentTx)
         assert.equal(nonceBefore, await _web3.eth.getTransactionCount(relayServer.managerAddress))
         sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
@@ -301,7 +307,8 @@ contract('TransactionManager', function (accounts) {
         // Mine a bunch of blocks, so tx1 is confirmed and tx2 is resent
         const confirmationsNeeded = 12
         await evmMineMany(confirmationsNeeded)
-        const resentTx2 = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+        latestBlock = await _web3.eth.getBlock('latest')
+        const resentTx2 = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
         const parsedTxHash2 = ethUtils.bufferToHex((new Transaction(resentTx2, relayServer.transactionManager.rawTxOptions)).hash())
         await assertTransactionRelayed(relayServer, parsedTxHash2, gasLess, recipientAddress, paymasterAddress, _web3)
         // Re-inject tx3 into the chain as if it were mined once tx2 goes through
@@ -311,7 +318,8 @@ contract('TransactionManager', function (accounts) {
         // Check that tx3 does not get resent, even after time passes or blocks get mined, and that store is empty
         nowIncrease = 60 * 60 * 1000 // 60 minutes in milliseconds
         await evmMineMany(confirmationsNeeded)
-        resentTx = await relayServer._resendUnconfirmedTransactions(await _web3.eth.getBlock('latest'))
+        latestBlock = await _web3.eth.getBlock('latest')
+        resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
         assert.equal(null, resentTx)
         assert.deepEqual([], await relayServer.transactionManager.txStoreManager.getAll())
       } finally {


### PR DESCRIPTION
Also:

1. Replace BlockHeader with BlockNumber as we are not really interested
in the rest of it.

2. Add chack that _worker is not provided with an older block