### PR TITLE
fix relayer registration flow.

### DIFF
--- a/src/cli/CommandsLogic.ts
+++ b/src/cli/CommandsLogic.ts
@@ -104,11 +104,11 @@ export default class CommandsLogic {
     return response.ready
   }
 
-  async waitForRelay (relayUrl: string): Promise<void> {
-    const timeout = 30
+  async waitForRelay (relayUrl: string, timeout = 60): Promise<void> {
     console.error(`Will wait up to ${timeout}s for the relay to be ready`)
 
-    for (let i = 0; i < timeout; ++i) {
+    const endTime = Date.now() + timeout * 1000
+    while (Date.now() < endTime) {
       let isReady = false
       try {
         isReady = await this.isRelayReady(relayUrl)
@@ -118,7 +118,7 @@ export default class CommandsLogic {
       if (isReady) {
         return
       }
-      await sleep(1000)
+      await sleep(3000)
     }
     throw Error(`Relay not ready after ${timeout}s`)
   }

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -37,10 +37,15 @@ import Timeout = NodeJS.Timeout
 const VERSION = '2.0.0-beta.3'
 const GAS_RESERVE = 100000
 
+// must receive some response for request from node
+const READY_TIMEOUT = 30000
+
 export class RelayServer extends EventEmitter {
   lastScannedBlock = 0
   lastRefreshBlock = 0
   ready = false
+  lastWorkerFinished = Date.now()
+  lastError = null
   readonly managerAddress: PrefixedHexString
   readonly workerAddress: PrefixedHexString
   gasPrice: number = 0
@@ -78,12 +83,13 @@ export class RelayServer extends EventEmitter {
     this.workerBalanceRequired = new AmountRequired('Worker Balance', toBN(this.config.workerMinBalance))
     this.printServerAddresses()
     log.setLevel(this.config.logLevel)
-    log.debug('Using server configuration:\n', this.config)
+    log.warn('RelayServer version', VERSION)
+    log.info('Using server configuration:\n', this.config)
   }
 
   printServerAddresses (): void {
-    console.log(`Server manager address  | ${this.managerAddress}`)
-    console.log(`Server worker  address  | ${this.workerAddress}`)
+    log.info(`Server manager address  | ${this.managerAddress}`)
+    log.info(`Server worker  address  | ${this.workerAddress}`)
   }
 
   getMinGasPrice (): number {
@@ -99,7 +105,7 @@ export class RelayServer extends EventEmitter {
       maxAcceptanceBudget: this._getPaymasterMaxAcceptanceBudget(paymaster),
       chainId: this.chainId.toString(),
       networkId: this.networkId.toString(),
-      ready: this.ready ?? false,
+      ready: this.isReady() ?? false,
       version: VERSION
     }
   }
@@ -199,8 +205,8 @@ export class RelayServer extends EventEmitter {
     if (paymasterBalance.lt(maxCharge)) {
       throw new Error(`paymaster balance too low: ${paymasterBalance.toString()}, maxCharge: ${maxCharge.toString()}`)
     }
-    log.info(`paymaster balance: ${paymasterBalance.toString()}, maxCharge: ${maxCharge.toString()}`)
-    log.info(`Estimated max charge of relayed tx: ${maxCharge.toString()}, GasLimit of relayed tx: ${maxPossibleGas}`)
+    log.debug(`paymaster balance: ${paymasterBalance.toString()}, maxCharge: ${maxCharge.toString()}`)
+    log.debug(`Estimated max charge of relayed tx: ${maxCharge.toString()}, GasLimit of relayed tx: ${maxPossibleGas}`)
 
     return {
       acceptanceBudget,
@@ -234,7 +240,7 @@ returnValue        | ${viewRelayCallRet.returnValue}
 
   async createRelayTransaction (req: RelayTransactionRequest): Promise<PrefixedHexString> {
     log.debug('dump request params', arguments[0])
-    if (!this.ready) {
+    if (!this.isReady()) {
       throw new Error('relay not ready')
     }
     this.validateInputTypes(req)
@@ -309,12 +315,20 @@ returnValue        | ${viewRelayCallRet.returnValue}
         if (transactions.length !== 0) {
           log.debug(`Done handling block #${blockNumber}. Created ${transactions.length} transactions.`)
         }
+        this.lastError = null
+        this.lastWorkerFinished = Date.now()
         this._workerSemaphoreOn = false
       })
       .catch((e) => {
-        this.emit('error', e)
-        log.error('error in worker:', e)
+        // don't spam log with repeated error: report only the first time, until any change (either in error string,
+        // or successful _worker with no error)
+        if (e !== this.lastError) {
+          this.emit('error', e)
+          log.error('error in worker:', e)
+          this.lastError = e
+        }
         this.setReadyState(false)
+        this.lastWorkerFinished = Date.now()
         this._workerSemaphoreOn = false
       })
   }
@@ -434,11 +448,11 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     const isReplenishPendingForWorker = await this.txStoreManager.isActionPending(ServerAction.VALUE_TRANSFER, this.workerAddress)
     if (mustReplenishWorker && !isReplenishPendingForWorker) {
       const refill = toBN(this.config.workerTargetBalance.toString()).sub(this.workerBalanceRequired.currentValue)
-      log.info(
+      log.debug(
         `== replenishServer: mgr balance=${managerEthBalance.toString()}  manager hub balance=${managerHubBalance.toString()}
           \n${this.workerBalanceRequired.description}\n refill=${refill.toString()}`)
       if (refill.lt(managerEthBalance.sub(toBN(this.config.managerMinBalance)))) {
-        log.info('Replenishing worker balance by manager eth balance')
+        log.debug('Replenishing worker balance by manager eth balance')
         const details: SendTransactionDetails = {
           signer: this.managerAddress,
           serverAction: ServerAction.VALUE_TRANSFER,
@@ -535,7 +549,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
   }
 
   _shouldRefreshState (currentBlock: number): boolean {
-    return currentBlock - this.lastRefreshBlock >= this.config.refreshStateTimeoutBlocks || !this.ready
+    return currentBlock - this.lastRefreshBlock >= this.config.refreshStateTimeoutBlocks || !this.isReady()
   }
 
   async handlePastHubEvents (blockNumber: number, hubEventsSinceLastScan: EventData[]): Promise<void> {
@@ -555,7 +569,8 @@ latestBlock timestamp   | ${latestBlock.timestamp}
       fromBlock: this.lastScannedBlock + 1,
       toBlock: 'latest'
     }
-    return await this.contractInteractor.getPastEventsForHub(topics, options)
+    const events = await this.contractInteractor.getPastEventsForHub(topics, options)
+    return events
   }
 
   async _handleTransactionRejectedByPaymasterEvent (blockNumber: number): Promise<void> {
@@ -615,9 +630,23 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     return this.trustedPaymastersGasLimits.get(paymaster.toLocaleLowerCase()) != null
   }
 
+  isReady (): boolean {
+    if (!this.ready) { return false }
+
+    if ((Date.now() - this.lastWorkerFinished) > READY_TIMEOUT) {
+      log.warn(chalk.bgRedBright('Relay state: Timed-out'))
+      this.ready = false
+    }
+    return this.ready
+  }
+
   setReadyState (isReady: boolean): void {
-    if (isReady && !this.ready) {
-      log.warn(chalk.greenBright('RELAY IS NOW READY'))
+    if (isReady !== this.ready) {
+      if (isReady) {
+        log.warn(chalk.greenBright('Relayer state: READY'))
+      } else {
+        log.warn(chalk.redBright('Relayer state: NOT-READY'))
+      }
     }
     this.ready = isReady
   }

--- a/src/relayserver/ServerConfigParams.ts
+++ b/src/relayserver/ServerConfigParams.ts
@@ -24,6 +24,7 @@ export interface ServerConfigParams {
   ethereumNodeUrl: string
   workdir: string
   checkInterval: number
+  readyTimeout: number
   devMode: boolean
   registrationBlockRate: number
   maxAcceptanceBudget: number
@@ -72,6 +73,7 @@ const serverDefaultConfiguration: ServerConfigParams = {
   managerTargetBalance: 0.3e18,
   minHubWithdrawalBalance: 0.1e18,
   checkInterval: 10000,
+  readyTimeout: 30000,
   devMode: false,
   logLevel: 1,
   baseRelayFee: '0',
@@ -103,6 +105,7 @@ const ConfigParamsTypes = {
   ethereumNodeUrl: 'string',
   workdir: 'string',
   checkInterval: 'number',
+  readyTimeout: 'number',
   devMode: 'boolean',
   logLevel: 'number',
   registrationBlockRate: 'number',

--- a/src/relayserver/TransactionManager.ts
+++ b/src/relayserver/TransactionManager.ts
@@ -100,7 +100,7 @@ data         | 0x${transaction.data.toString('hex')}
       const estimateGas = await method.estimateGas({ from })
       return parseInt(estimateGas)
     } catch (e) {
-      log.error(`Failed to estimate gas for method ${methodName}\n. Using default ${this.config.defaultGasLimit}`, e)
+      log.error(`Failed to estimate gas for method ${methodName}\n. Using default ${this.config.defaultGasLimit}`, e.message)
     }
     return this.config.defaultGasLimit
   }
@@ -226,11 +226,12 @@ data         | 0x${transaction.data.toString('hex')}
       if (shouldRecheck) {
         const receipt = await this.contractInteractor.getTransaction(transaction.txId)
         if (receipt == null) {
-          log.warn(`failed to fetch receipt for tx ${transaction.txId}`)
+          log.warn(`warning: failed to fetch receipt for tx ${transaction.txId}`)
           continue
         }
         if (receipt.blockNumber == null) {
-          throw new Error(`invalid block number in receipt ${JSON.stringify(receipt)}`)
+          log.warn(`warning: null block number in receipt for ${transaction.txId}`)
+          continue
         }
         const confirmations = blockNumber - receipt.blockNumber
         if (receipt.blockNumber !== transaction.minedBlockNumber) {

--- a/truffle.js
+++ b/truffle.js
@@ -45,6 +45,12 @@ module.exports = {
       },
       network_id: 42
     },
+    rinkeby: {
+      provider: function () {
+        return new HDWalletProvider(mnemonic, 'https://rinkeby.infura.io/v3/f40be2b1a3914db682491dc62a19ad43')
+      },
+      network_id: 4
+    },
     ropsten: {
       provider: function () {
         return new HDWalletProvider(mnemonic, 'https://ropsten.infura.io/v3/f40be2b1a3914db682491dc62a19ad43')


### PR DESCRIPTION
- removed error messages during registration (which are not errors)
- it takes ~3 blocks to register relayer. increased "gsn
relayer-register" timeout to 60 seconds.

- moved some "info" to "debug"
- "null block in receipt" appears too often, and doesn't reflect an
error. now doesn't throw an exception - just log a line.
- polling interval reduced to 3sec
- ready state times-out after 3 `checkInterval` intervals, so any kind
of error will make the server "not ready" at most with 30 sec delay
(client has 10-sec timeout, so they will switch to other relayer faster)