### PR TITLE
OG-187 withdraw too early

### DIFF
--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -51,6 +51,7 @@ export const HubAuthorized: EventName = 'HubAuthorized'
 export const HubUnauthorized: EventName = 'HubUnauthorized'
 export const StakeAdded: EventName = 'StakeAdded'
 export const StakeUnlocked: EventName = 'StakeUnlocked'
+export const StakeWithdrawn: EventName = 'StakeWithdrawn'
 export const StakePenalized: EventName = 'StakePenalized'
 
 export default class ContractInteractor {

--- a/src/relayserver/RegistrationManager.ts
+++ b/src/relayserver/RegistrationManager.ts
@@ -193,9 +193,10 @@ export class RegistrationManager {
   }
 
   async _handleHubUnauthorizedEvent (dlog: EventData, currentBlock: number): Promise<TransactionReceipt[]> {
-    if (dlog.returnValues.relayHub.toLowerCase() === this.hubAddress.toLowerCase()) {
-      this.isHubAuthorized = false
+    if (dlog.returnValues.relayHub.toLowerCase() !== this.hubAddress.toLowerCase()) {
+      return []
     }
+    this.isHubAuthorized = false
     return await this.withdrawAllFunds(false, currentBlock)
   }
 
@@ -211,7 +212,7 @@ export class RegistrationManager {
 
   /**
    * @param withdrawManager - whether to send the relay manager's balance to the owner.
-   *        Note that more then one relay process could be using the same manager account.
+   *        Note that more than one relay process could be using the same manager account.
    * @param currentBlock
    */
   async withdrawAllFunds (withdrawManager: boolean, currentBlock: number): Promise<TransactionReceipt[]> {

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -12,6 +12,7 @@ import { configureGSN } from '../src/relayclient/GSNConfigurator'
 import { defaultEnvironment } from '../src/common/Environments'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { sleep } from '../src/common/Utils'
+import { RelayHubConfiguration } from '../src/relayclient/types/RelayHubConfiguration'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -220,17 +221,22 @@ export function encodeRevertReason (reason: string): PrefixedHexString {
 
 export async function deployHub (
   stakeManager: string = constants.ZERO_ADDRESS,
-  penalizer: string = constants.ZERO_ADDRESS): Promise<RelayHubInstance> {
+  penalizer: string = constants.ZERO_ADDRESS,
+  configOverride: Partial<RelayHubConfiguration> = {}): Promise<RelayHubInstance> {
+  const relayHubConfiguration: RelayHubConfiguration = {
+    ...defaultEnvironment.relayHubConfiguration,
+    ...configOverride
+  }
   return await RelayHub.new(
     stakeManager,
     penalizer,
-    defaultEnvironment.relayHubConfiguration.maxWorkerCount,
-    defaultEnvironment.relayHubConfiguration.gasReserve,
-    defaultEnvironment.relayHubConfiguration.postOverhead,
-    defaultEnvironment.relayHubConfiguration.gasOverhead,
-    defaultEnvironment.relayHubConfiguration.maximumRecipientDeposit,
-    defaultEnvironment.relayHubConfiguration.minimumUnstakeDelay,
-    defaultEnvironment.relayHubConfiguration.minimumStake)
+    relayHubConfiguration.maxWorkerCount,
+    relayHubConfiguration.gasReserve,
+    relayHubConfiguration.postOverhead,
+    relayHubConfiguration.gasOverhead,
+    relayHubConfiguration.maximumRecipientDeposit,
+    relayHubConfiguration.minimumUnstakeDelay,
+    relayHubConfiguration.minimumStake)
 }
 
 /**

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -10,7 +10,7 @@ import { TxStoreManager } from '../../src/relayserver/TxStoreManager'
 import ContractInteractor from '../../src/relayclient/ContractInteractor'
 import { configureGSN } from '../../src/relayclient/GSNConfigurator'
 import { RelayServer } from '../../src/relayserver/RelayServer'
-import { revert, snapshot } from '../TestUtils'
+import { evmMineMany, revert, snapshot } from '../TestUtils'
 import { constants } from '../../src/common/Constants'
 import {
   assertRelayAdded,
@@ -19,12 +19,14 @@ import {
 } from './ServerTestUtils'
 import { ServerConfigParams, ServerDependencies } from '../../src/relayserver/ServerConfigParams'
 import { LocalhostOne, ServerTestEnvironment } from './ServerTestEnvironment'
+import { RegistrationManager } from '../../src/relayserver/RegistrationManager'
 
 const { expect } = chai.use(chaiAsPromised).use(sinonChai)
-const { oneEther, weekInSec } = constants
+const { oneEther } = constants
 
 const workerIndex = 0
 
+const unstakeDelay = 50
 contract('RegistrationManager', function (accounts) {
   const relayOwner = accounts[4]
   const anotherRelayer = accounts[5]
@@ -37,7 +39,7 @@ contract('RegistrationManager', function (accounts) {
   before(async function () {
     serverWorkdirs = getTemporaryWorkdirs()
     env = new ServerTestEnvironment(web3.currentProvider as HttpProvider, accounts)
-    await env.init()
+    await env.init({}, { minimumUnstakeDelay: unstakeDelay })
     env.newServerInstanceNoFunding({}, serverWorkdirs)
     await env.clearServerStorage()
     relayServer = env.relayServer
@@ -71,7 +73,7 @@ contract('RegistrationManager', function (accounts) {
         relayServer._worker(latestBlock.number)
       ).to.be.eventually.rejectedWith('Stake too low - actual:')
       assert.equal(relayServer.ready, false, 'relay should not be ready yet')
-      const res = await env.stakeManager.stakeForAddress(relayServer.managerAddress, weekInSec, {
+      const res = await env.stakeManager.stakeForAddress(relayServer.managerAddress, unstakeDelay, {
         from: relayOwner,
         value: oneEther
       })
@@ -136,7 +138,7 @@ contract('RegistrationManager', function (accounts) {
 
     let newServer: RelayServer
     it('should initialize relay after staking and funding it', async function () {
-      await env.newServerInstanceNoInit()
+      await env.newServerInstanceNoInit({}, undefined, unstakeDelay)
       newServer = env.relayServer
       await newServer.init()
       assert.equal(newServer.registrationManager.ownerAddress, undefined)
@@ -173,7 +175,7 @@ contract('RegistrationManager', function (accounts) {
     let relayServer: RelayServer
 
     before(async function () {
-      await env.newServerInstanceNoInit()
+      await env.newServerInstanceNoInit({}, undefined, unstakeDelay)
       relayServer = env.relayServer
     })
 
@@ -236,13 +238,14 @@ contract('RegistrationManager', function (accounts) {
       let newServer: RelayServer
       beforeEach(async function () {
         id = (await snapshot()).result
-        await env.newServerInstanceNoInit({ refreshStateTimeoutBlocks: 1 })
+        await env.newServerInstanceNoInit({ refreshStateTimeoutBlocks: 1 }, undefined, unstakeDelay)
         newServer = env.relayServer
         const latestBlock = await env.web3.eth.getBlock('latest')
         await newServer._worker(latestBlock.number)
 
         await env.relayHub.depositFor(newServer.managerAddress, { value: 1e18.toString() })
         await env.stakeManager.unlockStake(newServer.managerAddress, { from: relayOwner })
+        await evmMineMany(unstakeDelay)
       })
 
       afterEach(async function () {
@@ -283,7 +286,7 @@ contract('RegistrationManager', function (accounts) {
       let newServer: RelayServer
       beforeEach(async function () {
         id = (await snapshot()).result
-        await env.newServerInstanceNoInit()
+        await env.newServerInstanceNoInit({}, undefined, unstakeDelay)
         newServer = env.relayServer
       })
 
@@ -302,7 +305,7 @@ contract('RegistrationManager', function (accounts) {
       let newServer: RelayServer
       beforeEach(async function () {
         id = (await snapshot()).result
-        await env.newServerInstanceNoInit({ refreshStateTimeoutBlocks: 1 })
+        await env.newServerInstanceNoInit({ refreshStateTimeoutBlocks: 1 }, undefined, unstakeDelay)
         newServer = env.relayServer
         const latestBlock = await env.web3.eth.getBlock('latest')
         await newServer._worker(latestBlock.number)
@@ -312,7 +315,6 @@ contract('RegistrationManager', function (accounts) {
       afterEach(async function () {
         await revert(id)
       })
-
       it('should ignore unauthorizeHub of another hub', async function () {
         await env.stakeManager.stakeForAddress(anotherRelayer, 1000)
         await env.stakeManager.authorizeHubByManager(env.relayHub.address, {from:anotherRelayer})
@@ -327,7 +329,20 @@ contract('RegistrationManager', function (accounts) {
         assert.equal(workerBalanceBefore.toString(), workerBalanceAfter.toString())
       });
 
-      it('send only manager hub balance and workers\' balances to owner (not manager eth balance)', async function () {
+      it('should not send balance immediately after unauthorize (before unstake delay)', async function () {
+        await env.stakeManager.unauthorizeHubByOwner(newServer.managerAddress, env.relayHub.address, { from: relayOwner })
+        const workerBalanceBefore = await newServer.getWorkerBalance(workerIndex)
+
+        await evmMineMany(unstakeDelay - 3)
+        const latestBlock = await env.web3.eth.getBlock('latest')
+
+        const receipt = await newServer._worker(latestBlock.number)
+
+        assert.equal(receipt.length, 0)
+        assert.equal(workerBalanceBefore.toString(), await newServer.getWorkerBalance(workerIndex).then(b => b.toString()))
+      })
+
+      it('send only workers\' balances to owner (not manager hub,eth balance) - after unstake delay', async function () {
         await env.stakeManager.unauthorizeHubByOwner(newServer.managerAddress, env.relayHub.address, { from: relayOwner })
 
         const managerHubBalanceBefore = await env.relayHub.balanceOf(newServer.managerAddress)
@@ -338,6 +353,7 @@ contract('RegistrationManager', function (accounts) {
         assert.isTrue(workerBalanceBefore.gtn(0))
         const ownerBalanceBefore = toBN(await env.web3.eth.getBalance(relayOwner))
         assert.isTrue(newServer.registrationManager.isHubAuthorized, 'Hub should be authorized in server')
+        await evmMineMany(unstakeDelay)
         const latestBlock = await env.web3.eth.getBlock('latest')
         const receipts = await newServer._worker(latestBlock.number)
         assert.isFalse(newServer.registrationManager.isHubAuthorized, 'Hub should not be authorized in server')
@@ -365,13 +381,37 @@ contract('RegistrationManager', function (accounts) {
     it('_handleStakedEvent')
   })
 
+  describe('#_extractDuePendingEvents', () => {
+    let rm: RegistrationManager
+    let extracted: any[]
+
+    before(async () => {
+      // @ts-ignore
+      if (!relayServer.initialized) await relayServer.init()
+
+      rm = relayServer.registrationManager;
+
+      (rm as any).delayedEvents = [
+        { block: 1, eventData: 'event1' },
+        { block: 2, eventData: 'event2' },
+        { block: 3, eventData: 'event3' }
+      ]
+      extracted = rm._extractDuePendingEvents(2) as any
+    })
+    it('should extract events which are due (lower or equal block number)', function () {
+      assert.deepEqual(extracted, ['event1', 'event2'])
+    })
+    it('should should future events in the delayedEvents list', function () {
+      assert.deepEqual((rm as any).delayedEvents, [{ block: 3, eventData: 'event3' }])
+    })
+  })
   describe('#attemptRegistration()', function () {
     let newServer: RelayServer
 
     describe('without re-registration', function () {
       beforeEach(async function () {
         id = (await snapshot()).result
-        await env.newServerInstanceNoInit()
+        await env.newServerInstanceNoInit({}, undefined, unstakeDelay)
         await env.relayServer.init()
         newServer = env.relayServer
         // TODO: this is horrible!!!

--- a/test/relayserver/RelayServerRequestsProfiling.test.ts
+++ b/test/relayserver/RelayServerRequestsProfiling.test.ts
@@ -24,7 +24,7 @@ contract('RelayServerRequestsProfiling', function (accounts) {
       return contractInteractor
     }
     env = new ServerTestEnvironment(web3.currentProvider as HttpProvider, accounts)
-    await env.init({}, contractFactory)
+    await env.init({}, {}, contractFactory)
     await env.newServerInstance({ refreshStateTimeoutBlocks })
     relayServer = env.relayServer
     const latestBlock = await web3.eth.getBlock('latest')


### PR DESCRIPTION
relayer should withdraw funds after only after unstakeDelay
* HubUnauthorized - should wait until the removalBlock event param
* StakeUnlocked - should wait until the withdrawBlock event param

withdrawing any funds from worker before that makes the relayer penalizeable...