### PR TITLE
OG-268: revert reason of relayCall

### DIFF
--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -1,10 +1,9 @@
 import Common from 'ethereumjs-common'
 import Web3 from 'web3'
-import log from 'loglevel'
 import { BlockTransactionString } from 'web3-eth'
 import { EventData, PastEventOptions } from 'web3-eth-contract'
 import { PrefixedHexString, TransactionOptions } from 'ethereumjs-tx'
-import { toBN } from 'web3-utils'
+import { toBN, toHex } from 'web3-utils'
 import {
   BlockNumber,
   HttpProvider,
@@ -15,6 +14,7 @@ import {
   WebsocketProvider
 } from 'web3-core'
 
+import abi from 'web3-eth-abi'
 import RelayRequest from '../common/EIP712/RelayRequest'
 import paymasterAbi from '../common/interfaces/IPaymaster.json'
 import relayHubAbi from '../common/interfaces/IRelayHub.json'
@@ -23,7 +23,7 @@ import stakeManagerAbi from '../common/interfaces/IStakeManager.json'
 import gsnRecipientAbi from '../common/interfaces/IRelayRecipient.json'
 import knowForwarderAddressAbi from '../common/interfaces/IKnowForwarderAddress.json'
 
-import { event2topic } from '../common/Utils'
+import { decodeRevertReason, event2topic } from '../common/Utils'
 import { constants } from '../common/Constants'
 import replaceErrors from '../common/ErrorReplacerJSON'
 import VersionsManager from '../common/VersionsManager'
@@ -259,7 +259,14 @@ export default class ContractInteractor {
     return latestBlock.gasLimit
   }
 
-  async validateAcceptRelayCall (
+  /**
+   * make a view call to relayCall(), just like the way it will be called by the relayer.
+   * returns:
+   * - paymasterAccepted - true if accepted
+   * - reverted - true if relayCall was reverted.
+   * - returnValue - if either reverted or paymaster NOT accepted, then this is the reason string.
+   */
+  async validateRelayCall (
     paymasterMaxAcceptanceBudget: number,
     relayRequest: RelayRequest,
     signature: PrefixedHexString,
@@ -267,23 +274,49 @@ export default class ContractInteractor {
     const relayHub = this.relayHubInstance
     try {
       const externalGasLimit = await this._getBlockGasLimit()
-
-      const res = await relayHub.contract.methods.relayCall(
+      const encodedRelayCall = relayHub.contract.methods.relayCall(
         paymasterMaxAcceptanceBudget,
         relayRequest,
         signature,
         approvalData,
         externalGasLimit
-      )
-        .call({
-          from: relayRequest.relayData.relayWorker,
-          gasPrice: relayRequest.relayData.gasPrice,
-          gas: externalGasLimit
+      ).encodeABI()
+      const res = await new Promise((resolve, reject) => {
+        // @ts-ignore
+        this.web3.currentProvider.send({
+          jsonrpc: '2.0',
+          id: 1,
+          method: 'eth_call',
+          params: [
+            {
+              from: relayRequest.relayData.relayWorker,
+              to: relayHub.address,
+              gasPrice: toHex(relayRequest.relayData.gasPrice),
+              gas: toHex(externalGasLimit),
+              data: encodedRelayCall
+            },
+            'latest'
+          ]
+        }, (err: any, res: { result: string }) => {
+          const revertMsg = this._decodeRevertFromResponse(err, res)
+          if (revertMsg != null) {
+            reject(new Error(revertMsg))
+          }
+          if (err !== null) {
+            reject(err)
+          } else {
+            resolve(res.result)
+          }
         })
-      log.info(res)
+      })
+
+      // @ts-ignore
+      const decoded = abi.decodeParameters(['bool', 'string'], res as string)
+      const paymasterAccepted = decoded[0]
+      const returnValue = decoded[1]
       return {
-        returnValue: res.returnValue,
-        paymasterAccepted: res.paymasterAccepted,
+        returnValue: returnValue,
+        paymasterAccepted: paymasterAccepted,
         reverted: false
       }
     } catch (e) {
@@ -294,6 +327,33 @@ export default class ContractInteractor {
         returnValue: `view call to 'relayCall' reverted in client: ${message}`
       }
     }
+  }
+
+  /**
+   * decode revert from rpc response.
+   * called from the callback of the provider "eth_call" call.
+   * check if response is revert, and extract revert reason from it.
+   * support kovan, geth, ganache error formats..
+   * @param err - provider err value
+   * @param res - provider res value
+   */
+  // decode revert from rpc response.
+  //
+  _decodeRevertFromResponse (err?: { message?: string, data?: any }, res?: { error?: any, result?: string }): string | null {
+    const matchGanache = res?.error?.message?.match(/: revert (.*)/)
+    if (matchGanache != null) {
+      return matchGanache[1]
+    }
+    const m = err?.data?.match(/(0x08c379a0\S*)/)
+    if (m != null) {
+      return decodeRevertReason(m[1])
+    }
+
+    const result = res?.result ?? ''
+    if (result.startsWith('0x08c379a0')) {
+      return decodeRevertReason(result)
+    }
+    return null
   }
 
   encodeABI (paymasterMaxAcceptanceBudget: number, relayRequest: RelayRequest, sig: PrefixedHexString, approvalData: PrefixedHexString, externalGasLimit: IntString): PrefixedHexString {

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -281,7 +281,7 @@ export default class ContractInteractor {
         approvalData,
         externalGasLimit
       ).encodeABI()
-      const res = await new Promise((resolve, reject) => {
+      const res: string = await new Promise((resolve, reject) => {
         // @ts-ignore
         this.web3.currentProvider.send({
           jsonrpc: '2.0',
@@ -311,7 +311,7 @@ export default class ContractInteractor {
       })
 
       // @ts-ignore
-      const decoded = abi.decodeParameters(['bool', 'string'], res as string)
+      const decoded = abi.decodeParameters(['bool', 'string'], res)
       const paymasterAccepted = decoded[0]
       const returnValue = decoded[1]
       return {

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -226,7 +226,7 @@ export class RelayClient {
 
     this.emit(new GsnValidateRequestEvent())
 
-    const acceptRelayCallResult = await this.contractInteractor.validateAcceptRelayCall(maxAcceptanceBudget, httpRequest.relayRequest, httpRequest.metadata.signature, httpRequest.metadata.approvalData)
+    const acceptRelayCallResult = await this.contractInteractor.validateRelayCall(maxAcceptanceBudget, httpRequest.relayRequest, httpRequest.metadata.signature, httpRequest.metadata.approvalData)
     if (!acceptRelayCallResult.paymasterAccepted) {
       let message: string
       if (acceptRelayCallResult.reverted) {

--- a/test/dummies/BadContractInteractor.ts
+++ b/test/dummies/BadContractInteractor.ts
@@ -14,7 +14,7 @@ export default class BadContractInteractor extends ContractInteractor {
     this.failValidateARC = failValidateARC
   }
 
-  async validateAcceptRelayCall (paymasterMaxAcceptanceBudget: number, relayRequest: RelayRequest, signature: string, approvalData: string): Promise<{ paymasterAccepted: boolean, returnValue: string, reverted: boolean }> {
+  async validateRelayCall (paymasterMaxAcceptanceBudget: number, relayRequest: RelayRequest, signature: string, approvalData: string): Promise<{ paymasterAccepted: boolean, returnValue: string, reverted: boolean }> {
     if (this.failValidateARC) {
       return {
         paymasterAccepted: false,
@@ -22,7 +22,7 @@ export default class BadContractInteractor extends ContractInteractor {
         returnValue: BadContractInteractor.message
       }
     }
-    return await super.validateAcceptRelayCall(10e6, relayRequest, signature, approvalData)
+    return await super.validateRelayCall(10e6, relayRequest, signature, approvalData)
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await

--- a/test/relayclient/RevertMessage.test.ts
+++ b/test/relayclient/RevertMessage.test.ts
@@ -82,9 +82,6 @@ describe('RevertMessage.test', function () {
       })
 
       relayProvider = new RelayProvider(underlyingProvider as any, gsnConfig)
-      // NOTE: in real application its enough to set the provider in web3.
-      // however, in Truffle, all contracts are built BEFORE the test have started, and COPIED the web3,
-      // so changing the global one is not enough.
       // @ts-ignore
       TestRecipient.web3.setProvider(relayProvider)
 
@@ -92,7 +89,7 @@ describe('RevertMessage.test', function () {
     })
 
     it('should show relayCall revert messages', async function () {
-      this.timeout(30000)
+      this.timeout(20000)
 
       // explicitly request impossible gas limit, to cause a revert in relayCall()
       // (alternately, we could deploy a new paymaster with no balance and wait for "Paymaster balance too low"

--- a/test/relayclient/RevertMessage.test.ts
+++ b/test/relayclient/RevertMessage.test.ts
@@ -1,0 +1,106 @@
+/**
+ * run this test against different networks (ganache/geth/parity) to see that revert message can properly be processed:
+ *   truffle test --network rinkeby test/relayclient/RevertMessage.test.ts
+ * currently passes with "--network rinkeby", "--network ropsten" (geth node)
+ * it FAILS with "--network kovan":
+ * we still can't parse correctly parity response, since the provider doesn't pass the error response correctly.
+ */
+
+import { expectRevert } from '@openzeppelin/test-helpers'
+import { HttpProvider } from 'web3-core'
+import Web3 from 'web3'
+
+import { RelayProvider } from '../../src/relayclient/RelayProvider'
+import { configureGSN } from '../../src/relayclient/GSNConfigurator'
+import {
+  TestRecipientInstance
+} from '../../types/truffle-contracts'
+import { Address } from '../../src/relayclient/types/Aliases'
+import { GsnTestEnvironment } from '../../src/relayclient/GsnTestEnvironment'
+
+const underlyingProvider = web3.currentProvider as HttpProvider
+
+describe('RevertMessage.test', function () {
+  let web3: Web3
+  let forwarderAddress: Address
+  let relayHubAddress: Address
+  let paymasterAddress: Address
+  let relayProvider: RelayProvider
+
+  before(async function () {
+    this.timeout(30000)
+    web3 = new Web3(underlyingProvider)
+
+    // Addresses copied from latest release: https://github.com/opengsn/gsn/releases/tag/v2.0.1
+    const networks: any = {
+      3: {
+        hub: '0x29e41C2b329fF4921d8AC654CEc909a0B575df20',
+        forwarder: '0x25CEd1955423BA34332Ec1B60154967750a0297D',
+        paymaster: '0x8057c0fb7089BB646f824fF4A4f5a18A8d978ecC'
+      },
+      4: {
+        hub: '0x53C88539C65E0350408a2294C4A85eB3d8ce8789',
+        forwarder: '0x956868751Cc565507B3B58E53a6f9f41B56bed74',
+        paymaster: '0x43d66E6Dce20264F6511A0e8EEa3f570980341a2'
+      },
+      42: {
+        hub: '0xE9dcD2CccEcD77a92BA48933cb626e04214Edb92',
+        forwarder: '0x0842Ad6B8cb64364761C7c170D0002CC56b1c498',
+        paymaster: '0x083082b7Eada37dbD8f263050570B31448E61c94'
+      }
+    }
+    const chain = await web3.eth.net.getId()
+    if (chain > 1000) {
+      // @ts-ignore
+      const { deploymentResult } = await GsnTestEnvironment.startGsn(web3.currentProvider?.host ?? 'localhost')
+      forwarderAddress = deploymentResult.forwarderAddress
+      relayHubAddress = deploymentResult.relayHubAddress
+      paymasterAddress = deploymentResult.naivePaymasterAddress
+    } else {
+      relayHubAddress = networks[chain].hub
+      paymasterAddress = networks[chain].paymaster
+      forwarderAddress = networks[chain].forwarder
+    }
+  })
+
+  after('after all', async function () {
+    await GsnTestEnvironment.stopGsn()
+  })
+
+  describe('Use Provider to relay request', () => {
+    let testRecipient: TestRecipientInstance
+    let gasLess: Address
+
+    before(async function () {
+      this.timeout(30000)
+      const TestRecipient = artifacts.require('TestRecipient')
+      testRecipient = await TestRecipient.new(forwarderAddress)
+      const gsnConfig = configureGSN({
+        logLevel: 5,
+        relayHubAddress,
+        paymasterAddress
+      })
+
+      relayProvider = new RelayProvider(underlyingProvider as any, gsnConfig)
+      // NOTE: in real application its enough to set the provider in web3.
+      // however, in Truffle, all contracts are built BEFORE the test have started, and COPIED the web3,
+      // so changing the global one is not enough.
+      // @ts-ignore
+      TestRecipient.web3.setProvider(relayProvider)
+
+      gasLess = relayProvider.newAccount().address
+    })
+
+    it('should show relayCall revert messages', async function () {
+      this.timeout(30000)
+
+      // explicitly request impossible gas limit, to cause a revert in relayCall()
+      // (alternately, we could deploy a new paymaster with no balance and wait for "Paymaster balance too low"
+
+      await expectRevert(testRecipient.emitMessage('hello again', {
+        from: gasLess,
+        gas: 20e6.toString()
+      }), 'Not enough gas left for innerRelayCall')
+    })
+  })
+})


### PR DESCRIPTION
Client should see revert reasons (when called as view functions), as
these often contains useful diagnostics (e.g. paymaster not funded)

Unfortunately, there is no standard of returning revert reasons, and
Parity revert reason is hidden by the underlying provider in generic
exception.
Geth revert reason can be parsed (as ganache...)
The new test (RevertMessage.test.ts) runs on ganache, but can also be
executed as stand-alone against rinkeby (geth) where it succeeds ,and
kova (parity) where it fails..