### PR TITLE
relayer 2.0.0-beta.2

### DIFF
--- a/dockers/jsrelay/Dockerfile
+++ b/dockers/jsrelay/Dockerfile
@@ -1,3 +1,3 @@
 FROM node:13-buster-slim
 COPY dist/relayserver.js app/
-CMD node /app/relayserver.js
+CMD node --no-deprecation /app/relayserver.js

--- a/dockers/relaydc/docker-compose.yml
+++ b/dockers/relaydc/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 #### make sure to add instance name to the router command above
 
   gsn1:
-    image: opengsn/jsrelay:2.0.0-beta.1
+    image: opengsn/jsrelay:2.0.0-beta.2
     restart: on-failure
 
     # $ROOT - mapped by calling script to data folder

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-beta.1.3",
+  "version": "2.0.0-beta.2",
   "description": "Open Gas Stations Network",
   "name": "@opengsn/gsn",
   "license": "MIT",

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -36,6 +36,8 @@ import { toBN } from 'web3-utils'
 import TruffleContract = require('@truffle/contract')
 import Contract = Truffle.Contract
 
+require('source-map-support').install({ errorFormatterForce: true })
+
 type EventName = string
 
 export const RelayServerRegistered: EventName = 'RelayServerRegistered'
@@ -52,7 +54,7 @@ export const StakeUnlocked: EventName = 'StakeUnlocked'
 export const StakePenalized: EventName = 'StakePenalized'
 
 export default class ContractInteractor {
-  private readonly VERSION = '2.0.0-beta.1'
+  private readonly VERSION = '2.0.0-beta.2'
 
   private readonly IPaymasterContract: Contract<IPaymasterInstance>
   private readonly IRelayHubContract: Contract<IRelayHubInstance>
@@ -130,7 +132,7 @@ export default class ContractInteractor {
       throw new Error('_init was already called')
     }
     await this._initializeContracts()
-    await this._validateCompatibility()
+    await this._validateCompatibility().catch(err => console.log('WARNING: beta ignore version compatibility', err))
     const chain = await this.web3.eth.net.getNetworkType()
     this.chainId = await this.web3.eth.getChainId()
     this.networkId = await this.web3.eth.net.getId()

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -27,7 +27,7 @@ import { SendTransactionDetails, TransactionManager } from './TransactionManager
 import { configureServer, ServerConfigParams, ServerDependencies } from './ServerConfigParams'
 import Timeout = NodeJS.Timeout
 
-const VERSION = '2.0.0-beta.1'
+const VERSION = '2.0.0-beta.2'
 const GAS_RESERVE = 100000
 
 export class RelayServer extends EventEmitter {
@@ -323,10 +323,7 @@ export class RelayServer extends EventEmitter {
     } else {
       log.debug('code length', code.length)
     }
-    const version = await this.relayHubContract.versionHub().catch(_ => 'no getVersion() method')
-    if (!this.versionManager.isMinorSameOrNewer(version)) {
-      this.fatal(`Not a valid RelayHub at ${relayHubAddress}: version: ${version}`)
-    }
+
     this.registrationManager = new RegistrationManager(
       this.contractInteractor,
       this.transactionManager,

--- a/test/relayclient/ContractInteractor.test.ts
+++ b/test/relayclient/ContractInteractor.test.ts
@@ -16,7 +16,7 @@ contract('ContractInteractor', function () {
   })
 
   context('#_validateCompatibility()', function () {
-    it('should throw if the hub version is incompatible', async function () {
+    it.skip('should throw if the hub version is incompatible', async function () {
       const relayClient = new RelayClient(web3.currentProvider as HttpProvider, {
         relayHubAddress: testVersions.address
       })


### PR DESCRIPTION
updated versions to 2.0.0-beta.2
disabled beta version checking (so beta.2 relayer will work with existing deployed beta.1 hub)
(a separate issue is to fix our versioning check)