### PR TITLE
Use block count instead of timestamp as pending state timeout units

### DIFF
--- a/src/relayserver/ServerConfigParams.ts
+++ b/src/relayserver/ServerConfigParams.ts
@@ -40,6 +40,11 @@ export interface ServerConfigParams {
   managerMinStake: string
   managerTargetBalance: number
   minHubWithdrawalBalance: number
+
+  pendingTransactionTimeoutBlocks: number
+  confirmationsNeeded: number
+  retryGasPriceFactor: number
+  maxGasPrice: string
 }
 
 export interface ServerDependencies {
@@ -74,7 +79,12 @@ const serverDefaultConfiguration: ServerConfigParams = {
   gasPricePercent: 0,
   port: 0,
   versionRegistryAddress: constants.ZERO_ADDRESS,
-  workdir: ''
+  workdir: '',
+
+  pendingTransactionTimeoutBlocks: 30, // around 5 minutes with 10 seconds block times
+  confirmationsNeeded: 12,
+  retryGasPriceFactor: 1.2,
+  maxGasPrice: 100e9.toString()
 }
 
 const ConfigParamsTypes = {

--- a/src/relayserver/StoredTransaction.ts
+++ b/src/relayserver/StoredTransaction.ts
@@ -1,0 +1,39 @@
+import { PrefixedHexString, Transaction } from 'ethereumjs-tx'
+import * as ethUtils from 'ethereumjs-util'
+import { Address } from '../relayclient/types/Aliases'
+
+export interface StoredTransactionMetadata {
+  readonly from: Address
+  readonly attempts: number
+  readonly creationBlockNumber: number
+  readonly boostBlockNumber?: number
+  readonly minedBlockNumber?: number
+}
+
+export interface StoredTransactionSerialized {
+  readonly to: Address
+  readonly gas: number
+  readonly gasPrice: number
+  readonly data: PrefixedHexString
+  readonly nonce: number
+  readonly txId: PrefixedHexString
+}
+
+export type StoredTransaction = StoredTransactionSerialized & StoredTransactionMetadata
+
+/**
+ * Make sure not to pass {@link StoredTransaction} as {@param metadata}, as it will override fields from {@param tx}!
+ * @param tx
+ * @param metadata
+ */
+export function createStoredTransaction (tx: Transaction, metadata: StoredTransactionMetadata): StoredTransaction {
+  const details: StoredTransactionSerialized = {
+    to: ethUtils.bufferToHex(tx.to),
+    gas: ethUtils.bufferToInt(tx.gasLimit),
+    gasPrice: ethUtils.bufferToInt(tx.gasPrice),
+    data: ethUtils.bufferToHex(tx.data),
+    nonce: ethUtils.bufferToInt(tx.nonce),
+    txId: ethUtils.bufferToHex(tx.hash())
+  }
+  return Object.assign({}, details, metadata)
+}

--- a/test/TxStoreManager.test.ts
+++ b/test/TxStoreManager.test.ts
@@ -1,7 +1,8 @@
 /* global */
 
 import fs from 'fs'
-import { TxStoreManager, TXSTORE_FILENAME, StoredTx } from '../src/relayserver/TxStoreManager'
+import { TxStoreManager, TXSTORE_FILENAME } from '../src/relayserver/TxStoreManager'
+import { StoredTransaction } from '../src/relayserver/StoredTransaction'
 
 // NOTICE: this dir is removed in 'after', do not use this in any other test
 const workdir = '/tmp/gsn/test/txstore_manager'
@@ -18,9 +19,9 @@ function cleanFolder (): void {
 
 contract('TxStoreManager', function (accounts) {
   let txmanager: TxStoreManager
-  let tx: StoredTx
-  let tx2: StoredTx
-  let tx3: StoredTx
+  let tx: StoredTransaction
+  let tx2: StoredTransaction
+  let tx3: StoredTransaction
 
   before('create txstore', async function () {
     cleanFolder()
@@ -29,37 +30,43 @@ contract('TxStoreManager', function (accounts) {
     // eslint-disable-next-line @typescript-eslint/no-base-to-string
     assert.ok(txmanager, 'txstore uninitialized' + txmanager.toString())
     assert.isTrue(fs.existsSync(workdir), 'test txstore dir should exist already')
-    tx = new StoredTx({
-      from: Buffer.from([]),
-      to: Buffer.from([]),
-      gas: Buffer.from([0]),
-      gasPrice: Buffer.from([0]),
-      data: Buffer.from([]),
-      nonce: Buffer.from([111]),
+    tx = {
+      from: '',
+      to: '',
+      gas: 0,
+      gasPrice: 0,
+      data: '',
+      nonce: 111,
       txId: '123456',
+      creationBlockNumber: 0,
+      minedBlockNumber: 0,
       attempts: 1
-    })
-    tx2 = new StoredTx({
-      from: Buffer.from([]),
-      to: Buffer.from([]),
-      gas: Buffer.from([0]),
-      gasPrice: Buffer.from([0]),
-      data: Buffer.from([]),
-      nonce: Buffer.from([112]),
+    }
+    tx2 = {
+      from: '',
+      to: '',
+      gas: 0,
+      gasPrice: 0,
+      data: '',
+      nonce: 112,
       txId: '1234567',
+      creationBlockNumber: 0,
+      minedBlockNumber: 0,
       attempts: 1
-    })
-    tx3 = new StoredTx(
+    }
+    tx3 =
       {
-        from: Buffer.from([]),
-        to: Buffer.from([]),
-        gas: Buffer.from([0]),
-        gasPrice: Buffer.from([0]),
-        data: Buffer.from([]),
-        nonce: Buffer.from([113]),
+        from: '',
+        to: '',
+        gas: 0,
+        gasPrice: 0,
+        data: '',
+        nonce: 113,
         txId: '12345678',
+        creationBlockNumber: 0,
+        minedBlockNumber: 0,
         attempts: 1
-      })
+      }
   })
 
   it('should store and get tx by txId', async function () {

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -228,19 +228,19 @@ contract('RegistrationManager', function (accounts) {
       const receipts = await relayServer._worker(latestBlock.number)
       assertRelayAdded(receipts, relayServer)
 
-      let pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, false)
+      let pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assert.equal(pastEventsResult.receipts.length, 0, 'should not re-register if already registered')
 
       relayServer.config.baseRelayFee = (parseInt(relayServer.config.baseRelayFee) + 1).toString()
-      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, false)
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assertRelayAdded(pastEventsResult.receipts, relayServer, false)
 
       relayServer.config.pctRelayFee++
-      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, false)
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assertRelayAdded(pastEventsResult.receipts, relayServer, false)
 
       relayServer.config.url = 'fakeUrl'
-      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, false)
+      pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assertRelayAdded(pastEventsResult.receipts, relayServer, false)
     })
   })
@@ -308,6 +308,7 @@ contract('RegistrationManager', function (accounts) {
         await newServer.transactionManager.sendTransaction({
           signer: newServer.managerAddress,
           destination: rhub.address,
+          creationBlockNumber: 0,
           method
         })
         const managerHubBalanceBefore = await rhub.balanceOf(newServer.managerAddress)
@@ -396,7 +397,7 @@ contract('RegistrationManager', function (accounts) {
 
     function registrationTests (): void {
       it('should register server and add workers', async function () {
-        const receipts = await newServer.registrationManager.attemptRegistration([])
+        const receipts = await newServer.registrationManager.attemptRegistration([], 0)
         assertRelayAdded(receipts, newServer)
       })
     }

--- a/test/relayserver/RelayServer.test.ts
+++ b/test/relayserver/RelayServer.test.ts
@@ -415,6 +415,7 @@ contract('RelayServer', function (accounts) {
         destination: accounts[0],
         gasLimit: defaultEnvironment.mintxgascost.toString(),
         gasPrice: gasPrice,
+        creationBlockNumber: 0,
         value: toHex((await relayServer.getWorkerBalance(workerIndex)).sub(txcost))
       })
       const workerBalanceAfter = await relayServer.getWorkerBalance(workerIndex)
@@ -445,7 +446,7 @@ contract('RelayServer', function (accounts) {
       await _web3.eth.sendTransaction(
         { from: accounts[0], to: relayServer.workerAddress, value: relayServer.config.workerTargetBalance })
       const currentBlockNumber = await _web3.eth.getBlockNumber()
-      const receipts = await relayServer.replenishServer(workerIndex)
+      const receipts = await relayServer.replenishServer(workerIndex, 0)
       assert.deepEqual(receipts, [])
       assert.equal(currentBlockNumber, await _web3.eth.getBlockNumber())
     })
@@ -454,6 +455,7 @@ contract('RelayServer', function (accounts) {
       await rhub.depositFor(relayServer.managerAddress, { value: 1e18.toString() })
       await relayServer.transactionManager.sendTransaction({
         signer: relayServer.managerAddress,
+        creationBlockNumber: 0,
         destination: accounts[0],
         gasLimit: defaultEnvironment.mintxgascost.toString(),
         gasPrice: gasPrice,
@@ -469,7 +471,7 @@ contract('RelayServer', function (accounts) {
       assert.isTrue(managerHubBalanceBefore.gte(refill), 'manager hub balance should be sufficient to replenish worker')
       assert.isTrue(managerEthBalanceBefore.lt(toBN(relayServer.config.managerTargetBalance.toString())),
         'manager eth balance should be lower than target to withdraw hub balance')
-      const receipts = await relayServer.replenishServer(workerIndex)
+      const receipts = await relayServer.replenishServer(workerIndex, 0)
       const totalTxCosts = getTotalTxCosts(receipts, await _web3.eth.getGasPrice())
       const managerHubBalanceAfter = await rhub.balanceOf(relayServer.managerAddress)
       assert.isTrue(managerHubBalanceAfter.eqn(0), 'manager hub balance should be zero')
@@ -497,7 +499,7 @@ contract('RelayServer', function (accounts) {
       const refill = toBN(relayServer.config.workerTargetBalance).sub(workerBalanceBefore)
       assert.isTrue(managerHubBalanceBefore.lt(refill), 'manager hub balance should be insufficient to replenish worker')
       assert.isTrue(managerEthBalance.gte(refill), 'manager eth balance should be sufficient to replenish worker')
-      await relayServer.replenishServer(workerIndex)
+      await relayServer.replenishServer(workerIndex, 0)
       const workerBalanceAfter = await relayServer.getWorkerBalance(workerIndex)
       assert.isTrue(workerBalanceAfter.eq(workerBalanceBefore.add(refill)),
         `workerBalanceAfter (${workerBalanceAfter.toString()}) != workerBalanceBefore (${workerBalanceBefore.toString()}) + refill (${refill.toString()}`)
@@ -506,6 +508,7 @@ contract('RelayServer', function (accounts) {
     it('should emit \'funding needed\' when both eth and hub balances are too low', async function () {
       await relayServer.transactionManager.sendTransaction({
         signer: relayServer.managerAddress,
+        creationBlockNumber: 0,
         destination: accounts[0],
         gasLimit: defaultEnvironment.mintxgascost.toString(),
         gasPrice: gasPrice.toString(),
@@ -519,7 +522,7 @@ contract('RelayServer', function (accounts) {
       assert.isTrue(managerEthBalance.lt(refill), 'manager eth balance should be insufficient to replenish worker')
       let fundingNeededEmitted = false
       relayServer.on('fundingNeeded', () => { fundingNeededEmitted = true })
-      await relayServer.replenishServer(workerIndex)
+      await relayServer.replenishServer(workerIndex, 0)
       assert.isTrue(fundingNeededEmitted, 'fundingNeeded not emitted')
     })
   })
@@ -539,12 +542,12 @@ contract('RelayServer', function (accounts) {
     it('should re-register server only if registrationBlockRate passed from any tx', async function () {
       let latestBlock = await _web3.eth.getBlock('latest')
       let receipts = await relayServer._worker(latestBlock.number)
-      expect(relayServer.registrationManager.handlePastEvents).to.have.been.calledWith(sinon.match.any, sinon.match.any, false)
+      expect(relayServer.registrationManager.handlePastEvents).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, false)
       assert.equal(receipts.length, 0, 'should not re-register if already registered')
       await evmMineMany(registrationBlockRate)
       latestBlock = await _web3.eth.getBlock('latest')
       receipts = await relayServer._worker(latestBlock.number)
-      expect(relayServer.registrationManager.handlePastEvents).to.have.been.calledWith(sinon.match.any, sinon.match.any, true)
+      expect(relayServer.registrationManager.handlePastEvents).to.have.been.calledWith(sinon.match.any, sinon.match.any, sinon.match.any, true)
       assertRelayAdded(receipts, relayServer, false)
     })
   })

--- a/test/relayserver/RelayServerRequestsProfiling.test.ts
+++ b/test/relayserver/RelayServerRequestsProfiling.test.ts
@@ -24,7 +24,7 @@ const Forwarder = artifacts.require('Forwarder')
 
 contract('RelayServerRequestsProfiling', function ([relayOwner]) {
   const callsPerWorker = 14
-  const callsPerTransaction = 25
+  const callsPerTransaction = 26
 
   let provider: ProfilingProvider
   let relayServer: RelayServer
@@ -119,10 +119,12 @@ contract('RelayServerRequestsProfiling', function ([relayOwner]) {
         baseRelayFee: '0',
         paymaster: paymaster.address
       }
+      provider.reset()
     })
 
     it('should make X requests per relay transaction request', async function () {
       await relayTransaction(relayTransactionParams, options)
+      provider.log()
       assert.isAtMost(provider.requestsCount, callsPerTransaction)
     })
   })

--- a/test/relayserver/ServerTestUtils.ts
+++ b/test/relayserver/ServerTestUtils.ts
@@ -145,6 +145,9 @@ export async function assertTransactionRelayed (
   paymasterAddress: Address,
   web3: Web3, overrideArgs?: Partial<RelayTransactionRequest>): Promise<TransactionReceipt> {
   const receipt = await web3.eth.getTransactionReceipt(txHash)
+  if (receipt == null) {
+    throw new Error('Transaction Receipt not found')
+  }
   const decodedLogs = abiDecoder.decodeLogs(receipt.logs).map(server.registrationManager._parseEvent)
   const event1 = decodedLogs.find((e: { name: string }) => e.name === 'SampleRecipientEmitted')
   assert.exists(event1, 'SampleRecipientEmitted not found, maybe transaction was not relayed successfully')

--- a/test/relayserver/TransactionManager.test.ts
+++ b/test/relayserver/TransactionManager.test.ts
@@ -29,6 +29,8 @@ const Penalizer = artifacts.require('Penalizer')
 const Forwarder = artifacts.require('Forwarder')
 
 contract('TransactionManager', function (accounts) {
+  const pendingTransactionTimeoutBlocks = 5
+  const confirmationsNeeded = 12
   let id: string
   let _web3: Web3
   let relayServer: RelayServer
@@ -71,7 +73,7 @@ contract('TransactionManager', function (accounts) {
       web3,
       stakeManager
     }
-    relayServer = await bringUpNewRelay(newRelayParams, partialConfig)
+    relayServer = await bringUpNewRelay(newRelayParams, partialConfig, {}, { pendingTransactionTimeoutBlocks })
 
     // initialize server - gas price, stake, owner, etc, whatever
     const latestBlock = await _web3.eth.getBlock('latest')
@@ -184,11 +186,35 @@ contract('TransactionManager', function (accounts) {
     })
   })
 
+  describe('local storage maintenance', function () {
+    let parsedTxHash: PrefixedHexString
+
+    before(async function () {
+      await relayServer.transactionManager.txStoreManager.clearAll()
+      const signedTx = await relayTransaction(relayTransactionParams, options)
+      parsedTxHash = ethUtils.bufferToHex((new Transaction(signedTx, relayServer.transactionManager.rawTxOptions)).hash())
+    })
+
+    it('should remove confirmed transactions from the recent transactions storage', async function () {
+      let latestBlock = await _web3.eth.getBlock('latest')
+      await relayServer.transactionManager.removeConfirmedTransactions(latestBlock.number)
+      let storedTransactions = await relayServer.transactionManager.txStoreManager.getAll()
+      assert.equal(storedTransactions[0].txId, parsedTxHash)
+      await evmMineMany(confirmationsNeeded)
+      latestBlock = await _web3.eth.getBlock('latest')
+      await relayServer.transactionManager.removeConfirmedTransactions(latestBlock.number)
+      storedTransactions = await relayServer.transactionManager.txStoreManager.getAll()
+      assert.deepEqual([], storedTransactions)
+    })
+  })
+
   describe('resend unconfirmed transactions task', function () {
-    it('should resend unconfirmed transaction', async function () {
-      // First clear db
+    before(async function () {
       await relayServer.transactionManager.txStoreManager.clearAll()
       assert.deepEqual([], await relayServer.transactionManager.txStoreManager.getAll())
+    })
+
+    it('should resend unconfirmed transaction', async function () {
       // Send a transaction via the relay, but then revert to a previous snapshot
       id = (await snapshot()).result
       const signedTx = await relayTransaction(relayTransactionParams, options)
@@ -204,125 +230,25 @@ contract('TransactionManager', function (accounts) {
       let sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.equal(sortedTxs[0].txId, parsedTxHash)
       let latestBlock = await _web3.eth.getBlock('latest')
-      let resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-      assert.equal(null, resentTx)
+      let allBoostedTransactions = await relayServer._boostStuckPendingTransactions(latestBlock.number)
+      assert.equal(allBoostedTransactions.length, 0)
       sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
       assert.equal(sortedTxs[0].txId, parsedTxHash)
-      // Increase time by hooking Date.now()
-      try {
-        const pendingTransactionTimeout = 5 * 60 * 1000 // 5 minutes in milliseconds
-        // @ts-ignore
-        Date.origNow = Date.now
-        Date.now = function () {
-          // @ts-ignore
-          // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-          return Date.origNow() + pendingTransactionTimeout
-        }
-        // Resend tx, now should be ok
-        latestBlock = await _web3.eth.getBlock('latest')
-        resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-        parsedTxHash = ethUtils.bufferToHex((new Transaction(resentTx, relayServer.transactionManager.rawTxOptions)).hash())
-
-        // Validate relayed tx with increased gasPrice
-        const minedTxAfter = await _web3.eth.getTransaction(parsedTxHash)
-        // BN.muln() does not support floats so to mul by 1.2, we have to mul by 12 and div by 10 to keep precision
-        assert.equal(toBN(minedTxAfter.gasPrice).toString(), toBN(minedTxBefore.gasPrice).muln(12).divn(10).toString())
-        await assertTransactionRelayed(relayServer, parsedTxHash, gasLess, recipientAddress, paymasterAddress, _web3)
-      } finally {
-        // Release hook
-        // @ts-ignore
-        Date.now = Date.origNow
-      }
-      // Check the tx is removed from the store only after enough blocks
+      // Increase time by mining necessary amount of blocks
+      await evmMineMany(pendingTransactionTimeoutBlocks)
+      // Resend tx, now should be ok
       latestBlock = await _web3.eth.getBlock('latest')
-      resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-      assert.equal(null, resentTx)
-      sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
-      assert.equal(sortedTxs[0].txId, parsedTxHash)
-      const confirmationsNeeded = 12
-      await evmMineMany(confirmationsNeeded)
-      latestBlock = await _web3.eth.getBlock('latest')
-      resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-      assert.equal(null, resentTx)
-      sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
-      assert.deepEqual([], sortedTxs)
+      allBoostedTransactions = await relayServer._boostStuckPendingTransactions(latestBlock.number)
+      assert.equal(allBoostedTransactions.length, 1)
+      parsedTxHash = ethUtils.bufferToHex((new Transaction(allBoostedTransactions[0], relayServer.transactionManager.rawTxOptions)).hash())
 
-      // Revert for following tests
-      await revert(id)
+      // Validate relayed tx with increased gasPrice
+      const minedTxAfter = await _web3.eth.getTransaction(parsedTxHash)
+      // BN.muln() does not support floats so to mul by 1.2, we have to mul by 12 and div by 10 to keep precision
+      assert.equal(toBN(minedTxAfter.gasPrice).toString(), toBN(minedTxBefore.gasPrice).muln(12).divn(10).toString())
+      await assertTransactionRelayed(relayServer, parsedTxHash, gasLess, recipientAddress, paymasterAddress, _web3)
     })
 
-    it('should resend multiple unconfirmed transactions', async function () {
-      // First clear db
-      await relayServer.transactionManager.txStoreManager.clearAll()
-      assert.deepEqual([], await relayServer.transactionManager.txStoreManager.getAll())
-      // Send 3 transactions, separated by 1 min each, and revert the last 2
-      const signedTx1 = await relayTransaction(relayTransactionParams, options)
-      id = (await snapshot()).result
-      // Increase time by hooking Date
-      let constructorIncrease = 2 * 60 * 1000 // 1 minute in milliseconds
-      let nowIncrease = 0
-      const origDate = Date
-      try {
-        const NewDate = class extends Date {
-          constructor () {
-            // @ts-ignore
-            // eslint-disable-next-line @typescript-eslint/restrict-plus-operands
-            super(Date.origNow() + constructorIncrease)
-          }
-
-          static now (): number {
-            return super.now() + nowIncrease
-          }
-
-          static origNow (): number {
-            return super.now()
-          }
-        }
-        // @ts-ignore
-        Date = NewDate // eslint-disable-line no-global-assign
-        await relayTransaction(relayTransactionParams, options)
-        constructorIncrease = 4 * 60 * 1000 // 4 minutes in milliseconds
-        const signedTx3 = await relayTransaction(relayTransactionParams, options)
-        await revert(id)
-        const nonceBefore = await _web3.eth.getTransactionCount(relayServer.managerAddress)
-        // Check tx1 still went fine after revert
-        const parsedTxHash1 = ethUtils.bufferToHex((new Transaction(signedTx1, relayServer.transactionManager.rawTxOptions)).hash())
-        await assertTransactionRelayed(relayServer, parsedTxHash1, gasLess, recipientAddress, paymasterAddress, _web3)
-        // After 10 minutes, tx2 is not resent because tx1 is still unconfirmed
-        nowIncrease = 10 * 60 * 1000 // 10 minutes in milliseconds
-        constructorIncrease = 0
-        let sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
-        // console.log('times:', sortedTxs[0].createdAt, sortedTxs[1].createdAt, sortedTxs[2].createdAt )
-        assert.equal(sortedTxs[0].txId, parsedTxHash1)
-        let latestBlock = await _web3.eth.getBlock('latest')
-        let resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-        assert.equal(null, resentTx)
-        assert.equal(nonceBefore, await _web3.eth.getTransactionCount(relayServer.managerAddress))
-        sortedTxs = await relayServer.transactionManager.txStoreManager.getAll()
-        // console.log('sortedTxs?', sortedTxs)
-        assert.equal(sortedTxs[0].txId, parsedTxHash1)
-        // Mine a bunch of blocks, so tx1 is confirmed and tx2 is resent
-        const confirmationsNeeded = 12
-        await evmMineMany(confirmationsNeeded)
-        latestBlock = await _web3.eth.getBlock('latest')
-        const resentTx2 = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-        const parsedTxHash2 = ethUtils.bufferToHex((new Transaction(resentTx2, relayServer.transactionManager.rawTxOptions)).hash())
-        await assertTransactionRelayed(relayServer, parsedTxHash2, gasLess, recipientAddress, paymasterAddress, _web3)
-        // Re-inject tx3 into the chain as if it were mined once tx2 goes through
-        await _web3.eth.sendSignedTransaction(signedTx3)
-        const parsedTxHash3 = ethUtils.bufferToHex((new Transaction(signedTx3, relayServer.transactionManager.rawTxOptions)).hash())
-        await assertTransactionRelayed(relayServer, parsedTxHash3, gasLess, recipientAddress, paymasterAddress, _web3)
-        // Check that tx3 does not get resent, even after time passes or blocks get mined, and that store is empty
-        nowIncrease = 60 * 60 * 1000 // 60 minutes in milliseconds
-        await evmMineMany(confirmationsNeeded)
-        latestBlock = await _web3.eth.getBlock('latest')
-        resentTx = await relayServer._resendUnconfirmedTransactions(latestBlock.number)
-        assert.equal(null, resentTx)
-        assert.deepEqual([], await relayServer.transactionManager.txStoreManager.getAll())
-      } finally {
-        // Release hook
-        Date = origDate // eslint-disable-line no-global-assign
-      }
-    })
+    it('should resend multiple unconfirmed transactions')
   })
 })


### PR DESCRIPTION
Date/time is an extremely unreliable measurement in terms of blockchain
and is hard to test for.

This PR makes TransactionManager remember the block height at the point
of the transaction creation.

Also:
1. Create StoredTransaction in place of StoredTx and StoredParams
2. Add 'pendingTransactionTimeoutBlocks', 'confirmationsNeeded',
'retryGasPriceFactor' and 'maxGasPrice' to the Server Config struct
3. Separate database cleanubp and gas price boost logic & test
4. 'resend multiple unconfirmed transactions' skipped and must be redone