### PR TITLE
OG-232 Relayer withdraws too early on HubUnauthorized.

### DIFF
--- a/src/relayserver/RegistrationManager.ts
+++ b/src/relayserver/RegistrationManager.ts
@@ -211,14 +211,14 @@ export class RegistrationManager {
 
   /**
    * @param withdrawManager - whether to send the relay manager's balance to the owner.
-   *        Note that more then one relay process could be using the same manager account.
+   *        Note that more than one relay process could be using the same manager account.
    * @param currentBlock
    */
   async withdrawAllFunds (withdrawManager: boolean, currentBlock: number): Promise<TransactionReceipt[]> {
     let receipts: TransactionReceipt[] = []
-    receipts = receipts.concat(await this._sendManagerHubBalanceToOwner(currentBlock))
     receipts = receipts.concat(await this._sendWorkersEthBalancesToOwner(currentBlock))
     if (withdrawManager) {
+      receipts = receipts.concat(await this._sendManagerHubBalanceToOwner(currentBlock))
       receipts = receipts.concat(await this._sendManagerEthBalanceToOwner(currentBlock))
     }
 

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -312,7 +312,7 @@ contract('RegistrationManager', function (accounts) {
         await revert(id)
       })
 
-      it('send only manager hub balance and workers\' balances to owner (not manager eth balance)', async function () {
+      it('send only workers\' balances to owner (not manager hub,eth balance)', async function () {
         await env.stakeManager.unauthorizeHubByOwner(newServer.managerAddress, env.relayHub.address, { from: relayOwner })
 
         const managerHubBalanceBefore = await env.relayHub.balanceOf(newServer.managerAddress)
@@ -328,21 +328,20 @@ contract('RegistrationManager', function (accounts) {
         assert.isFalse(newServer.registrationManager.isHubAuthorized, 'Hub should not be authorized in server')
         const gasPrice = await env.web3.eth.getGasPrice()
         // TODO: these two hard-coded indexes are dependent on the order of operations in 'withdrawAllFunds'
-        const workerEthTxCost = getTotalTxCosts([receipts[1]], gasPrice)
-        const managerHubSendTxCost = getTotalTxCosts([receipts[0]], gasPrice)
+        const workerEthTxCost = getTotalTxCosts([receipts[0]], gasPrice)
         const ownerBalanceAfter = toBN(await env.web3.eth.getBalance(relayOwner))
         const managerHubBalanceAfter = await env.relayHub.balanceOf(newServer.managerAddress)
         const managerBalanceAfter = await newServer.getManagerBalance()
         const workerBalanceAfter = await newServer.getWorkerBalance(workerIndex)
-        assert.isTrue(managerHubBalanceAfter.eqn(0))
+        assert.equal(managerHubBalanceAfter.toString(), managerHubBalanceBefore.toString())
         assert.isTrue(workerBalanceAfter.eqn(0))
-        assert.equal(managerBalanceAfter.toString(), managerBalanceBefore.sub(managerHubSendTxCost).toString())
+        assert.equal(managerBalanceAfter.toString(), managerBalanceBefore.toString())
         assert.equal(
           ownerBalanceAfter.sub(
             ownerBalanceBefore).toString(),
-          managerHubBalanceBefore.add(workerBalanceBefore).sub(workerEthTxCost).toString(),
+          workerBalanceBefore.sub(workerEthTxCost).toString(),
           `ownerBalanceAfter(${ownerBalanceAfter.toString()}) - ownerBalanceBefore(${ownerBalanceBefore.toString()}) != 
-         managerHubBalanceBefore(${managerHubBalanceBefore.toString()}) + workerBalanceBefore(${workerBalanceBefore.toString()})
+         workerBalanceBefore(${workerBalanceBefore.toString()})
          - workerEthTxCost(${workerEthTxCost.toString()})`)
       })
     })


### PR DESCRIPTION
1. relayer should wait the unstakeDelay (as specified in the event before withdraw)
2. only withdraw worker balances on HubUnauthorized, not manager's stake or deposit (as it is shared with other relayer instances)
3. delay withdrawals also for StakeUnlocked event.