### PR TITLE
OG-219 Make RelayServer not wait for the transaction to be mined

### DIFF
--- a/src/common/dev/NetworkSimulatingProvider.ts
+++ b/src/common/dev/NetworkSimulatingProvider.ts
@@ -1,0 +1,82 @@
+import { PrefixedHexString } from 'ethereumjs-tx'
+import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
+import web3Utils from 'web3-utils'
+
+import { WrapperProviderBase } from './WrapperProviderBase'
+import { SendCallback } from './SendCallback'
+import { HttpProvider } from 'web3-core'
+
+export class NetworkSimulatingProvider extends WrapperProviderBase {
+  private isDelayTransactionsOn = false
+
+  mempool = new Map<PrefixedHexString, JsonRpcPayload>()
+
+  public constructor (provider: HttpProvider) {
+    super(provider)
+  }
+
+  setDelayTransactions (delayTransactions: boolean): void {
+    this.isDelayTransactionsOn = delayTransactions
+  }
+
+  calculateTxHash (payload: JsonRpcPayload): PrefixedHexString {
+    const txHash = web3Utils.sha3(payload.params[0])
+    if (txHash == null) {
+      throw new Error('Failed to hash transaction')
+    }
+    return txHash
+  }
+
+  send (payload: JsonRpcPayload, callback: SendCallback): void {
+    let resp: JsonRpcResponse | undefined
+    switch (payload.method) {
+      case 'eth_sendRawTransaction':
+        if (this.isDelayTransactionsOn) {
+          const txHash = this.calculateTxHash(payload)
+          resp = {
+            jsonrpc: '2.0',
+            id: castId(payload.id),
+            result: txHash
+          }
+          this.mempool.set(txHash, payload)
+        }
+        break
+    }
+    if (resp != null) {
+      callback(null, resp)
+    } else {
+      this.provider.send(payload, callback)
+    }
+  }
+
+  supportsSubscriptions (): boolean {
+    return false
+  }
+
+  async mineTransaction (txHash: PrefixedHexString): Promise<any> {
+    const txPayload: JsonRpcPayload | undefined = this.mempool.get(txHash)
+    this.mempool.delete(txHash)
+    return await new Promise((resolve, reject) => {
+      if (txPayload == null) {
+        throw new Error('Transaction is not in simulated mempool. It must be already mined')
+      }
+      this.provider.send(txPayload, function (error: (Error | null), result?: JsonRpcResponse) {
+        if (error != null || result == null) {
+          reject(error)
+        } else {
+          resolve(result)
+        }
+      })
+    })
+  }
+}
+
+function castId (id: string | number | undefined): number {
+  if (typeof id === 'string') {
+    return parseInt(id)
+  } else if (typeof id === 'number') {
+    return id
+  } else {
+    return 0
+  }
+}

--- a/src/common/dev/SendCallback.ts
+++ b/src/common/dev/SendCallback.ts
@@ -1,0 +1,3 @@
+import { JsonRpcResponse } from 'web3-core-helpers'
+
+export type SendCallback = (error: (Error | null), result?: JsonRpcResponse) => void

--- a/src/common/dev/WrapperProviderBase.ts
+++ b/src/common/dev/WrapperProviderBase.ts
@@ -1,0 +1,29 @@
+import { HttpProvider } from 'web3-core'
+import { SendCallback } from './SendCallback'
+import { JsonRpcPayload } from 'web3-core-helpers'
+
+export abstract class WrapperProviderBase implements HttpProvider {
+  provider: HttpProvider
+
+  protected constructor (provider: HttpProvider) {
+    this.provider = provider
+  }
+
+  get connected (): boolean {
+    return this.provider.connected
+  }
+
+  get host (): string {
+    return this.provider.host
+  }
+
+  disconnect (): boolean {
+    return this.provider.disconnect()
+  }
+
+  abstract send (payload: JsonRpcPayload, callback: SendCallback): void
+
+  supportsSubscriptions (): boolean {
+    return this.provider.supportsSubscriptions()
+  }
+}

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -1,5 +1,13 @@
 import Web3 from 'web3'
-import { BlockNumber, provider, Transaction, TransactionReceipt } from 'web3-core'
+import {
+  BlockNumber,
+  HttpProvider,
+  IpcProvider,
+  provider,
+  Transaction,
+  TransactionReceipt,
+  WebsocketProvider
+} from 'web3-core'
 import { EventData, PastEventOptions } from 'web3-eth-contract'
 import { PrefixedHexString, TransactionOptions } from 'ethereumjs-tx'
 
@@ -53,6 +61,11 @@ export const StakeAdded: EventName = 'StakeAdded'
 export const StakeUnlocked: EventName = 'StakeUnlocked'
 export const StakePenalized: EventName = 'StakePenalized'
 
+export type Web3Provider =
+  | HttpProvider
+  | IpcProvider
+  | WebsocketProvider
+
 export default class ContractInteractor {
   private readonly VERSION = '2.0.0-beta.2'
 
@@ -70,8 +83,8 @@ export default class ContractInteractor {
   private relayRecipientInstance?: BaseRelayRecipientInstance
   private knowForwarderAddressInstance?: IKnowForwarderAddressInstance
 
-  private readonly web3: Web3
-  private readonly provider: provider
+  readonly web3: Web3
+  private readonly provider: Web3Provider
   private readonly config: GSNConfig
   private readonly versionManager: VersionsManager
 
@@ -80,7 +93,7 @@ export default class ContractInteractor {
   private networkId?: number
   private networkType?: string
 
-  constructor (provider: provider, config: GSNConfig) {
+  constructor (provider: Web3Provider, config: GSNConfig) {
     this.versionManager = new VersionsManager(this.VERSION)
     this.web3 = new Web3(provider)
     this.config = config
@@ -124,8 +137,6 @@ export default class ContractInteractor {
   }
 
   getProvider (): provider { return this.provider }
-
-  getWeb3 (): Web3 { return this.web3 }
 
   async init (): Promise<void> {
     if (this.rawTxOptions != null) {
@@ -420,6 +431,36 @@ export default class ContractInteractor {
   async getAddRelayWorkersMethod (workers: Address[]): Promise<any> {
     const hub = this.relayHubInstance
     return hub.contract.methods.addRelayWorkers(workers)
+  }
+
+  /**
+   * Web3.js as of 1.2.6 (see web3-core-method::_confirmTransaction) does not allow
+   * broadcasting of a transaction without waiting for it to be mined.
+   * This method sends the RPC call directly
+   * @param signedTransaction - the raw signed transaction to broadcast
+   */
+  async broadcastTransaction (signedTransaction: PrefixedHexString): Promise<PrefixedHexString> {
+    return await new Promise((resolve, reject) => {
+      if (this.provider == null) {
+        throw new Error('provider is not set')
+      }
+      this.provider.send({
+        jsonrpc: '2.0',
+        method: 'eth_sendRawTransaction',
+        params: [
+          signedTransaction
+        ],
+        id: Date.now()
+      }, (e: Error | null, r: any) => {
+        if (e != null) {
+          reject(e)
+        } else if (r.error != null) {
+          reject(r.error)
+        } else {
+          resolve(r.result)
+        }
+      })
+    })
   }
 }
 

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -1,7 +1,7 @@
 import { HttpProvider } from 'web3-core'
 import { Address, AsyncDataCallback, AsyncScoreCalculator, IntString, PingFilter, RelayFilter } from './types/Aliases'
 import HttpClient from './HttpClient'
-import ContractInteractor from './ContractInteractor'
+import ContractInteractor, { Web3Provider } from './ContractInteractor'
 import KnownRelaysManager, { DefaultRelayScore, EmptyFilter, IKnownRelaysManager } from './KnownRelaysManager'
 import AccountManager from './AccountManager'
 import RelayedTransactionValidator from './RelayedTransactionValidator'
@@ -47,7 +47,7 @@ export function configureGSN (partialConfig: Partial<GSNConfig>): GSNConfig {
  * @param provider - web3 provider needed to query blockchain
  * @param partialConfig
  */
-export async function resolveConfigurationGSN (provider: provider, partialConfig: Partial<GSNConfig>): Promise<GSNConfig> {
+export async function resolveConfigurationGSN (provider: Web3Provider, partialConfig: Partial<GSNConfig>): Promise<GSNConfig> {
   // @ts-ignore
   if (provider.send == null && provider.sendAsync == null) {
     throw new Error('First param is not a web3 provider')

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -146,9 +146,9 @@ export class RelayClient {
 
   async _isAlreadySubmitted (txHash: string): Promise<boolean> {
     const [txMinedReceipt, pendingBlock] = await Promise.all([
-      this.contractInteractor.getWeb3().eth.getTransactionReceipt(txHash),
+      this.contractInteractor.web3.eth.getTransactionReceipt(txHash),
       // mempool transactions
-      this.contractInteractor.getWeb3().eth.getBlock('pending')
+      this.contractInteractor.web3.eth.getBlock('pending')
     ])
 
     if (txMinedReceipt != null) {

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -3,7 +3,6 @@ import ow from 'ow'
 import { EventData } from 'web3-eth-contract'
 import { EventEmitter } from 'events'
 import { PrefixedHexString } from 'ethereumjs-tx'
-import { TransactionReceipt } from 'web3-core'
 import { toBN, toHex } from 'web3-utils'
 
 import ContractInteractor, { TransactionRejectedByPaymaster } from '../relayclient/ContractInteractor'

--- a/test/Utils.test.ts
+++ b/test/Utils.test.ts
@@ -19,6 +19,7 @@ import { encodeRevertReason } from './TestUtils'
 import CommandsLogic from '../src/cli/CommandsLogic'
 import { configureGSN, GSNConfig, resolveConfigurationGSN } from '../src/relayclient/GSNConfigurator'
 import { defaultEnvironment } from '../src/common/Environments'
+import { Web3Provider } from '../src/relayclient/ContractInteractor'
 require('source-map-support').install({ errorFormatterForce: true })
 
 const { expect, assert } = chai.use(chaiAsPromised)
@@ -210,7 +211,7 @@ contract('Utils', function (accounts) {
         paymasterAddress: deploymentResult.naivePaymasterAddress,
         minGasPrice
       }
-      const resolvedPartialConfig = await resolveConfigurationGSN(web3.currentProvider, partialConfig)
+      const resolvedPartialConfig = await resolveConfigurationGSN(web3.currentProvider as Web3Provider, partialConfig)
       assert.equal(resolvedPartialConfig.paymasterAddress, deploymentResult.naivePaymasterAddress)
       assert.equal(resolvedPartialConfig.relayHubAddress, deploymentResult.relayHubAddress)
       assert.equal(resolvedPartialConfig.minGasPrice, minGasPrice, 'Input value lost')
@@ -219,7 +220,7 @@ contract('Utils', function (accounts) {
 
     it('should throw if no paymaster at address', async function () {
       await expect(resolveConfigurationGSN(
-        web3.currentProvider, {})
+        web3.currentProvider as Web3Provider, {})
       ).to.be.eventually.rejectedWith('Cannot resolve GSN deployment without paymaster address')
     })
   })

--- a/test/dummies/BadContractInteractor.ts
+++ b/test/dummies/BadContractInteractor.ts
@@ -1,4 +1,4 @@
-import ContractInteractor from '../../src/relayclient/ContractInteractor'
+import ContractInteractor, { Web3Provider } from '../../src/relayclient/ContractInteractor'
 import RelayRequest from '../../src/common/EIP712/RelayRequest'
 import { GSNConfig } from '../../src/relayclient/GSNConfigurator'
 import { TransactionReceipt } from 'web3-core'
@@ -9,7 +9,7 @@ export default class BadContractInteractor extends ContractInteractor {
 
   private readonly failValidateARC: boolean
 
-  constructor (provider: provider, config: GSNConfig, failValidateARC: boolean) {
+  constructor (provider: Web3Provider, config: GSNConfig, failValidateARC: boolean) {
     super(provider, config)
     this.failValidateARC = failValidateARC
   }

--- a/test/relayclient/ContractInteractor.test.ts
+++ b/test/relayclient/ContractInteractor.test.ts
@@ -4,6 +4,12 @@ import chaiAsPromised from 'chai-as-promised'
 import { TestVersionsInstance } from '../../types/truffle-contracts'
 import { RelayClient } from '../../src/relayclient/RelayClient'
 import { HttpProvider } from 'web3-core'
+import { ProfilingProvider } from '../../src/common/dev/ProfilingProvider'
+import ContractInteractor from '../../src/relayclient/ContractInteractor'
+import { configureGSN } from '../../src/relayclient/GSNConfigurator'
+import { PrefixedHexString } from 'ethereumjs-tx'
+import Transaction from 'ethereumjs-tx/dist/transaction'
+import { constants } from '../../src/common/Constants'
 
 const { expect } = chai.use(chaiAsPromised)
 
@@ -15,6 +21,7 @@ contract('ContractInteractor', function () {
     testVersions = await TestVersions.new()
   })
 
+  // TODO: these tests create an entire instance of the client to test one method.
   context('#_validateCompatibility()', function () {
     it.skip('should throw if the hub version is incompatible', async function () {
       const relayClient = new RelayClient(web3.currentProvider as HttpProvider, {
@@ -26,6 +33,30 @@ contract('ContractInteractor', function () {
     it('should not throw if the hub address is not configured', async function () {
       const relayClient = new RelayClient(web3.currentProvider as HttpProvider, {})
       await relayClient._init()
+    })
+  })
+
+  context('#broadcastTransaction()', function () {
+    let provider: ProfilingProvider
+    let contractInteractor: ContractInteractor
+    let sampleTransactionHash: PrefixedHexString
+    let sampleTransactionData: PrefixedHexString
+
+    before(async function () {
+      provider = new ProfilingProvider(web3.currentProvider as HttpProvider)
+      contractInteractor = new ContractInteractor(provider, configureGSN({}))
+      const nonce = await web3.eth.getTransactionCount('0xb473D6BE09D0d6a23e1832046dBE258cF6E8635B')
+      const transaction = new Transaction({ to: constants.ZERO_ADDRESS, gasLimit: '0x5208', nonce })
+      transaction.sign(Buffer.from('46e6ef4a356fa3fa3929bf4b59e6b3eb9d0521ea660fd2879c67bd501002ac2b', 'hex'))
+      sampleTransactionData = '0x' + transaction.serialize().toString('hex')
+      sampleTransactionHash = '0x' + transaction.hash(true).toString('hex')
+    })
+
+    it('should sent the transaction to the blockchain directly', async function () {
+      const txHash = await contractInteractor.broadcastTransaction(sampleTransactionData)
+      assert.equal(txHash, sampleTransactionHash)
+      assert.equal(provider.methodsCount.size, 1)
+      assert.equal(provider.methodsCount.get('eth_sendRawTransaction'), 1)
     })
   })
 })

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -29,6 +29,7 @@ import { RelayInfo } from '../../src/relayclient/types/RelayInfo'
 import PingResponse from '../../src/common/PingResponse'
 import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 import { GsnEvent } from '../../src/relayclient/GsnEvents'
+import { Web3Provider } from '../../src/relayclient/ContractInteractor'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -277,7 +278,7 @@ contract('RelayClient', function (accounts) {
     })
 
     it('should return error if view call to \'relayCall()\' fails', async function () {
-      const badContractInteractor = new BadContractInteractor(web3.currentProvider, configureGSN(gsnConfig), true)
+      const badContractInteractor = new BadContractInteractor(web3.currentProvider as Web3Provider, configureGSN(gsnConfig), true)
       const relayClient =
         new RelayClient(underlyingProvider, gsnConfig, { contractInteractor: badContractInteractor })
       await relayClient._init()

--- a/test/relayserver/NetworkSimultaion.test.ts
+++ b/test/relayserver/NetworkSimultaion.test.ts
@@ -1,0 +1,54 @@
+import { ServerTestEnvironment } from './ServerTestEnvironment'
+import { NetworkSimulatingProvider } from '../../src/common/dev/NetworkSimulatingProvider'
+import { HttpProvider } from 'web3-core'
+import { configureGSN, GSNConfig } from '../../src/relayclient/GSNConfigurator'
+import ContractInteractor from '../../src/relayclient/ContractInteractor'
+
+contract('Network Simulation for Relay Server', function (accounts) {
+  let env: ServerTestEnvironment
+  let provider: NetworkSimulatingProvider
+
+  before(async function () {
+    provider = new NetworkSimulatingProvider(web3.currentProvider as HttpProvider)
+    const contractFactory = async function (partialConfig: Partial<GSNConfig>): Promise<ContractInteractor> {
+      const contractInteractor = new ContractInteractor(provider, configureGSN(partialConfig))
+      await contractInteractor.init()
+      return contractInteractor
+    }
+    env = new ServerTestEnvironment(web3.currentProvider as HttpProvider, accounts)
+    await env.init({}, contractFactory)
+    await env.newServerInstance()
+    provider.setDelayTransactions(true)
+  })
+
+  describe('without automated mining', function () {
+    beforeEach(async function () {
+      await env.clearServerStorage()
+    })
+
+    it('should resolve once the transaction is broadcast', async function () {
+      assert.equal(provider.mempool.size, 0)
+      const { txHash } = await env.relayTransaction(false)
+      assert.equal(provider.mempool.size, 1)
+      const receipt = await env.web3.eth.getTransactionReceipt(txHash)
+      assert.isNull(receipt)
+      await provider.mineTransaction(txHash)
+      assert.equal(provider.mempool.size, 0)
+      await env.assertTransactionRelayed(txHash)
+    })
+
+    it('should broadcast multiple transactions at once', async function () {
+      assert.equal(provider.mempool.size, 0)
+      // cannot use the same sender as it will create same request with same forwarder nonce, etc
+      const overrideDetails = { from: accounts[1] }
+      // noinspection ES6MissingAwait - done on purpose
+      const promises = [env.relayTransaction(false), env.relayTransaction(false, overrideDetails)]
+      const txs = await Promise.all(promises)
+      assert.equal(provider.mempool.size, 2)
+      await provider.mineTransaction(txs[0].txHash)
+      await env.assertTransactionRelayed(txs[0].txHash)
+      await provider.mineTransaction(txs[1].txHash)
+      await env.assertTransactionRelayed(txs[1].txHash, overrideDetails)
+    })
+  })
+})

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -179,22 +179,22 @@ contract('RegistrationManager', function (accounts) {
     it('should re-register server with new configuration', async function () {
       const latestBlock = await env.web3.eth.getBlock('latest')
       const receipts = await relayServer._worker(latestBlock.number)
-      assertRelayAdded(receipts, relayServer)
+      await assertRelayAdded(receipts, relayServer)
 
       let pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
-      assert.equal(pastEventsResult.receipts.length, 0, 'should not re-register if already registered')
+      assert.equal(pastEventsResult.transactionHashes.length, 0, 'should not re-register if already registered')
 
       relayServer.config.baseRelayFee = (parseInt(relayServer.config.baseRelayFee) + 1).toString()
       pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
-      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+      await assertRelayAdded(pastEventsResult.transactionHashes, relayServer, false)
 
       relayServer.config.pctRelayFee++
       pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
-      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+      await assertRelayAdded(pastEventsResult.transactionHashes, relayServer, false)
 
       relayServer.config.url = 'fakeUrl'
       pastEventsResult = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
-      assertRelayAdded(pastEventsResult.receipts, relayServer, false)
+      await assertRelayAdded(pastEventsResult.transactionHashes, relayServer, false)
     })
   })
 
@@ -212,7 +212,7 @@ contract('RegistrationManager', function (accounts) {
         // assert.equal(newServer.config.withdrawBlock?.toString(), '0')
         const latestBlock = await env.web3.eth.getBlock('latest')
         const receipts = await newServer._worker(latestBlock.number)
-        const totalTxCosts = getTotalTxCosts(receipts, gasPrice)
+        const totalTxCosts = await getTotalTxCosts(receipts, gasPrice)
         const ownerBalanceAfter = toBN(await env.web3.eth.getBalance(newServer.registrationManager.ownerAddress!))
         assert.equal(
           ownerBalanceAfter.sub(
@@ -328,8 +328,8 @@ contract('RegistrationManager', function (accounts) {
         assert.isFalse(newServer.registrationManager.isHubAuthorized, 'Hub should not be authorized in server')
         const gasPrice = await env.web3.eth.getGasPrice()
         // TODO: these two hard-coded indexes are dependent on the order of operations in 'withdrawAllFunds'
-        const workerEthTxCost = getTotalTxCosts([receipts[1]], gasPrice)
-        const managerHubSendTxCost = getTotalTxCosts([receipts[0]], gasPrice)
+        const workerEthTxCost = await getTotalTxCosts([receipts[1]], gasPrice)
+        const managerHubSendTxCost = await getTotalTxCosts([receipts[0]], gasPrice)
         const ownerBalanceAfter = toBN(await env.web3.eth.getBalance(relayOwner))
         const managerHubBalanceAfter = await env.relayHub.balanceOf(newServer.managerAddress)
         const managerBalanceAfter = await newServer.getManagerBalance()
@@ -376,7 +376,7 @@ contract('RegistrationManager', function (accounts) {
 
       it('should register server and add workers', async function () {
         const receipts = await newServer.registrationManager.attemptRegistration([], 0)
-        assertRelayAdded(receipts, newServer)
+        await assertRelayAdded(receipts, newServer)
       })
     })
   })

--- a/test/relayserver/RelayServerRequestsProfiling.test.ts
+++ b/test/relayserver/RelayServerRequestsProfiling.test.ts
@@ -10,7 +10,7 @@ contract('RelayServerRequestsProfiling', function (accounts) {
   const refreshStateTimeoutBlocks = 2
   const callsPerStateRefresh = 11
   const callsPerBlock = 0
-  const callsPerTransaction = 26
+  const callsPerTransaction = 25
 
   let provider: ProfilingProvider
   let relayServer: RelayServer

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -130,7 +130,7 @@ export class ServerTestEnvironment {
     // initialize server - gas price, stake, owner, etc, whatever
     const latestBlock = await this.web3.eth.getBlock('latest')
     const receipts = await this.relayServer._worker(latestBlock.number)
-    assertRelayAdded(receipts, this.relayServer) // sanity check
+    await assertRelayAdded(receipts, this.relayServer) // sanity check
   }
 
   _createKeyManager (workdir?: string): KeyManager {
@@ -207,7 +207,10 @@ export class ServerTestEnvironment {
     return await this.relayClient._prepareRelayHttpRequest(relayInfo, Object.assign({}, gsnTransactionDetails, overrideDetails))
   }
 
-  async relayTransaction (assertRelayed = true, overrideDetails: Partial<GsnTransactionDetails> = {}): Promise<PrefixedHexString> {
+  async relayTransaction (assertRelayed = true, overrideDetails: Partial<GsnTransactionDetails> = {}): Promise<{
+    signedTx: PrefixedHexString
+    txHash: PrefixedHexString
+  }> {
     const req = await this.createRelayHttpRequest(overrideDetails)
     const signedTx = await this.relayServer.createRelayTransaction(req)
     const txHash = ethUtils.bufferToHex(ethUtils.keccak256(Buffer.from(removeHexPrefix(signedTx), 'hex')))
@@ -215,7 +218,10 @@ export class ServerTestEnvironment {
     if (assertRelayed) {
       await this.assertTransactionRelayed(txHash)
     }
-    return signedTx
+    return {
+      txHash,
+      signedTx
+    }
   }
 
   async clearServerStorage (): Promise<void> {
@@ -223,11 +229,12 @@ export class ServerTestEnvironment {
     assert.deepEqual([], await this.relayServer.transactionManager.txStoreManager.getAll())
   }
 
-  async assertTransactionRelayed (txHash: string): Promise<void> {
+  async assertTransactionRelayed (txHash: string, overrideDetails: Partial<GsnTransactionDetails> = {}): Promise<void> {
     const receipt = await web3.eth.getTransactionReceipt(txHash)
     if (receipt == null) {
       throw new Error('Transaction Receipt not found')
     }
+    const sender = overrideDetails.from ?? this.gasLess
     const decodedLogs = abiDecoder.decodeLogs(receipt.logs).map(this.relayServer.registrationManager._parseEvent)
     const event1 = decodedLogs.find((e: { name: string }) => e.name === 'SampleRecipientEmitted')
     assert.exists(event1, 'SampleRecipientEmitted not found, maybe transaction was not relayed successfully')
@@ -236,7 +243,7 @@ export class ServerTestEnvironment {
     assert.exists(event2, 'TransactionRelayed not found, maybe transaction was not relayed successfully')
     assert.equal(event2.name, 'TransactionRelayed')
     assert.equal(event2.args.relayWorker.toLowerCase(), this.relayServer.workerAddress.toLowerCase())
-    assert.equal(event2.args.from.toLowerCase(), this.gasLess.toLowerCase())
+    assert.equal(event2.args.from.toLowerCase(), sender.toLowerCase())
     assert.equal(event2.args.to.toLowerCase(), this.recipient.address.toLowerCase())
     assert.equal(event2.args.paymaster.toLowerCase(), this.paymaster.address.toLowerCase())
   }

--- a/test/relayserver/ServerTestUtils.ts
+++ b/test/relayserver/ServerTestUtils.ts
@@ -2,7 +2,6 @@
 import abiDecoder from 'abi-decoder'
 import { TransactionReceipt } from 'web3-core'
 import { toBN } from 'web3-utils'
-import * as ethUtils from 'ethereumjs-util'
 
 import PayMasterABI from '../../src/common/interfaces/IPaymaster.json'
 import RelayHubABI from '../../src/common/interfaces/IRelayHub.json'

--- a/test/relayserver/ServerTestUtils.ts
+++ b/test/relayserver/ServerTestUtils.ts
@@ -8,6 +8,7 @@ import PayMasterABI from '../../src/common/interfaces/IPaymaster.json'
 import RelayHubABI from '../../src/common/interfaces/IRelayHub.json'
 import StakeManagerABI from '../../src/common/interfaces/IStakeManager.json'
 import { RelayServer } from '../../src/relayserver/RelayServer'
+import { PrefixedHexString } from 'ethereumjs-tx'
 
 const TestRecipient = artifacts.require('TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('TestPaymasterEverythingAccepted')
@@ -20,7 +21,14 @@ abiDecoder.addABI(TestRecipient.abi)
 // @ts-ignore
 abiDecoder.addABI(TestPaymasterEverythingAccepted.abi)
 
-export function assertRelayAdded (receipts: TransactionReceipt[], server: RelayServer, checkWorkers = true): void {
+async function resolveAllReceipts (transactionHashes: PrefixedHexString[]): Promise<TransactionReceipt[]> {
+  // actually returns promise for '.all'
+  // eslint-disable-next-line @typescript-eslint/promise-function-async
+  return await Promise.all(transactionHashes.map((transactionHash) => web3.eth.getTransactionReceipt(transactionHash)))
+}
+
+export async function assertRelayAdded (transactionHashes: PrefixedHexString[], server: RelayServer, checkWorkers = true): Promise<void> {
+  const receipts = await resolveAllReceipts(transactionHashes)
   const registeredReceipt = receipts.find(r => {
     const decodedLogs = abiDecoder.decodeLogs(r.logs).map(server.registrationManager._parseEvent)
     return decodedLogs[0].name === 'RelayServerRegistered'
@@ -47,7 +55,8 @@ export function assertRelayAdded (receipts: TransactionReceipt[], server: RelayS
   }
 }
 
-export function getTotalTxCosts (receipts: TransactionReceipt[], gasPrice: string): ethUtils.BN {
+export async function getTotalTxCosts (transactionHashes: PrefixedHexString[], gasPrice: string): Promise<BN> {
+  const receipts = await resolveAllReceipts(transactionHashes)
   return receipts.map(r => toBN(r.gasUsed).mul(toBN(gasPrice))).reduce(
     (previous, current) => previous.add(current), toBN(0))
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,37 +614,19 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
+"@truffle/blockchain-utils@^0.0.19":
+  version "0.0.19"
+  resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.19.tgz#921a478e388c5ad85dad01caf4b2cf501bbed0ab"
+  integrity sha512-1CU22UiYCBsrl4eXvTS7rdCQafFGeevcmpl+hVxKlJ9yHqWKiq/52f9T9TI10PJFWLSaE7Nm6LvUz7vbZ15PDw==
+  dependencies:
+    source-map-support "^0.5.19"
+
 "@truffle/blockchain-utils@^0.0.20":
   version "0.0.20"
   resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.20.tgz#17af5712504861cb374d3bbfa201ff0a2d2fead2"
   integrity sha512-BZY31tWdmf7QFc9ejzsqJ3zSsjIrJyiAYdjJfRBt1JFG/VBmYer4QiZgMQjlVE/1gB/RZAy2XOA91XlxkyfEMw==
   dependencies:
     source-map-support "^0.5.19"
-
-"@truffle/blockchain-utils@^0.0.25":
-  version "0.0.25"
-  resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz#f4b320890113d282f25f1a1ecd65b94a8b763ac1"
-  integrity sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==
-  dependencies:
-    source-map-support "^0.5.19"
-
-"@truffle/codec@^0.5.14":
-  version "0.5.14"
-  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.5.14.tgz#6948150517defb136fa64fe47f064cb80341004b"
-  integrity sha512-O4DsnOD4Xkm2sfNWyIfNqhc/RnlFTQa+SG6aYFLScyap9JGoQT5oXeeRbwputPIdiBOstrbn6QP37gKhfl0hNA==
-  dependencies:
-    big.js "^5.2.2"
-    bn.js "^4.11.8"
-    borc "^2.1.2"
-    debug "^4.1.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.escaperegexp "^4.1.2"
-    lodash.partition "^4.6.0"
-    lodash.sum "^4.0.2"
-    semver "^6.3.0"
-    source-map-support "^0.5.19"
-    utf8 "^3.0.0"
-    web3-utils "1.2.1"
 
 "@truffle/codec@^0.5.4":
   version "0.5.4"
@@ -663,6 +645,33 @@
     utf8 "^3.0.0"
     web3-utils "1.2.1"
 
+"@truffle/codec@^0.6.1":
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.6.1.tgz#ed26bb4948d8a3d4b5884538ae41b1c7f9f900ba"
+  integrity sha512-HrInHX9yLVVRCGOsXG2mZNG5P724KHZH3Pez6tMn39yLPsiKm9CzHcAHF5uX7ExhponOTEtKViudQ4MAFfh9Jg==
+  dependencies:
+    big.js "^5.2.2"
+    bn.js "^4.11.8"
+    borc "^2.1.2"
+    debug "^4.1.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.partition "^4.6.0"
+    lodash.sum "^4.0.2"
+    semver "^6.3.0"
+    source-map-support "^0.5.19"
+    utf8 "^3.0.0"
+    web3-utils "1.2.1"
+
+"@truffle/contract-schema@^3.1.0":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.5.tgz#498bbadad955daefd2638af4b195607734b306b9"
+  integrity sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==
+  dependencies:
+    ajv "^6.10.0"
+    crypto-js "^3.1.9-1"
+    debug "^4.1.0"
+
 "@truffle/contract-schema@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.0.tgz#4ddd43cf3eda11ec82bb2661725a19c2f4326e96"
@@ -672,28 +681,20 @@
     crypto-js "^3.1.9-1"
     debug "^4.1.0"
 
-"@truffle/contract-schema@^3.2.4":
-  version "3.2.4"
-  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.4.tgz#4e1227cfdecd31919f771c05fc845b1da4d1332d"
-  integrity sha512-CkacOyA7WE71nOJ7vHjlY3gqyeM++SplVJcTNc91BaLTh7TNhMa8Qr6pyNNiQJCZ8V7HNiMAlNw7wqQKNTpyBQ==
+"@truffle/contract@4.2.4":
+  version "4.2.4"
+  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.2.4.tgz#850983d51f6bc123bd3d9e0272d23648c13dcdf7"
+  integrity sha512-91CELArpITxK8uDgGZlWPcuBBLY0Aa4bqEPZFx3nVH0p8n4ncj6pzUvBsis/zkp8XbwETIbbeocc8dM7dLgO0A==
   dependencies:
-    ajv "^6.10.0"
-    crypto-js "^3.1.9-1"
-    debug "^4.1.0"
-
-"@truffle/contract@4.2.20":
-  version "4.2.20"
-  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.2.20.tgz#033174d35a25057a77e71e1a7063a9ccabc0c234"
-  integrity sha512-5GBHSXu3Mu15hDOuqtTgISEh+x14vdSOhAz9p+ArkuTLxe3diZSMWGGSU2DMenDdsj6pc+VBLum9y4i+TaMaKQ==
-  dependencies:
-    "@truffle/blockchain-utils" "^0.0.25"
-    "@truffle/contract-schema" "^3.2.4"
-    "@truffle/debug-utils" "^4.2.6"
-    "@truffle/error" "^0.0.10"
-    "@truffle/interface-adapter" "^0.4.16"
+    "@truffle/blockchain-utils" "^0.0.19"
+    "@truffle/contract-schema" "^3.1.0"
+    "@truffle/debug-utils" "^4.1.2"
+    "@truffle/error" "^0.0.8"
+    "@truffle/interface-adapter" "^0.4.7"
     bignumber.js "^7.2.1"
     ethereum-ens "^0.8.0"
     ethers "^4.0.0-beta.1"
+    exorcist "^1.0.1"
     source-map-support "^0.5.19"
     web3 "1.2.1"
     web3-core-helpers "1.2.1"
@@ -721,6 +722,18 @@
     web3-eth-abi "1.2.1"
     web3-utils "1.2.1"
 
+"@truffle/debug-utils@^4.1.2":
+  version "4.2.8"
+  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.2.8.tgz#2e5f865b9fea26884344396aef29a332bc1a7a75"
+  integrity sha512-o1apbR4FpQDVNCtT7nnXDAmHKGHEOVGuXyz9QG/IhjRdqxwZEE0pzBAW13tdIwduNaj6TQQVTB/Fx8uz914qzg==
+  dependencies:
+    "@truffle/codec" "^0.6.1"
+    "@trufflesuite/chromafi" "^2.1.2"
+    chalk "^2.4.2"
+    debug "^4.1.0"
+    highlight.js "^9.15.8"
+    highlightjs-solidity "^1.0.18"
+
 "@truffle/debug-utils@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.1.5.tgz#76cc1194a0557e0a8ebf9e9697c020c7710f6eea"
@@ -733,23 +746,6 @@
     highlight.js "^9.15.8"
     highlightjs-solidity "^1.0.15"
     node-dir "0.1.17"
-
-"@truffle/debug-utils@^4.2.6":
-  version "4.2.6"
-  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.2.6.tgz#7094b4d111cb7197034d5f563f3cfdf6c9abcc31"
-  integrity sha512-fyJ1w7oScwcvAaJhODC2Nt3ZG2Wqe6ZfY6xXZaYjKiK+5Q6nt2ezTt7y8fUITHv6lbL5QR8yCri5fgLBkxr+FQ==
-  dependencies:
-    "@truffle/codec" "^0.5.14"
-    "@trufflesuite/chromafi" "^2.1.2"
-    chalk "^2.4.2"
-    debug "^4.1.0"
-    highlight.js "^9.15.8"
-    highlightjs-solidity "^1.0.18"
-
-"@truffle/error@^0.0.10":
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.10.tgz#ae5c222ffada8a3063cc5cf6dceaea7ea7289d3c"
-  integrity sha512-7WrOoqH3VpfnaTB4TUKRAxzjuMZ3yP/sVet4zCdqGVcH/m1niu/ncttPy8LBfYi437PlBlhj7BpExKLYRPgAIA==
 
 "@truffle/error@^0.0.8":
   version "0.0.8"
@@ -772,7 +768,7 @@
     web3 "1.2.1"
     web3-provider-engine "https://github.com/trufflesuite/provider-engine#web3-one"
 
-"@truffle/interface-adapter@^0.4.16":
+"@truffle/interface-adapter@^0.4.7":
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.4.16.tgz#6bd65d9d17b4a2a51f39d05dd8b467daa8855792"
   integrity sha512-lsxk26Lz/h0n8fe37K1ZxowxokXj0AZeNR10QHltDvkHukuTIC4L6fXvrUi74mCwI9hShl4CSBas1Q8kAyJyOA==
@@ -3244,7 +3240,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.5.1:
+convert-source-map@^1.1.0, convert-source-map@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4879,6 +4875,16 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
+exorcist@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/exorcist/-/exorcist-1.0.1.tgz#79316e3c4885845490f7bb405c0e5b5db1167c52"
+  integrity sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=
+  dependencies:
+    is-stream "~1.1.0"
+    minimist "0.0.5"
+    mkdirp "~0.5.1"
+    mold-source-map "~0.4.0"
+
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -6287,7 +6293,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0, is-stream@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -7241,6 +7247,11 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
+minimist@0.0.5:
+  version "0.0.5"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
+  integrity sha1-16oye87PUY+RBqxrjwA/o7zqhWY=
+
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -7342,6 +7353,14 @@ mock-fs@^4.1.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.12.0.tgz#a5d50b12d2d75e5bec9dac3b67ffe3c41d31ade4"
   integrity sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==
+
+mold-source-map@~0.4.0:
+  version "0.4.0"
+  resolved "https://registry.yarnpkg.com/mold-source-map/-/mold-source-map-0.4.0.tgz#cf67e0b31c47ab9badb5c9c25651862127bb8317"
+  integrity sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=
+  dependencies:
+    convert-source-map "^1.1.0"
+    through "~2.2.7"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -9814,6 +9833,11 @@ through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
+
+through@~2.2.7:
+  version "2.2.7"
+  resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
+  integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
 
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -614,19 +614,37 @@
   dependencies:
     defer-to-connect "^1.0.1"
 
-"@truffle/blockchain-utils@^0.0.19":
-  version "0.0.19"
-  resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.19.tgz#921a478e388c5ad85dad01caf4b2cf501bbed0ab"
-  integrity sha512-1CU22UiYCBsrl4eXvTS7rdCQafFGeevcmpl+hVxKlJ9yHqWKiq/52f9T9TI10PJFWLSaE7Nm6LvUz7vbZ15PDw==
-  dependencies:
-    source-map-support "^0.5.19"
-
 "@truffle/blockchain-utils@^0.0.20":
   version "0.0.20"
   resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.20.tgz#17af5712504861cb374d3bbfa201ff0a2d2fead2"
   integrity sha512-BZY31tWdmf7QFc9ejzsqJ3zSsjIrJyiAYdjJfRBt1JFG/VBmYer4QiZgMQjlVE/1gB/RZAy2XOA91XlxkyfEMw==
   dependencies:
     source-map-support "^0.5.19"
+
+"@truffle/blockchain-utils@^0.0.25":
+  version "0.0.25"
+  resolved "https://registry.yarnpkg.com/@truffle/blockchain-utils/-/blockchain-utils-0.0.25.tgz#f4b320890113d282f25f1a1ecd65b94a8b763ac1"
+  integrity sha512-XA5m0BfAWtysy5ChHyiAf1fXbJxJXphKk+eZ9Rb9Twi6fn3Jg4gnHNwYXJacYFEydqT5vr2s4Ou812JHlautpw==
+  dependencies:
+    source-map-support "^0.5.19"
+
+"@truffle/codec@^0.5.14":
+  version "0.5.14"
+  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.5.14.tgz#6948150517defb136fa64fe47f064cb80341004b"
+  integrity sha512-O4DsnOD4Xkm2sfNWyIfNqhc/RnlFTQa+SG6aYFLScyap9JGoQT5oXeeRbwputPIdiBOstrbn6QP37gKhfl0hNA==
+  dependencies:
+    big.js "^5.2.2"
+    bn.js "^4.11.8"
+    borc "^2.1.2"
+    debug "^4.1.0"
+    lodash.clonedeep "^4.5.0"
+    lodash.escaperegexp "^4.1.2"
+    lodash.partition "^4.6.0"
+    lodash.sum "^4.0.2"
+    semver "^6.3.0"
+    source-map-support "^0.5.19"
+    utf8 "^3.0.0"
+    web3-utils "1.2.1"
 
 "@truffle/codec@^0.5.4":
   version "0.5.4"
@@ -645,33 +663,6 @@
     utf8 "^3.0.0"
     web3-utils "1.2.1"
 
-"@truffle/codec@^0.6.1":
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/@truffle/codec/-/codec-0.6.1.tgz#ed26bb4948d8a3d4b5884538ae41b1c7f9f900ba"
-  integrity sha512-HrInHX9yLVVRCGOsXG2mZNG5P724KHZH3Pez6tMn39yLPsiKm9CzHcAHF5uX7ExhponOTEtKViudQ4MAFfh9Jg==
-  dependencies:
-    big.js "^5.2.2"
-    bn.js "^4.11.8"
-    borc "^2.1.2"
-    debug "^4.1.0"
-    lodash.clonedeep "^4.5.0"
-    lodash.escaperegexp "^4.1.2"
-    lodash.partition "^4.6.0"
-    lodash.sum "^4.0.2"
-    semver "^6.3.0"
-    source-map-support "^0.5.19"
-    utf8 "^3.0.0"
-    web3-utils "1.2.1"
-
-"@truffle/contract-schema@^3.1.0":
-  version "3.2.5"
-  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.5.tgz#498bbadad955daefd2638af4b195607734b306b9"
-  integrity sha512-07lzyYJinGvpaKc/WUm1sigtE5qDjFfUb/wUfV5cNsUmRSd/Ji9vTZ+of/zYP4MztJQLT/ZtuG836oXhWgqntg==
-  dependencies:
-    ajv "^6.10.0"
-    crypto-js "^3.1.9-1"
-    debug "^4.1.0"
-
 "@truffle/contract-schema@^3.2.0":
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.0.tgz#4ddd43cf3eda11ec82bb2661725a19c2f4326e96"
@@ -681,20 +672,28 @@
     crypto-js "^3.1.9-1"
     debug "^4.1.0"
 
-"@truffle/contract@4.2.4":
-  version "4.2.4"
-  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.2.4.tgz#850983d51f6bc123bd3d9e0272d23648c13dcdf7"
-  integrity sha512-91CELArpITxK8uDgGZlWPcuBBLY0Aa4bqEPZFx3nVH0p8n4ncj6pzUvBsis/zkp8XbwETIbbeocc8dM7dLgO0A==
+"@truffle/contract-schema@^3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@truffle/contract-schema/-/contract-schema-3.2.4.tgz#4e1227cfdecd31919f771c05fc845b1da4d1332d"
+  integrity sha512-CkacOyA7WE71nOJ7vHjlY3gqyeM++SplVJcTNc91BaLTh7TNhMa8Qr6pyNNiQJCZ8V7HNiMAlNw7wqQKNTpyBQ==
   dependencies:
-    "@truffle/blockchain-utils" "^0.0.19"
-    "@truffle/contract-schema" "^3.1.0"
-    "@truffle/debug-utils" "^4.1.2"
-    "@truffle/error" "^0.0.8"
-    "@truffle/interface-adapter" "^0.4.7"
+    ajv "^6.10.0"
+    crypto-js "^3.1.9-1"
+    debug "^4.1.0"
+
+"@truffle/contract@4.2.20":
+  version "4.2.20"
+  resolved "https://registry.yarnpkg.com/@truffle/contract/-/contract-4.2.20.tgz#033174d35a25057a77e71e1a7063a9ccabc0c234"
+  integrity sha512-5GBHSXu3Mu15hDOuqtTgISEh+x14vdSOhAz9p+ArkuTLxe3diZSMWGGSU2DMenDdsj6pc+VBLum9y4i+TaMaKQ==
+  dependencies:
+    "@truffle/blockchain-utils" "^0.0.25"
+    "@truffle/contract-schema" "^3.2.4"
+    "@truffle/debug-utils" "^4.2.6"
+    "@truffle/error" "^0.0.10"
+    "@truffle/interface-adapter" "^0.4.16"
     bignumber.js "^7.2.1"
     ethereum-ens "^0.8.0"
     ethers "^4.0.0-beta.1"
-    exorcist "^1.0.1"
     source-map-support "^0.5.19"
     web3 "1.2.1"
     web3-core-helpers "1.2.1"
@@ -722,18 +721,6 @@
     web3-eth-abi "1.2.1"
     web3-utils "1.2.1"
 
-"@truffle/debug-utils@^4.1.2":
-  version "4.2.8"
-  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.2.8.tgz#2e5f865b9fea26884344396aef29a332bc1a7a75"
-  integrity sha512-o1apbR4FpQDVNCtT7nnXDAmHKGHEOVGuXyz9QG/IhjRdqxwZEE0pzBAW13tdIwduNaj6TQQVTB/Fx8uz914qzg==
-  dependencies:
-    "@truffle/codec" "^0.6.1"
-    "@trufflesuite/chromafi" "^2.1.2"
-    chalk "^2.4.2"
-    debug "^4.1.0"
-    highlight.js "^9.15.8"
-    highlightjs-solidity "^1.0.18"
-
 "@truffle/debug-utils@^4.1.5":
   version "4.1.5"
   resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.1.5.tgz#76cc1194a0557e0a8ebf9e9697c020c7710f6eea"
@@ -746,6 +733,23 @@
     highlight.js "^9.15.8"
     highlightjs-solidity "^1.0.15"
     node-dir "0.1.17"
+
+"@truffle/debug-utils@^4.2.6":
+  version "4.2.6"
+  resolved "https://registry.yarnpkg.com/@truffle/debug-utils/-/debug-utils-4.2.6.tgz#7094b4d111cb7197034d5f563f3cfdf6c9abcc31"
+  integrity sha512-fyJ1w7oScwcvAaJhODC2Nt3ZG2Wqe6ZfY6xXZaYjKiK+5Q6nt2ezTt7y8fUITHv6lbL5QR8yCri5fgLBkxr+FQ==
+  dependencies:
+    "@truffle/codec" "^0.5.14"
+    "@trufflesuite/chromafi" "^2.1.2"
+    chalk "^2.4.2"
+    debug "^4.1.0"
+    highlight.js "^9.15.8"
+    highlightjs-solidity "^1.0.18"
+
+"@truffle/error@^0.0.10":
+  version "0.0.10"
+  resolved "https://registry.yarnpkg.com/@truffle/error/-/error-0.0.10.tgz#ae5c222ffada8a3063cc5cf6dceaea7ea7289d3c"
+  integrity sha512-7WrOoqH3VpfnaTB4TUKRAxzjuMZ3yP/sVet4zCdqGVcH/m1niu/ncttPy8LBfYi437PlBlhj7BpExKLYRPgAIA==
 
 "@truffle/error@^0.0.8":
   version "0.0.8"
@@ -768,7 +772,7 @@
     web3 "1.2.1"
     web3-provider-engine "https://github.com/trufflesuite/provider-engine#web3-one"
 
-"@truffle/interface-adapter@^0.4.7":
+"@truffle/interface-adapter@^0.4.16":
   version "0.4.16"
   resolved "https://registry.yarnpkg.com/@truffle/interface-adapter/-/interface-adapter-0.4.16.tgz#6bd65d9d17b4a2a51f39d05dd8b467daa8855792"
   integrity sha512-lsxk26Lz/h0n8fe37K1ZxowxokXj0AZeNR10QHltDvkHukuTIC4L6fXvrUi74mCwI9hShl4CSBas1Q8kAyJyOA==
@@ -3240,7 +3244,7 @@ content-type@~1.0.4:
   resolved "https://registry.yarnpkg.com/content-type/-/content-type-1.0.4.tgz#e138cc75e040c727b1966fe5e5f8c9aee256fe3b"
   integrity sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==
 
-convert-source-map@^1.1.0, convert-source-map@^1.5.1:
+convert-source-map@^1.5.1:
   version "1.7.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.7.0.tgz#17a2cb882d7f77d3490585e2ce6c524424a3a442"
   integrity sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
@@ -4875,16 +4879,6 @@ execa@^1.0.0:
     signal-exit "^3.0.0"
     strip-eof "^1.0.0"
 
-exorcist@^1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/exorcist/-/exorcist-1.0.1.tgz#79316e3c4885845490f7bb405c0e5b5db1167c52"
-  integrity sha1-eTFuPEiFhFSQ97tAXA5bXbEWfFI=
-  dependencies:
-    is-stream "~1.1.0"
-    minimist "0.0.5"
-    mkdirp "~0.5.1"
-    mold-source-map "~0.4.0"
-
 expand-brackets@^2.1.4:
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/expand-brackets/-/expand-brackets-2.1.4.tgz#b77735e315ce30f6b6eff0f83b04151a22449622"
@@ -6293,7 +6287,7 @@ is-retry-allowed@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz#d778488bd0a4666a3be8a1482b9f2baafedea8b4"
   integrity sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==
 
-is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0, is-stream@~1.1.0:
+is-stream@^1.0.0, is-stream@^1.0.1, is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -7247,11 +7241,6 @@ minimalistic-crypto-utils@^1.0.0, minimalistic-crypto-utils@^1.0.1:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@0.0.5:
-  version "0.0.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.5.tgz#d7aa327bcecf518f9106ac6b8f003fa3bcea8566"
-  integrity sha1-16oye87PUY+RBqxrjwA/o7zqhWY=
-
 minimist@0.0.8:
   version "0.0.8"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-0.0.8.tgz#857fcabfc3397d2625b8228262e86aa7a011b05d"
@@ -7353,14 +7342,6 @@ mock-fs@^4.1.0:
   version "4.12.0"
   resolved "https://registry.yarnpkg.com/mock-fs/-/mock-fs-4.12.0.tgz#a5d50b12d2d75e5bec9dac3b67ffe3c41d31ade4"
   integrity sha512-/P/HtrlvBxY4o/PzXY9cCNBrdylDNxg7gnrv2sMNxj+UJ2m8jSpl0/A6fuJeNAWr99ZvGWH8XCbE0vmnM5KupQ==
-
-mold-source-map@~0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/mold-source-map/-/mold-source-map-0.4.0.tgz#cf67e0b31c47ab9badb5c9c25651862127bb8317"
-  integrity sha1-z2fgsxxHq5uttcnCVlGGISe7gxc=
-  dependencies:
-    convert-source-map "^1.1.0"
-    through "~2.2.7"
 
 move-concurrently@^1.0.1:
   version "1.0.1"
@@ -9833,11 +9814,6 @@ through@^2.3.6, through@^2.3.8, through@~2.3.4, through@~2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-through@~2.2.7:
-  version "2.2.7"
-  resolved "https://registry.yarnpkg.com/through/-/through-2.2.7.tgz#6e8e21200191d4eb6a99f6f010df46aa1c6eb2bd"
-  integrity sha1-bo4hIAGR1OtqmfbwEN9Gqhxusr0=
 
 timed-out@^4.0.0, timed-out@^4.0.1:
   version "4.0.1"


### PR DESCRIPTION
As there is no way to broadcast a transaction with Web3, implement the
low-level RPC call directly in the ContractInteractor.

Also:
1. Introduce Web3Provider type definition
2. Extract common 'WrapperProviderBase' abstract class
3. Make 'pollNonce' always return locally known nonce