### PR TITLE
OG-210 Forwarder add registerDomainSeparator

### DIFF
--- a/contracts/forwarder/Forwarder.sol
+++ b/contracts/forwarder/Forwarder.sol
@@ -10,8 +10,7 @@ contract Forwarder is IForwarder {
 
     string public constant GENERIC_PARAMS = "address from,address to,uint256 value,uint256 gas,uint256 nonce,bytes data";
 
-    string public constant EIP712_DOMAIN_PREFIX = "EIP712Domain(";
-    string public constant EIP712_DOMAIN_SUFFIX = ",uint256 chainId,address verifyingContract)";
+    string public constant EIP712_DOMAIN_TYPE = "EIP712Domain(string name,string version,uint256 chainId,address verifyingContract)";
 
     mapping(bytes32 => bool) public typeHashes;
     mapping(bytes32 => bool) public domains;
@@ -89,22 +88,22 @@ contract Forwarder is IForwarder {
         registerRequestTypeInternal(requestType);
     }
 
-    function registerDomainSeparator(string calldata typePrefix, bytes memory dataPrefix) external override {
-        bytes memory domainType = abi.encodePacked(EIP712_DOMAIN_PREFIX, typePrefix, EIP712_DOMAIN_SUFFIX );
+    function registerDomainSeparator(string calldata name, string calldata version) external override {
         uint256 chainId;
         /* solhint-disable-next-line no-inline-assembly */
         assembly { chainId := chainid() }
 
-        bytes memory domainValue = abi.encodePacked(
-            keccak256(domainType),
-            dataPrefix,
+        bytes memory domainValue = abi.encode(
+            keccak256(bytes(EIP712_DOMAIN_TYPE)),
+            keccak256(bytes(name)),
+            keccak256(bytes(version)),
             chainId,
-            uint256(uint160(address(this))));
+            address(this));
 
         bytes32 domainHash = keccak256(domainValue);
 
         domains[domainHash] = true;
-        emit DomainRegistered(domainHash, string(domainType), domainValue);
+        emit DomainRegistered(domainHash, domainValue);
     }
 
     function registerRequestTypeInternal(string memory requestType) internal {
@@ -114,7 +113,7 @@ contract Forwarder is IForwarder {
         emit RequestTypeRegistered(requestTypehash, requestType);
     }
 
-    event DomainRegistered(bytes32 indexed domainSeparator, string domainType, bytes domainValue);
+    event DomainRegistered(bytes32 indexed domainSeparator, bytes domainValue);
 
     event RequestTypeRegistered(bytes32 indexed typeHash, string typeStr);
 

--- a/contracts/forwarder/Forwarder.sol
+++ b/contracts/forwarder/Forwarder.sol
@@ -128,8 +128,8 @@ contract Forwarder is IForwarder {
     internal
     view
     {
-        require(domains[domainSeparator], "invalid domain separator");
-        require(typeHashes[requestTypeHash], "invalid request typehash");
+        require(domains[domainSeparator], "unregistered domain separator");
+        require(typeHashes[requestTypeHash], "unregistered request typehash");
         bytes32 digest = keccak256(abi.encodePacked(
                 "\x19\x01", domainSeparator,
                 keccak256(_getEncoded(req, requestTypeHash, suffixData))

--- a/contracts/forwarder/IForwarder.sol
+++ b/contracts/forwarder/IForwarder.sol
@@ -60,4 +60,14 @@ interface IForwarder {
      *        if it does contain a value, then a comma is added first.
      */
     function registerRequestType(string calldata typeName, string calldata typeSuffix) external;
+
+    /**
+     * register a new domain separator.
+     * A valid domain separator must have chainId set to current network's chain-id, and
+     * verifyingContract set to this forwarder. It may contain other fields as prefix
+     * a domain Type always start with "EIP712Domain(" and ends with ",uint256 chainId,address verifyingContract)"
+     * @param typePrefix more domain parameters to add before the trailing chainId and verifyingContract
+     * @param dataPrefix value for the above added fields.
+     */
+    function registerDomainSeparator(string calldata typePrefix, bytes memory dataPrefix) external;
 }

--- a/contracts/forwarder/IForwarder.sol
+++ b/contracts/forwarder/IForwarder.sol
@@ -62,12 +62,12 @@ interface IForwarder {
     function registerRequestType(string calldata typeName, string calldata typeSuffix) external;
 
     /**
-     * register a new domain separator.
-     * A valid domain separator must have chainId set to current network's chain-id, and
-     * verifyingContract set to this forwarder. It may contain other fields as prefix
-     * a domain Type always start with "EIP712Domain(" and ends with ",uint256 chainId,address verifyingContract)"
-     * @param typePrefix more domain parameters to add before the trailing chainId and verifyingContract
-     * @param dataPrefix value for the above added fields.
+     * Register a new domain separator.
+     * The domain separator must have the following fields: name,version,chainId, verifyingContract.
+     * the chainId is the current network's chainId, and the verifyingContract is this forwarder.
+     * This method is given the domain name and version to create and register the domain separator value.
+     * @param name the domain's display name
+     * @param version the domain/protocol version
      */
-    function registerDomainSeparator(string calldata typePrefix, bytes memory dataPrefix) external;
+    function registerDomainSeparator(string calldata name, string calldata version) external;
 }

--- a/contracts/forwarder/test/TestForwarder.sol
+++ b/contracts/forwarder/test/TestForwarder.sol
@@ -22,4 +22,9 @@ contract TestForwarder {
         //unknown buffer. return as-is
         return string(ret);
     }
+
+    function getChainId() public pure returns (uint256 id){
+        /* solhint-disable-next-line no-inline-assembly */
+        assembly { id := chainid() }
+    }
 }

--- a/src/cli/CommandsLogic.ts
+++ b/src/cli/CommandsLogic.ts
@@ -21,10 +21,10 @@ import ContractInteractor from '../relayclient/ContractInteractor'
 import { GSNConfig } from '../relayclient/GSNConfigurator'
 import HttpClient from '../relayclient/HttpClient'
 import HttpWrapper from '../relayclient/HttpWrapper'
-import { GsnRequestType } from '../common/EIP712/TypedRequestData'
 import { constants } from '../common/Constants'
 import { RelayHubConfiguration } from '../relayclient/types/RelayHubConfiguration'
 import { string32 } from '../common/VersionRegistry'
+import { registerForwarderForGsn } from '../common/EIP712/ForwarderUtil'
 
 interface RegisterOptions {
   from: Address
@@ -269,10 +269,7 @@ export default class CommandsLogic {
     }
     this.config.relayHubAddress = rInstance.options.address
 
-    await fInstance.methods.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    ).send(options)
+    await registerForwarderForGsn(fInstance, options)
 
     return {
       relayHubAddress: rInstance.options.address,

--- a/src/common/EIP712/ForwarderUtil.ts
+++ b/src/common/EIP712/ForwarderUtil.ts
@@ -1,4 +1,4 @@
-import { getRegisterDomainSeparatorData, GsnRequestType } from './TypedRequestData'
+import { GsnDomainSeparatorType, GsnRequestType } from './TypedRequestData'
 import { IForwarderInstance } from '../../../types/truffle-contracts'
 import { Contract } from 'web3-eth-contract'
 
@@ -19,6 +19,5 @@ export async function registerForwarderForGsn (forwarderTruffleOrWeb3: IForwarde
     GsnRequestType.typeSuffix
   ).send(sendOptions)
 
-  const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
-  await forwarder.methods.registerDomainSeparator(prefix, dataPrefix).send(sendOptions)
+  await forwarder.methods.registerDomainSeparator(GsnDomainSeparatorType.name, GsnDomainSeparatorType.version).send(sendOptions)
 }

--- a/src/common/EIP712/ForwarderUtil.ts
+++ b/src/common/EIP712/ForwarderUtil.ts
@@ -1,0 +1,24 @@
+import { getRegisterDomainSeparatorData, GsnRequestType } from './TypedRequestData'
+import { IForwarderInstance } from '../../../types/truffle-contracts'
+import { Contract } from 'web3-eth-contract'
+
+// register a forwarder for use with GSN: the request-type and domain separator we're using.
+export async function registerForwarderForGsn (forwarderTruffleOrWeb3: IForwarderInstance|Contract, sendOptions: any = undefined): Promise<void> {
+  let forwarder: Contract
+  if ((forwarderTruffleOrWeb3 as any).contract != null) {
+    forwarder = (forwarderTruffleOrWeb3 as any).contract
+    // truffle-contract carries default options (e.g. from) in the object.
+    // @ts-ignore
+    sendOptions = { ...forwarderTruffleOrWeb3.constructor.defaults(), ...sendOptions }
+  } else {
+    forwarder = forwarderTruffleOrWeb3 as any
+  }
+
+  await forwarder.methods.registerRequestType(
+    GsnRequestType.typeName,
+    GsnRequestType.typeSuffix
+  ).send(sendOptions)
+
+  const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
+  await forwarder.methods.registerDomainSeparator(prefix, dataPrefix).send(sendOptions)
+}

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -4,7 +4,6 @@ import { EIP712Domain, EIP712TypedData, EIP712TypeProperty, EIP712Types, TypedDa
 
 import { bufferToHex } from 'ethereumjs-util'
 import { PrefixedHexString } from 'ethereumjs-tx'
-import { keccak256 } from 'web3-utils'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -51,13 +50,6 @@ export const GsnDomainSeparatorType = {
   prefix: 'string name,string version',
   name: 'GSN Relayed Transaction',
   version: '2'
-}
-
-export function getRegisterDomainSeparatorData (): {prefix: string, dataPrefix: string } {
-  return {
-    prefix: GsnDomainSeparatorType.prefix,
-    dataPrefix: keccak256(GsnDomainSeparatorType.name) + keccak256(GsnDomainSeparatorType.version).slice(2)
-  }
 }
 
 export function getDomainSeparator (verifier: Address, chainId: number): EIP712Domain {

--- a/src/common/EIP712/TypedRequestData.ts
+++ b/src/common/EIP712/TypedRequestData.ts
@@ -4,6 +4,9 @@ import { EIP712Domain, EIP712TypedData, EIP712TypeProperty, EIP712Types, TypedDa
 
 import { bufferToHex } from 'ethereumjs-util'
 import { PrefixedHexString } from 'ethereumjs-tx'
+import { keccak256 } from 'web3-utils'
+
+require('source-map-support').install({ errorFormatterForce: true })
 
 const EIP712DomainType = [
   { name: 'name', type: 'string' },
@@ -43,10 +46,24 @@ interface Types extends EIP712Types {
   RelayData: EIP712TypeProperty[]
 }
 
+// use these values in registerDomainSeparator
+export const GsnDomainSeparatorType = {
+  prefix: 'string name,string version',
+  name: 'GSN Relayed Transaction',
+  version: '2'
+}
+
+export function getRegisterDomainSeparatorData (): {prefix: string, dataPrefix: string } {
+  return {
+    prefix: GsnDomainSeparatorType.prefix,
+    dataPrefix: keccak256(GsnDomainSeparatorType.name) + keccak256(GsnDomainSeparatorType.version).slice(2)
+  }
+}
+
 export function getDomainSeparator (verifier: Address, chainId: number): EIP712Domain {
   return {
-    name: 'GSN Relayed Transaction',
-    version: '2',
+    name: GsnDomainSeparatorType.name,
+    version: GsnDomainSeparatorType.version,
     chainId: chainId,
     verifyingContract: verifier
   }

--- a/src/common/Environments.ts
+++ b/src/common/Environments.ts
@@ -12,7 +12,7 @@ interface Environment {
 }
 
 const defaultRelayHubConfiguration: RelayHubConfiguration = {
-  gasOverhead: 35965,
+  gasOverhead: 35901,
   postOverhead: 13849,
   gasReserve: 100000,
   maxWorkerCount: 10,

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -14,7 +14,7 @@ import {
 import { deployHub, startRelay, stopRelay } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { GSNConfig } from '../src/relayclient/GSNConfigurator'
-import { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
@@ -76,10 +76,7 @@ options.forEach(params => {
       const forwarder = await Forwarder.new()
       sr = await TestRecipient.new(forwarder.address)
 
-      await forwarder.registerRequestType(
-        GsnRequestType.typeName,
-        GsnRequestType.typeSuffix
-      )
+      await registerForwarderForGsn(forwarder)
 
       paymaster = await TestPaymasterEverythingAccepted.new()
       await paymaster.setTrustedForwarder(forwarder.address)

--- a/test/Forwarder.test.ts
+++ b/test/Forwarder.test.ts
@@ -57,6 +57,7 @@ contract('Forwarder', ([from]) => {
   const senderPrivateKey = toBuffer(bytes32(1))
   const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
 
+
   before(async () => {
     fwd = await Forwarder.new()
     tf = await TestForwarder.new()
@@ -89,10 +90,11 @@ contract('Forwarder', ([from]) => {
   })
 
   describe('#registerDomainSeparator', () => {
+
     it('registered domain should match local definition', async () => {
       const data = {
         domain: {
-          extra:1234,
+          extra: 1234,
           chainId,
           verifyingContract: fwd.address
         },
@@ -108,14 +110,14 @@ contract('Forwarder', ([from]) => {
 
       const localDomainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))
       const typehash = TypedDataUtils.hashType('EIP712Domain', data.types)
-      const ret = await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234) )
+      const ret = await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234))
 
       const { domainSeparator, domainType, domainValue } = ret.logs[0].args
       assert.equal(domainType, 'EIP712Domain(uint256 extra,uint256 chainId,address verifyingContract)')
-      assert.equal(domainValue, web3.eth.abi.encodeParameters(['bytes32','uint256','uint256','address'],[typehash, data.domain.extra, data.domain.chainId, fwd.address]))
+      assert.equal(domainValue, web3.eth.abi.encodeParameters(['bytes32', 'uint256', 'uint256', 'address'], [typehash, data.domain.extra, data.domain.chainId, fwd.address]))
       assert.equal(domainSeparator, localDomainSeparator)
 
-      assert.equal( await fwd.domains(localDomainSeparator), true )
+      assert.equal(await fwd.domains(localDomainSeparator), true)
     })
   })
 
@@ -136,21 +138,21 @@ contract('Forwarder', ([from]) => {
   describe('#verify', () => {
     const typeName = `ForwardRequest(${GENERIC_PARAMS})`
     const typeHash = keccak256(typeName)
-    let domainInfo :any
+    let domainInfo: any
     const dummyDomainType = [
       { name: 'extra', type: 'uint256' },
       { name: 'chainId', type: 'uint256' },
       { name: 'verifyingContract', type: 'address' }
-    ];
+    ]
 
     let domainSeparator: string
 
-    before( 'register domain separator', async()=>{
+    before('register domain separator', async () => {
       domainInfo = {
-        extra:1234,
+        extra: 1234,
         chainId,
         verifyingContract: fwd.address
-      };
+      }
 
       const data = {
         domain: domainInfo,
@@ -161,10 +163,11 @@ contract('Forwarder', ([from]) => {
       }
 
       domainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))
-      await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234) )
+      await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234))
     })
 
     describe('#verify failures', () => {
+
       const req = {
         to: addr(1),
         data: '0x',
@@ -174,10 +177,10 @@ contract('Forwarder', ([from]) => {
         gas: 123
       }
 
-      it('should fail on invalid domain separator', async () => {
+      it('should fail on unregistered domain separator', async () => {
         const dummyDomainSeparator = bytes32(1)
 
-        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'.padEnd(65*2+2, '1b')), 'invalid domain separator')
+        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'.padEnd(65 * 2 + 2, '1b')), 'unregistered domain separator')
       })
 
       it('should fail on wrong nonce', async () => {
@@ -317,8 +320,8 @@ contract('Forwarder', ([from]) => {
       recipient = await TestForwarderTarget.new(fwd.address)
       testfwd = await TestForwarder.new()
 
-      const namehash = keccak256(bufferToHex(Buffer.from(data.domain.name!,'ascii')))
-      const versionhash = keccak256(bufferToHex(Buffer.from(data.domain.version!,'ascii')))
+      const namehash = keccak256(bufferToHex(Buffer.from(data.domain.name!, 'ascii')))
+      const versionhash = keccak256(bufferToHex(Buffer.from(data.domain.version!, 'ascii')))
       const ret = await fwd.registerDomainSeparator('string name,string version', web3.eth.abi.encodeParameters(['bytes32', 'bytes32'], [namehash, versionhash]))
 
       domainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))

--- a/test/Forwarder.test.ts
+++ b/test/Forwarder.test.ts
@@ -8,6 +8,7 @@ import { EIP712TypedData, signTypedData_v4, TypedDataUtils, signTypedData } from
 import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util'
 import { ether, expectRevert } from '@openzeppelin/test-helpers'
 import { toChecksumAddress } from 'web3-utils'
+require('source-map-support').install({ errorFormatterForce: true })
 
 const TestForwarderTarget = artifacts.require('TestForwarderTarget')
 
@@ -49,11 +50,17 @@ contract('Forwarder', ([from]) => {
 
   let fwd: ForwarderInstance
 
+  let tf: TestForwarderInstance
+
+  let chainId: number
+
   const senderPrivateKey = toBuffer(bytes32(1))
   const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
 
   before(async () => {
     fwd = await Forwarder.new()
+    tf = await TestForwarder.new()
+    chainId = (await tf.getChainId()).toNumber()
     assert.equal(await fwd.GENERIC_PARAMS(), GENERIC_PARAMS)
   })
 
@@ -81,6 +88,37 @@ contract('Forwarder', ([from]) => {
     })
   })
 
+  describe('#registerDomainSeparator', () => {
+    it('registered domain should match local definition', async () => {
+      const data = {
+        domain: {
+          extra:1234,
+          chainId,
+          verifyingContract: fwd.address
+        },
+        primaryType: 'ForwardRequest',
+        types: {
+          EIP712Domain: [
+            { name: 'extra', type: 'uint256' },
+            { name: 'chainId', type: 'uint256' },
+            { name: 'verifyingContract', type: 'address' }
+          ]
+        }
+      }
+
+      const localDomainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))
+      const typehash = TypedDataUtils.hashType('EIP712Domain', data.types)
+      const ret = await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234) )
+
+      const { domainSeparator, domainType, domainValue } = ret.logs[0].args
+      assert.equal(domainType, 'EIP712Domain(uint256 extra,uint256 chainId,address verifyingContract)')
+      assert.equal(domainValue, web3.eth.abi.encodeParameters(['bytes32','uint256','uint256','address'],[typehash, data.domain.extra, data.domain.chainId, fwd.address]))
+      assert.equal(domainSeparator, localDomainSeparator)
+
+      assert.equal( await fwd.domains(localDomainSeparator), true )
+    })
+  })
+
   describe('registered typehash', () => {
     const fullType = `test4(${GENERIC_PARAMS},bool extra)`
     const hash = keccak256(fullType)
@@ -98,10 +136,35 @@ contract('Forwarder', ([from]) => {
   describe('#verify', () => {
     const typeName = `ForwardRequest(${GENERIC_PARAMS})`
     const typeHash = keccak256(typeName)
+    let domainInfo :any
+    const dummyDomainType = [
+      { name: 'extra', type: 'uint256' },
+      { name: 'chainId', type: 'uint256' },
+      { name: 'verifyingContract', type: 'address' }
+    ];
+
+    let domainSeparator: string
+
+    before( 'register domain separator', async()=>{
+      domainInfo = {
+        extra:1234,
+        chainId,
+        verifyingContract: fwd.address
+      };
+
+      const data = {
+        domain: domainInfo,
+        primaryType: 'ForwardRequest',
+        types: {
+          EIP712Domain: dummyDomainType
+        }
+      }
+
+      domainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))
+      await fwd.registerDomainSeparator('uint256 extra', web3.eth.abi.encodeParameter('uint256', 1234) )
+    })
 
     describe('#verify failures', () => {
-      const dummyDomainSeparator = bytes32(1)
-
       const req = {
         to: addr(1),
         data: '0x',
@@ -111,16 +174,22 @@ contract('Forwarder', ([from]) => {
         gas: 123
       }
 
+      it('should fail on invalid domain separator', async () => {
+        const dummyDomainSeparator = bytes32(1)
+
+        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'.padEnd(65*2+2, '1b')), 'invalid domain separator')
+      })
+
       it('should fail on wrong nonce', async () => {
         await expectRevert(fwd.verify({
           ...req,
           nonce: 123
-        }, dummyDomainSeparator, typeHash, '0x', '0x'), 'revert nonce mismatch')
+        }, domainSeparator, typeHash, '0x', '0x'), 'revert nonce mismatch')
       })
       it('should fail on invalid signature', async () => {
-        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x'), 'invalid signature length')
-        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x123456'), 'invalid signature length')
-        await expectRevert(fwd.verify(req, dummyDomainSeparator, typeHash, '0x', '0x' + '1b'.repeat(65)), 'signature mismatch')
+        await expectRevert(fwd.verify(req, domainSeparator, typeHash, '0x', '0x'), 'invalid signature length')
+        await expectRevert(fwd.verify(req, domainSeparator, typeHash, '0x', '0x123456'), 'invalid signature length')
+        await expectRevert(fwd.verify(req, domainSeparator, typeHash, '0x', '0x' + '1b'.repeat(65)), 'signature mismatch')
       })
     })
     describe('#verify success', () => {
@@ -137,15 +206,10 @@ contract('Forwarder', ([from]) => {
 
       before(() => {
         data = {
-          domain: {
-            name: 'Test Domain',
-            version: '1',
-            chainId: 1234,
-            verifyingContract: fwd.address
-          },
+          domain: domainInfo,
           primaryType: 'ForwardRequest',
           types: {
-            EIP712Domain: EIP712DomainType,
+            EIP712Domain: dummyDomainType,
             ForwardRequest: ForwardRequestType
           },
           message: req
@@ -190,7 +254,7 @@ contract('Forwarder', ([from]) => {
           domain: data.domain,
           primaryType: 'ExtendedMessage',
           types: {
-            EIP712Domain: EIP712DomainType,
+            EIP712Domain: dummyDomainType,
             ExtendedMessage: ExtendedMessageType,
             ExtraData: ExtraDataType
           },
@@ -229,11 +293,12 @@ contract('Forwarder', ([from]) => {
       typeName = `ForwardRequest(${GENERIC_PARAMS})`
       typeHash = web3.utils.keccak256(typeName)
       await fwd.registerRequestType('TestCall', '')
+
       data = {
         domain: {
           name: 'Test Domain',
           version: '1',
-          chainId: 1234,
+          chainId,
           verifyingContract: fwd.address
         },
         primaryType: 'ForwardRequest',
@@ -248,10 +313,18 @@ contract('Forwarder', ([from]) => {
       assert.equal(calcType, typeName)
       const calcTypeHash = bufferToHex(TypedDataUtils.hashType('ForwardRequest', data.types))
       assert.equal(calcTypeHash, typeHash)
+
       recipient = await TestForwarderTarget.new(fwd.address)
       testfwd = await TestForwarder.new()
 
+      const namehash = keccak256(bufferToHex(Buffer.from(data.domain.name!,'ascii')))
+      const versionhash = keccak256(bufferToHex(Buffer.from(data.domain.version!,'ascii')))
+      const ret = await fwd.registerDomainSeparator('string name,string version', web3.eth.abi.encodeParameters(['bytes32', 'bytes32'], [namehash, versionhash]))
+
       domainSeparator = bufferToHex(TypedDataUtils.hashStruct('EIP712Domain', data.domain, data.types))
+
+      // validate registration matches local definition
+      assert.equal(domainSeparator, ret.logs[0].args.domainSeparator)
     })
 
     it('should call function', async () => {

--- a/test/Forwarder.test.ts
+++ b/test/Forwarder.test.ts
@@ -3,6 +3,7 @@ import {
   TestForwarderInstance,
   TestForwarderTargetInstance
 } from '../types/truffle-contracts'
+
 // @ts-ignore
 import { EIP712TypedData, signTypedData_v4, TypedDataUtils, signTypedData } from 'eth-sig-util'
 import { bufferToHex, privateToAddress, toBuffer } from 'ethereumjs-util'
@@ -57,7 +58,6 @@ contract('Forwarder', ([from]) => {
   const senderPrivateKey = toBuffer(bytes32(1))
   const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
 
-
   before(async () => {
     fwd = await Forwarder.new()
     tf = await TestForwarder.new()
@@ -90,7 +90,6 @@ contract('Forwarder', ([from]) => {
   })
 
   describe('#registerDomainSeparator', () => {
-
     it('registered domain should match local definition', async () => {
       const data = {
         domain: {
@@ -167,7 +166,6 @@ contract('Forwarder', ([from]) => {
     })
 
     describe('#verify failures', () => {
-
       const req = {
         to: addr(1),
         data: '0x',

--- a/test/PaymasterCommitment.test.ts
+++ b/test/PaymasterCommitment.test.ts
@@ -3,7 +3,7 @@ import BN from 'bn.js'
 
 import { getEip712Signature } from '../src/common/Utils'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
-import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import {
   RelayHubInstance,
@@ -17,6 +17,7 @@ import { PrefixedHexString } from 'ethereumjs-tx'
 import ForwardRequest from '../src/common/EIP712/ForwardRequest'
 import RelayData from '../src/common/EIP712/RelayData'
 import { deployHub, encodeRevertReason } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const StakeManager = artifacts.require('StakeManager')
 const Forwarder = artifacts.require('Forwarder')
@@ -102,11 +103,7 @@ contract('Paymaster Commitment', function ([_, relayOwner, relayManager, relayWo
     const testUtil = await TestUtil.new()
     chainId = (await testUtil.libGetChainID()).toNumber()
 
-    // register hub's RelayRequest with forwarder, if not already done.
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     target = recipientContract.address
     relayHub = relayHubInstance.address

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -5,7 +5,7 @@ import { expect } from 'chai'
 import { decodeRevertReason, getEip712Signature, removeHexPrefix } from '../src/common/Utils'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
 import { defaultEnvironment } from '../src/common/Environments'
-import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import {
   RelayHubInstance,
@@ -17,6 +17,7 @@ import {
   TestPaymasterConfigurableMisbehaviorInstance
 } from '../types/truffle-contracts'
 import { deployHub, encodeRevertReason } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const StakeManager = artifacts.require('StakeManager')
 const Forwarder = artifacts.require('Forwarder')
@@ -60,10 +61,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
     recipientContract = await TestRecipient.new(forwarder)
 
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     target = recipientContract.address
     paymaster = paymasterContract.address

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -2,7 +2,7 @@ import BN from 'bn.js'
 import { ether, expectEvent } from '@openzeppelin/test-helpers'
 
 import { calculateTransactionMaxPossibleGas, getEip712Signature } from '../src/common/Utils'
-import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 import { defaultEnvironment } from '../src/common/Environments'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
 
@@ -15,6 +15,7 @@ import {
   PenalizerInstance
 } from '../types/truffle-contracts'
 import { deployHub } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const Forwarder = artifacts.require('Forwarder')
 const StakeManager = artifacts.require('StakeManager')
@@ -63,10 +64,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
     await paymaster.setTrustedForwarder(forwarder)
     await paymaster.setRelayHub(relayHub.address)
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     await relayHub.depositFor(paymaster.address, {
       value: ether('1'),

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -332,7 +332,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
           }
           const gasUsed = res.receipt.gasUsed
           const diff = await diffBalances(await beforeBalances)
-          assert.equal(diff.paymasters, gasUsed)
+          assert.equal(diff.paymasters.toNumber(), gasUsed)
         })
       })
   })

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -10,7 +10,7 @@ import { expect } from 'chai'
 
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
-import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 import { defaultEnvironment } from '../src/common/Environments'
 import {
   PenalizerInstance,
@@ -20,6 +20,7 @@ import {
 } from '../types/truffle-contracts'
 
 import { deployHub } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 import TransactionResponse = Truffle.TransactionResponse
 
@@ -52,10 +53,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
     forwarder = forwarderInstance.address
     recipient = await TestRecipient.new(forwarder)
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     paymaster = await TestPaymasterEverythingAccepted.new()
     await stakeManager.stakeForAddress(relayManager, 1000, {

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -5,8 +5,8 @@ import {
 } from '../types/truffle-contracts'
 import BN from 'bn.js'
 import { PrefixedHexString } from 'ethereumjs-tx'
-import { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
 import { deployHub } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -48,10 +48,7 @@ contract('SampleRecipient', function (accounts) {
     const rhub = await deployHub(stakeManager.address, penalizer.address)
     await paymaster.setTrustedForwarder(forwarder)
     await paymaster.setRelayHub(rhub.address)
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     // transfer eth into paymaster (using the normal "transfer" helper, which internally
     // uses hub.depositFor)

--- a/test/TestBatchForwarder.test.ts
+++ b/test/TestBatchForwarder.test.ts
@@ -2,7 +2,7 @@
 
 import { ether, expectEvent } from '@openzeppelin/test-helpers'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
-import TypedRequestData, { GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import { getEip712Signature } from '../src/common/Utils'
 
@@ -14,6 +14,7 @@ import {
   BatchForwarderInstance
 } from '../types/truffle-contracts'
 import { deployHub, encodeRevertReason } from './TestUtils'
+import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted.sol')
 const StakeManager = artifacts.require('StakeManager')
@@ -50,10 +51,8 @@ contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
     await hub.depositFor(paymaster.address, { value: paymasterDeposit })
 
     forwarder = await BatchForwarder.new()
-    await forwarder.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarder)
+
     recipient = await TestRecipient.new(forwarder.address)
 
     await paymaster.setTrustedForwarder(forwarder.address)

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -7,7 +7,10 @@ import { HttpProvider } from 'web3-core'
 
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
-import TypedRequestData, { getDomainSeparatorHash, GsnRequestType } from '../src/common/EIP712/TypedRequestData'
+import TypedRequestData, {
+  getDomainSeparatorHash, getRegisterDomainSeparatorData,
+  GsnRequestType
+} from '../src/common/EIP712/TypedRequestData'
 import { expectEvent } from '@openzeppelin/test-helpers'
 import { ForwarderInstance, TestRecipientInstance, TestUtilInstance } from '../types/truffle-contracts'
 import { PrefixedHexString } from 'ethereumjs-tx'
@@ -16,6 +19,7 @@ import { encodeRevertReason } from './TestUtils'
 import CommandsLogic from '../src/cli/CommandsLogic'
 import { configureGSN, GSNConfig, resolveConfigurationGSN } from '../src/relayclient/GSNConfigurator'
 import { defaultEnvironment } from '../src/common/Environments'
+require('source-map-support').install({ errorFormatterForce: true })
 
 const { expect, assert } = chai.use(chaiAsPromised)
 
@@ -53,6 +57,14 @@ contract('Utils', function (accounts) {
       const relayWorker = accounts[9]
       const paymasterData = '0x'
       const clientId = '0'
+
+      const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
+      const res1 = await forwarderInstance.registerDomainSeparator(prefix, dataPrefix)
+      console.log(res1.logs[0])
+      const { domainSeparator } = res1.logs[0].args
+
+      // sanity check: our locally-calculated domain-separator is the same as on-chain registered domain-separator
+      assert.equal(domainSeparator, getDomainSeparatorHash(forwarder, chainId))
 
       const res = await forwarderInstance.registerRequestType(
         GsnRequestType.typeName,
@@ -105,6 +117,12 @@ contract('Utils', function (accounts) {
     it('library constants should match RelayHub eip712 constants', async function () {
       assert.equal(GsnRequestType.typeName, await testUtil.libRelayRequestName())
       assert.equal(GsnRequestType.typeSuffix, await testUtil.libRelayRequestSuffix())
+
+      const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
+      const res1 = await forwarderInstance.registerDomainSeparator(prefix, dataPrefix)
+      console.log(res1.logs[0])
+      const { domainSeparator } = res1.logs[0].args
+      assert.equal(domainSeparator, await testUtil.libDomainSeparator(forwarder))
 
       const res = await forwarderInstance.registerRequestType(
         GsnRequestType.typeName,

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -8,8 +8,8 @@ import { HttpProvider } from 'web3-core'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
 import TypedRequestData, {
-  getDomainSeparatorHash, getRegisterDomainSeparatorData,
-  GsnRequestType
+  getDomainSeparatorHash,
+  GsnDomainSeparatorType, GsnRequestType
 } from '../src/common/EIP712/TypedRequestData'
 import { expectEvent } from '@openzeppelin/test-helpers'
 import { ForwarderInstance, TestRecipientInstance, TestUtilInstance } from '../types/truffle-contracts'
@@ -58,8 +58,7 @@ contract('Utils', function (accounts) {
       const paymasterData = '0x'
       const clientId = '0'
 
-      const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
-      const res1 = await forwarderInstance.registerDomainSeparator(prefix, dataPrefix)
+      const res1 = await forwarderInstance.registerDomainSeparator(GsnDomainSeparatorType.name, GsnDomainSeparatorType.version)
       console.log(res1.logs[0])
       const { domainSeparator } = res1.logs[0].args
 
@@ -118,8 +117,7 @@ contract('Utils', function (accounts) {
       assert.equal(GsnRequestType.typeName, await testUtil.libRelayRequestName())
       assert.equal(GsnRequestType.typeSuffix, await testUtil.libRelayRequestSuffix())
 
-      const { prefix, dataPrefix } = getRegisterDomainSeparatorData()
-      const res1 = await forwarderInstance.registerDomainSeparator(prefix, dataPrefix)
+      const res1 = await forwarderInstance.registerDomainSeparator(GsnDomainSeparatorType.name, GsnDomainSeparatorType.version)
       console.log(res1.logs[0])
       const { domainSeparator } = res1.logs[0].args
       assert.equal(domainSeparator, await testUtil.libDomainSeparator(forwarder))

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -15,7 +15,7 @@ import { prepareTransaction } from './RelayProvider.test'
 import sinon from 'sinon'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { RelayRegisteredEventInfo } from '../../src/relayclient/types/RelayRegisteredEventInfo'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -77,10 +77,7 @@ contract('KnownRelaysManager', function (
       const forwarderInstance = await Forwarder.new()
       const forwarderAddress = forwarderInstance.address
       testRecipient = await TestRecipient.new(forwarderAddress)
-      await forwarderInstance.registerRequestType(
-        GsnRequestType.typeName,
-        GsnRequestType.typeSuffix
-      )
+      await registerForwarderForGsn(forwarderInstance)
 
       paymaster = await TestPaymasterConfigurableMisbehavior.new()
       await paymaster.setTrustedForwarder(forwarderAddress)

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -27,7 +27,7 @@ import BadRelayedTransactionValidator from '../dummies/BadRelayedTransactionVali
 import { deployHub, startRelay, stopRelay } from '../TestUtils'
 import { RelayInfo } from '../../src/relayclient/types/RelayInfo'
 import PingResponse from '../../src/common/PingResponse'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -65,10 +65,8 @@ contract('RelayClient', function (accounts) {
     forwarderAddress = forwarderInstance.address
     testRecipient = await TestRecipient.new(forwarderAddress)
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
+
     paymaster = await TestPaymasterEverythingAccepted.new()
     await paymaster.setTrustedForwarder(forwarderAddress)
     await paymaster.setRelayHub(relayHub.address)

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -23,7 +23,8 @@ import BadRelayClient from '../dummies/BadRelayClient'
 
 import { getEip712Signature } from '../../src/common/Utils'
 import RelayRequest from '../../src/common/EIP712/RelayRequest'
-import TypedRequestData, { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import TypedRequestData from '../../src/common/EIP712/TypedRequestData'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
 
@@ -96,10 +97,7 @@ contract('RelayProvider', function (accounts) {
     relayHub = await deployHub(stakeManager.address)
     const forwarderInstance = await Forwarder.new()
     forwarderAddress = forwarderInstance.address
-    await forwarderInstance.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarderInstance)
 
     paymasterInstance = await TestPaymasterEverythingAccepted.new()
     paymaster = paymasterInstance.address

--- a/test/relayserver/RelayServer.test.ts
+++ b/test/relayserver/RelayServer.test.ts
@@ -24,7 +24,6 @@ import {
   TestPaymasterEverythingAcceptedInstance
 } from '../../types/truffle-contracts'
 import { configureGSN, GSNConfig } from '../../src/relayclient/GSNConfigurator'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
 
 import { deployHub, evmMine, evmMineMany, revert, snapshot } from '../TestUtils'
 import {
@@ -44,6 +43,7 @@ import { sleep } from '../../src/common/Utils'
 import { TxStoreManager } from '../../src/relayserver/TxStoreManager'
 import ContractInteractor from '../../src/relayclient/ContractInteractor'
 import { KeyManager } from '../../src/relayserver/KeyManager'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const { expect, assert } = chai.use(chaiAsPromised).use(sinonChai)
 
@@ -98,10 +98,7 @@ contract('RelayServer', function (accounts) {
     const sr = await TestRecipient.new(forwarderAddress)
     paymaster = await TestPaymasterEverythingAccepted.new()
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarder.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarder)
 
     await paymaster.setTrustedForwarder(forwarderAddress)
     await paymaster.setRelayHub(rhub.address)

--- a/test/relayserver/RelayServerRequestsProfiling.test.ts
+++ b/test/relayserver/RelayServerRequestsProfiling.test.ts
@@ -14,7 +14,7 @@ import { HttpProvider } from 'web3-core'
 import { ProfilingProvider } from '../../src/common/dev/ProfilingProvider'
 import { Address } from '../../src/relayclient/types/Aliases'
 import { RelayClient } from '../../src/relayclient/RelayClient'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -93,10 +93,7 @@ contract('RelayServerRequestsProfiling', function ([relayOwner]) {
       gasLess = await web3.eth.personal.newAccount('password')
       const forwarder = await Forwarder.new()
       // register hub's RelayRequest with forwarder, if not already done.
-      await forwarder.registerRequestType(
-        GsnRequestType.typeName,
-        GsnRequestType.typeSuffix
-      )
+      await registerForwarderForGsn(forwarder)
 
       const forwarderAddress = forwarder.address
 

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -19,7 +19,6 @@ import {
 import ContractInteractor from '../../src/relayclient/ContractInteractor'
 import GsnTransactionDetails from '../../src/relayclient/types/GsnTransactionDetails'
 import PingResponse from '../../src/common/PingResponse'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
 import { KeyManager } from '../../src/relayserver/KeyManager'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { RelayClient } from '../../src/relayclient/RelayClient'
@@ -36,6 +35,7 @@ import { RelayTransactionRequest } from '../../src/relayclient/types/RelayTransa
 import RelayHubABI from '../../src/common/interfaces/IRelayHub.json'
 import StakeManagerABI from '../../src/common/interfaces/IStakeManager.json'
 import PayMasterABI from '../../src/common/interfaces/IPaymaster.json'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const Forwarder = artifacts.require('Forwarder')
 const StakeManager = artifacts.require('StakeManager')
@@ -103,11 +103,7 @@ export class ServerTestEnvironment {
     this.forwarder = await Forwarder.new()
     this.recipient = await TestRecipient.new(this.forwarder.address)
     this.paymaster = await TestPaymasterEverythingAccepted.new()
-    // register hub's RelayRequest with forwarder, if not already done.
-    await this.forwarder.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(this.forwarder)
 
     await this.paymaster.setTrustedForwarder(this.forwarder.address)
     await this.paymaster.setRelayHub(this.relayHub.address)

--- a/test/relayserver/TransactionManager.test.ts
+++ b/test/relayserver/TransactionManager.test.ts
@@ -19,8 +19,8 @@ import Web3 from 'web3'
 import { HttpProvider } from 'web3-core'
 import { RelayClient } from '../../src/relayclient/RelayClient'
 import { TestPaymasterEverythingAcceptedInstance } from '../../types/truffle-contracts'
-import { GsnRequestType } from '../../src/common/EIP712/TypedRequestData'
 import { GSNConfig } from '../../src/relayclient/GSNConfigurator'
+import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -53,10 +53,7 @@ contract('TransactionManager', function (accounts) {
     const penalizer = await Penalizer.new()
     const forwarder = await Forwarder.new()
     // register hub's RelayRequest with forwarder, if not already done.
-    await forwarder.registerRequestType(
-      GsnRequestType.typeName,
-      GsnRequestType.typeSuffix
-    )
+    await registerForwarderForGsn(forwarder)
 
     const rhub = await deployHub(stakeManager.address, penalizer.address)
     const relayHubAddress = rhub.address


### PR DESCRIPTION
Without it, requests from one forwarder can be replayed through another forwarder (on the same network, or on another network)
By registering the domainSeparator, the forwarder can verify it appears in it as the verifyingContract, and that the chainId is valid.