### PR TITLE
OG-293 Allow skipping 'isTrustedForwarder' check

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,9 @@
   "description": "Open Gas Stations Network",
   "name": "@opengsn/gsn",
   "license": "MIT",
+  "engines": {
+    "node": ">=11.0.0"
+  },
   "repository": {
     "url": "https://github.com/opengsn/gsn",
     "type": "git"

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -28,7 +28,7 @@ const DEFAULT_RELAY_TIMEOUT_GRACE_SEC = 1800
 const DEFAULT_LOOKUP_WINDOW_BLOCKS = 60000
 
 const defaultGsnConfig: GSNConfig = {
-  tmpCheckRecipientForwarder: true,
+  skipRecipientForwarderValidation: false,
   preferredRelays: [],
   relayLookupWindowBlocks: DEFAULT_LOOKUP_WINDOW_BLOCKS,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
@@ -117,7 +117,7 @@ export async function resolveConfigurationGSN (provider: Web3Provider, partialCo
  * @field jsonStringifyRequest - should be 'true' for Metamask, false for ganache
  */
 export interface GSNConfig {
-  tmpCheckRecipientForwarder: boolean
+  skipRecipientForwarderValidation: boolean
   preferredRelays: string[]
   relayLookupWindowBlocks: number
   methodSuffix: string

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -28,6 +28,7 @@ const DEFAULT_RELAY_TIMEOUT_GRACE_SEC = 1800
 const DEFAULT_LOOKUP_WINDOW_BLOCKS = 60000
 
 const defaultGsnConfig: GSNConfig = {
+  tmpCheckRecipientForwarder: true,
   preferredRelays: [],
   relayLookupWindowBlocks: DEFAULT_LOOKUP_WINDOW_BLOCKS,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
@@ -116,6 +117,7 @@ export async function resolveConfigurationGSN (provider: Web3Provider, partialCo
  * @field jsonStringifyRequest - should be 'true' for Metamask, false for ganache
  */
 export interface GSNConfig {
+  tmpCheckRecipientForwarder: boolean
   preferredRelays: string[]
   relayLookupWindowBlocks: number
   methodSuffix: string

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -352,7 +352,7 @@ export class RelayClient {
       if (!isRecipientDeployed) {
         console.warn(`No IRelayRecipient code at ${gsnTransactionDetails.to}, proceeding without validating 'isTrustedForwarder'!
         Unless you are using some counterfactual contract deployment technique the transaction will fail!`)
-      } else {
+      } else if (this.config.tmpCheckRecipientForwarder) {
         const isTrusted = await this.contractInteractor.isTrustedForwarder(gsnTransactionDetails.to, forwarderAddress)
         if (!isTrusted) {
           throw new Error('The Forwarder address configured but is not trusted by the Recipient contract')

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -352,7 +352,7 @@ export class RelayClient {
       if (!isRecipientDeployed) {
         console.warn(`No IRelayRecipient code at ${gsnTransactionDetails.to}, proceeding without validating 'isTrustedForwarder'!
         Unless you are using some counterfactual contract deployment technique the transaction will fail!`)
-      } else if (this.config.tmpCheckRecipientForwarder) {
+      } else if (!this.config.skipRecipientForwarderValidation) {
         const isTrusted = await this.contractInteractor.isTrustedForwarder(gsnTransactionDetails.to, forwarderAddress)
         if (!isTrusted) {
           throw new Error('The Forwarder address configured but is not trusted by the Recipient contract')


### PR DESCRIPTION
It is possible tot make relayed calls to contracts that are not
recipients if they do not accesss 'msg.sender'.
This flag enables such use-case.