### PR TITLE
OG-275 fix relayer state timeout

### DIFF
--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -623,7 +623,8 @@ latestBlock timestamp   | ${latestBlock.timestamp}
   isReady (): boolean {
     if (!this.ready) { return false }
 
-    if ((Date.now() - this.lastWorkerFinished) > this.config.readyTimeout) {
+    const timedOut = (Date.now() - this.lastWorkerFinished) > this.config.readyTimeout
+    if (!this.config.devMode && timedOut) {
       log.warn(chalk.bgRedBright('Relay state: Timed-out'))
       this.ready = false
     }

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -620,6 +620,16 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     return this.trustedPaymastersGasLimits.get(paymaster.toLocaleLowerCase()) != null
   }
 
+  isReady (): boolean {
+    if (!this.ready) { return false }
+
+    if ((Date.now() - this.lastWorkerFinished) > this.config.readyTimeout) {
+      log.warn(chalk.bgRedBright('Relay state: Timed-out'))
+      this.ready = false
+    }
+    return this.ready
+  }
+
   setReadyState (isReady: boolean): void {
     if (isReady !== this.ready) {
       if (isReady) {

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -620,17 +620,6 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     return this.trustedPaymastersGasLimits.get(paymaster.toLocaleLowerCase()) != null
   }
 
-  isReady (): boolean {
-    if (!this.ready) { return false }
-
-    const timedOut = (Date.now() - this.lastWorkerFinished) > this.config.readyTimeout
-    if (!this.config.devMode && timedOut) {
-      log.warn(chalk.bgRedBright('Relay state: Timed-out'))
-      this.ready = false
-    }
-    return this.ready
-  }
-
   setReadyState (isReady: boolean): void {
     if (isReady !== this.ready) {
       if (isReady) {

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -87,7 +87,6 @@ export class RelayServer extends EventEmitter {
     this.workerBalanceRequired = new AmountRequired('Worker Balance', toBN(this.config.workerMinBalance))
     this.printServerAddresses()
     log.setLevel(this.config.logLevel)
-    log.setLevel(0)
     log.warn('RelayServer version', VERSION)
     log.info('Using server configuration:\n', this.config)
   }

--- a/src/relayserver/ServerConfigParams.ts
+++ b/src/relayserver/ServerConfigParams.ts
@@ -43,6 +43,7 @@ export interface ServerConfigParams {
   minHubWithdrawalBalance: number
   refreshStateTimeoutBlocks: number
   pendingTransactionTimeoutBlocks: number
+  successfulRoundsForReady: number
   confirmationsNeeded: number
   retryGasPriceFactor: number
   maxGasPrice: string
@@ -85,6 +86,7 @@ const serverDefaultConfiguration: ServerConfigParams = {
   workdir: '',
   refreshStateTimeoutBlocks: 5,
   pendingTransactionTimeoutBlocks: 30, // around 5 minutes with 10 seconds block times
+  successfulRoundsForReady: 3, // successful mined blocks to become ready after exception
   confirmationsNeeded: 12,
   retryGasPriceFactor: 1.2,
   defaultGasLimit: 500000,

--- a/test/relayserver/RegistrationManager.test.ts
+++ b/test/relayserver/RegistrationManager.test.ts
@@ -58,7 +58,7 @@ contract('RegistrationManager', function (accounts) {
       latestBlock = await env.web3.eth.getBlock('latest')
       transactionHashes = await relayServer._worker(latestBlock.number)
       assert.equal(transactionHashes.length, 0)
-      assert.equal(relayServer.ready, false, 'relay should not be ready yet')
+      assert.equal(relayServer.isReady(), false, 'relay should not be ready yet')
       assert.equal((await relayServer.getManagerBalance()).cmp(toBN(expectedBalance)), 0)
       await evmMine()
     })
@@ -67,7 +67,7 @@ contract('RegistrationManager', function (accounts) {
       let latestBlock = await env.web3.eth.getBlock('latest')
       const transactionHashes = await relayServer._worker(latestBlock.number)
       assert.equal(transactionHashes.length, 0)
-      assert.equal(relayServer.ready, false, 'relay should not be ready yet')
+      assert.equal(relayServer.isReady(), false, 'relay should not be ready yet')
       const res = await env.stakeManager.stakeForAddress(relayServer.managerAddress, unstakeDelay, {
         from: relayOwner,
         value: oneEther
@@ -85,7 +85,7 @@ contract('RegistrationManager', function (accounts) {
       assert.deepEqual(relayServer.registrationManager.stakeRequired.currentValue, oneEther)
       assert.equal(relayServer.registrationManager.ownerAddress, relayOwner)
       assert.equal(workerBalanceAfter.toString(), relayServer.config.workerTargetBalance.toString())
-      assert.equal(relayServer.ready, true, 'relay not ready?')
+      assert.equal(relayServer.isReady(), true, 'relay not ready?')
       await assertRelayAdded(receipts, relayServer)
     })
 
@@ -118,7 +118,7 @@ contract('RegistrationManager', function (accounts) {
       await newRelayServer.init()
       const latestBlock = await env.web3.eth.getBlock('latest')
       await newRelayServer._worker(latestBlock.number)
-      assert.equal(relayServer.ready, true, 'relay not ready?')
+      assert.equal(relayServer.isReady(), true, 'relay not ready?')
     })
   })
 
@@ -143,7 +143,7 @@ contract('RegistrationManager', function (accounts) {
       assert.equal(newServer.registrationManager.ownerAddress, relayOwner, 'owner should be set after refreshing stake')
 
       const expectedGasPrice = parseInt(await env.web3.eth.getGasPrice()) * newServer.config.gasPriceFactor
-      assert.equal(newServer.ready, false)
+      assert.equal(newServer.isReady(), false)
       assert.equal(newServer.lastScannedBlock, 0)
       const workerBalanceBefore = await newServer.getWorkerBalance(workerIndex)
       assert.equal(workerBalanceBefore.toString(), '0')
@@ -152,7 +152,7 @@ contract('RegistrationManager', function (accounts) {
       await newServer._worker(latestBlock.number + 1)
       assert.equal(newServer.lastScannedBlock, latestBlock.number + 1)
       assert.equal(newServer.gasPrice, expectedGasPrice)
-      assert.equal(newServer.ready, true, 'relay no ready?')
+      assert.equal(newServer.isReady(), true, 'relay no ready?')
       const workerBalanceAfter = await newServer.getWorkerBalance(workerIndex)
       assert.deepEqual(newServer.registrationManager.stakeRequired.currentValue, oneEther)
       assert.equal(newServer.registrationManager.ownerAddress, relayOwner)

--- a/test/relayserver/RelayServer.test.ts
+++ b/test/relayserver/RelayServer.test.ts
@@ -22,7 +22,7 @@ import { assertRelayAdded, getTotalTxCosts } from './ServerTestUtils'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { ServerAction } from '../../src/relayserver/StoredTransaction'
 
-const {expect, assert} = chai.use(chaiAsPromised).use(sinonChai)
+const { expect, assert } = chai.use(chaiAsPromised).use(sinonChai)
 
 const TestPaymasterConfigurableMisbehavior = artifacts.require('TestPaymasterConfigurableMisbehavior')
 
@@ -94,7 +94,7 @@ contract('RelayServer', function (accounts) {
       assert.equal(relayServer.isReady(), false)
     })
 
-    it('after setReadyState(true), should stay non ready', ()=> {
+    it('after setReadyState(true), should stay non ready', () => {
       relayServer.config.readyTimeout = 100
       relayServer.setReadyState(true)
       assert.equal(relayServer.isReady(), false)
@@ -273,7 +273,7 @@ contract('RelayServer', function (accounts) {
           rejectingPaymaster = await TestPaymasterConfigurableMisbehavior.new()
           await rejectingPaymaster.setTrustedForwarder(env.forwarder.address)
           await rejectingPaymaster.setRelayHub(env.relayHub.address)
-          await rejectingPaymaster.deposit({value: env.web3.utils.toWei('1', 'ether')})
+          await rejectingPaymaster.deposit({ value: env.web3.utils.toWei('1', 'ether') })
           req = await env.createRelayHttpRequest()
           req.relayRequest.relayData.paymaster = rejectingPaymaster.address
         })
@@ -387,7 +387,7 @@ contract('RelayServer', function (accounts) {
         value: relayServer.config.managerTargetBalance
       })
       await env.web3.eth.sendTransaction(
-        {from: accounts[0], to: relayServer.workerAddress, value: relayServer.config.workerTargetBalance})
+        { from: accounts[0], to: relayServer.workerAddress, value: relayServer.config.workerTargetBalance })
       const currentBlockNumber = await env.web3.eth.getBlockNumber()
       const receipts = await relayServer.replenishServer(workerIndex, 0)
       assert.deepEqual(receipts, [])
@@ -395,7 +395,7 @@ contract('RelayServer', function (accounts) {
     })
 
     it('should withdraw hub balance to manager first, then use eth balance to fund workers', async function () {
-      await env.relayHub.depositFor(relayServer.managerAddress, {value: 1e18.toString()})
+      await env.relayHub.depositFor(relayServer.managerAddress, { value: 1e18.toString() })
       await relayServer.transactionManager.sendTransaction({
         signer: relayServer.managerAddress,
         serverAction: ServerAction.VALUE_TRANSFER,
@@ -407,7 +407,7 @@ contract('RelayServer', function (accounts) {
       })
       assert.equal((await relayServer.getManagerBalance()).toString(), '0')
       await env.web3.eth.sendTransaction(
-        {from: accounts[0], to: relayServer.managerAddress, value: relayServer.config.managerTargetBalance - 1e7})
+        { from: accounts[0], to: relayServer.managerAddress, value: relayServer.config.managerTargetBalance - 1e7 })
       const managerHubBalanceBefore = await env.relayHub.balanceOf(relayServer.managerAddress)
       const managerEthBalanceBefore = await relayServer.getManagerBalance()
       const workerBalanceBefore = await relayServer.getWorkerBalance(workerIndex)
@@ -577,7 +577,7 @@ contract('RelayServer', function (accounts) {
       rejectingPaymaster = await TestPaymasterConfigurableMisbehavior.new()
       await rejectingPaymaster.setTrustedForwarder(env.forwarder.address)
       await rejectingPaymaster.setRelayHub(env.relayHub.address)
-      await rejectingPaymaster.deposit({value: env.web3.utils.toWei('1', 'ether')})
+      await rejectingPaymaster.deposit({ value: env.web3.utils.toWei('1', 'ether') })
       await attackTheServer(newServer)
     })
     afterEach(async function () {
@@ -587,12 +587,12 @@ contract('RelayServer', function (accounts) {
 
     async function attackTheServer (server: RelayServer): Promise<void> {
       const _sendTransactionOrig = server.transactionManager.sendTransaction
-      server.transactionManager.sendTransaction = async function ({signer, method, destination, value = '0x', gasLimit, gasPrice}: SendTransactionDetails): Promise<SignedTransactionDetails> {
+      server.transactionManager.sendTransaction = async function ({ signer, method, destination, value = '0x', gasLimit, gasPrice }: SendTransactionDetails): Promise<SignedTransactionDetails> {
         await rejectingPaymaster.setRevertPreRelayCall(true)
         // @ts-ignore
         return (await _sendTransactionOrig.call(server.transactionManager, ...arguments))
       }
-      const req = await env.createRelayHttpRequest({paymaster: rejectingPaymaster.address})
+      const req = await env.createRelayHttpRequest({ paymaster: rejectingPaymaster.address })
       await env.relayServer.createRelayTransaction(req)
       // await relayTransaction(relayTransactionParams2, options2, { paymaster: rejectingPaymaster.address }, false)
       const currentBlock = await env.web3.eth.getBlock('latest')


### PR DESCRIPTION
- relayer timeout now managed by setTimeout callback
- added deferReadiness: control when setReady takes effect immediately or after delay (see below): deferReadiness becomes "true" after first crash of worker.
- added timeToReady: when setting relayer to ready (in deferReadiness), it doesn't take effect immediately but only after readyTimeout.

- removed the "ready" flag. instead, there is "futureReadyTime":
  - < Date.now() - we're already ready
  - Nan - we're in "not-ready" state (after exception)
  - &gt; Date.now() - we're waiting for this future time to become ready

- The "deferReadiness" controls whether setReadyState(true) will set
    futureTime to "now" or to some time into the future