### PR TITLE
OG-280 relayclient initialization outside of first transaction

### DIFF
--- a/src/common/EIP712/ForwarderUtil.ts
+++ b/src/common/EIP712/ForwarderUtil.ts
@@ -1,6 +1,7 @@
 import { GsnDomainSeparatorType, GsnRequestType } from './TypedRequestData'
 import { IForwarderInstance } from '../../../types/truffle-contracts'
 import { Contract } from 'web3-eth-contract'
+import log from 'loglevel'
 
 // register a forwarder for use with GSN: the request-type and domain separator we're using.
 export async function registerForwarderForGsn (forwarderTruffleOrWeb3: IForwarderInstance|Contract, sendOptions: any = undefined): Promise<void> {
@@ -18,10 +19,10 @@ export async function registerForwarderForGsn (forwarderTruffleOrWeb3: IForwarde
 
   function logTx (p: any): any {
     p.on('transactionHash', function (hash: string) {
-      console.log(`Transaction broadcast: ${hash}`)
+      log.debug(`Transaction broadcast: ${hash}`)
     })
     p.on('error', function (err: Error) {
-      console.log(`tx error: ${err.message}`)
+      log.debug(`tx error: ${err.message}`)
     })
     return p
   }

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -67,7 +67,7 @@ export type Web3Provider =
   | WebsocketProvider
 
 export default class ContractInteractor {
-  private readonly VERSION = '2.0.1'
+  private readonly VERSION = '2.0.2'
 
   private readonly IPaymasterContract: Contract<IPaymasterInstance>
   private readonly IRelayHubContract: Contract<IRelayHubInstance>

--- a/src/relayclient/GsnEvents.ts
+++ b/src/relayclient/GsnEvents.ts
@@ -2,44 +2,45 @@
  * base export class for all events fired by RelayClient.
  * for "progress" report, it is enough to test the base export class only.
  * subclasses contain some extra information about the events.
+ * Last event is when we receive response from relayer that event was sent - now we should wait for mining..
  */
-const TOTAL_EVENTS = 8
+const TOTAL_EVENTS = 7
 export class GsnEvent {
   total = TOTAL_EVENTS
   constructor (readonly event: string, readonly step: number) {}
 }
 
-// initialize client (takes time only on first request)
+// initialize client (should be done before all requests. not counted in "total")
 export class GsnInitEvent extends GsnEvent {
-  constructor () { super('init', 1) }
+  constructor () { super('init', 0) }
 }
 
 export class GsnRefreshRelaysEvent extends GsnEvent {
-  constructor () { super('refresh-relays', 2) }
+  constructor () { super('refresh-relays', 1) }
 }
 
 export class GsnDoneRefreshRelaysEvent extends GsnEvent {
-  constructor (readonly relaysCount: number) { super('refreshed-relays', 3) }
+  constructor (readonly relaysCount: number) { super('refreshed-relays', 2) }
 }
 
 export class GsnNextRelayEvent extends GsnEvent {
-  constructor (readonly relayUrl: string) { super('next-relay', 4) }
+  constructor (readonly relayUrl: string) { super('next-relay', 3) }
 }
 
 export class GsnSignRequestEvent extends GsnEvent {
-  constructor () { super('sign-request', 5) }
+  constructor () { super('sign-request', 4) }
 }
 
 // before sending the request to the relayer, the client attempt to verify it will succeed.
 // validation may fail if the paymaster rejects the request
 export class GsnValidateRequestEvent extends GsnEvent {
-  constructor () { super('validate-request', 6) }
+  constructor () { super('validate-request', 5) }
 }
 
 export class GsnSendToRelayerEvent extends GsnEvent {
-  constructor (readonly relayUrl: string) { super('send-to-relayer', 7) }
+  constructor (readonly relayUrl: string) { super('send-to-relayer', 6) }
 }
 
 export class GsnRelayerResponseEvent extends GsnEvent {
-  constructor (readonly success: boolean) { super('relayer-response', 8) }
+  constructor (readonly success: boolean) { super('relayer-response', 7) }
 }

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -179,7 +179,7 @@ export class RelayClient {
   async relayTransaction (gsnTransactionDetails: GsnTransactionDetails): Promise<RelayingResult> {
     if (!this.initialized) {
       if (!this.initMutex.isLocked()) {
-        log.warn('better call RelayClient.init() in advance (to make first request faster)')
+        this._warn('better call RelayClient.init() in advance (to make first request faster)')
       }
       await this.init()
     }
@@ -216,6 +216,10 @@ export class RelayClient {
         pingErrors: relaySelectionManager.errors
       }
     }
+  }
+
+  _warn (msg: string): void {
+    log.warn(msg)
   }
 
   async _calculateGasPrice (): Promise<PrefixedHexString> {

--- a/src/relayclient/RelayClient.ts
+++ b/src/relayclient/RelayClient.ts
@@ -26,6 +26,7 @@ import {
   GsnDoneRefreshRelaysEvent,
   GsnRefreshRelaysEvent, GsnRelayerResponseEvent, GsnSendToRelayerEvent, GsnSignRequestEvent, GsnValidateRequestEvent
 } from './GsnEvents'
+import { Mutex } from 'async-mutex'
 
 // generate "approvalData" and "paymasterData" for a request.
 // both are bytes arrays. paymasterData is part of the client request.
@@ -67,6 +68,7 @@ export class RelayClient {
 
   public readonly accountManager: AccountManager
   private initialized = false
+  private readonly initMutex = new Mutex()
 
   /**
    * create a RelayClient library object, to force contracts to go through a relay.
@@ -162,15 +164,25 @@ export class RelayClient {
     return false
   }
 
-  async _init (): Promise<void> {
-    if (this.initialized) { return }
-    this.emit(new GsnInitEvent())
-    await this.contractInteractor.init()
-    this.initialized = true
+  async init (): Promise<this> {
+    await this.initMutex.runExclusive(async () => {
+      if (this.initialized) {
+        return this
+      }
+      this.emit(new GsnInitEvent())
+      await this.contractInteractor.init()
+      this.initialized = true
+    })
+    return this
   }
 
   async relayTransaction (gsnTransactionDetails: GsnTransactionDetails): Promise<RelayingResult> {
-    await this._init()
+    if (!this.initialized) {
+      if (!this.initMutex.isLocked()) {
+        log.warn('better call RelayClient.init() in advance (to make first request faster)')
+      }
+      await this.init()
+    }
     // TODO: should have a better strategy to decide how often to refresh known relays
     this.emit(new GsnRefreshRelaysEvent())
     await this.knownRelaysManager.refresh()

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -56,6 +56,11 @@ export class RelayProvider implements HttpProvider {
     this._delegateEventsApi(origProvider)
   }
 
+  async init (): Promise<this> {
+    await this.relayClient.init()
+    return this
+  }
+
   registerEventListener (handler: (event: GsnEvent) => void): void {
     this.relayClient.registerEventListener(handler)
   }

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -34,7 +34,7 @@ import { configureServer, ServerConfigParams, ServerDependencies } from './Serve
 
 import Timeout = NodeJS.Timeout
 
-const VERSION = '2.0.1'
+const VERSION = '2.0.2'
 const GAS_RESERVE = 100000
 
 export class RelayServer extends EventEmitter {

--- a/test/relayclient/ContractInteractor.test.ts
+++ b/test/relayclient/ContractInteractor.test.ts
@@ -27,12 +27,12 @@ contract('ContractInteractor', function () {
       const relayClient = new RelayClient(web3.currentProvider as HttpProvider, {
         relayHubAddress: testVersions.address
       })
-      await expect(relayClient._init()).to.be.eventually.rejectedWith('Provided Hub version(3.0.0) is not supported by the current interactor')
+      await expect(relayClient.init()).to.be.eventually.rejectedWith('Provided Hub version(3.0.0) is not supported by the current interactor')
     })
 
     it('should not throw if the hub address is not configured', async function () {
-      const relayClient = new RelayClient(web3.currentProvider as HttpProvider, { logLevel: 5 })
-      await relayClient._init()
+      const relayClient = await new RelayClient(web3.currentProvider as HttpProvider, { logLevel: 5 }).init()
+      await relayClient.init()
     })
   })
 

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -37,7 +37,6 @@ import { Server } from 'http'
 import HttpClient from '../../src/relayclient/HttpClient'
 import HttpWrapper from '../../src/relayclient/HttpWrapper'
 import { RelayTransactionRequest } from '../../src/relayclient/types/RelayTransactionRequest'
-import log from 'loglevel'
 
 const StakeManager = artifacts.require('StakeManager')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -130,15 +129,25 @@ contract('RelayClient', function (accounts) {
   describe('#relayTransaction()', function () {
     it('should warn if called relayTransaction without calling init first', async function () {
       relayClient = new RelayClient(underlyingProvider, gsnConfig)
-      sinon.spy(log, 'warn')
-      await relayClient.relayTransaction(options)
-      expect(log.warn).to.have.been.calledWithMatch(/.*call RelayClient.init*/)
+      sinon.spy(relayClient, '_warn')
+      try {
+        await relayClient.relayTransaction(options)
+        expect(relayClient._warn).to.have.been.calledWithMatch(/.*call RelayClient.init*/)
+      } finally {
+        // @ts-ignore
+        relayClient._warn.restore()
+      }
     })
     it('should not warn if called "new RelayClient().init()"', async function () {
       relayClient = await new RelayClient(underlyingProvider, gsnConfig).init()
-      sinon.spy(log, 'warn')
-      await relayClient.relayTransaction(options)
-      expect(log.warn).to.have.not.been.called
+      sinon.spy(relayClient, '_warn')
+      try {
+        await relayClient.relayTransaction(options)
+        expect(relayClient._warn).to.have.not.been.called
+      } finally {
+        // @ts-ignore
+        relayClient._warn.restore()
+      }
     })
 
     it('should send transaction to a relay and receive a signed transaction in response', async function () {

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -279,16 +279,16 @@ contract('RelayClient', function (accounts) {
         gsnEvents.push(e)
       }
 
-      before('registerEventsListener', () => {
-        relayClient = new RelayClient(underlyingProvider, gsnConfig)
+      before('registerEventsListener', async () => {
+        relayClient = await new RelayClient(underlyingProvider, gsnConfig).init()
         relayClient.registerEventListener(eventsHandler)
       })
-      it('should call events handler', async function () {
+      it('should call all events handler', async function () {
         await relayClient.relayTransaction(options)
-        assert.equal(gsnEvents.length, 8)
+        assert.equal(gsnEvents.length, 7)
         assert.equal(gsnEvents[0].step, 1)
-        assert.equal(gsnEvents[0].total, 8)
-        assert.equal(gsnEvents[7].step, 8)
+        assert.equal(gsnEvents[0].total, 7)
+        assert.equal(gsnEvents[6].step, 7)
       })
       describe('removing events listener', () => {
         before('registerEventsListener', () => {


### PR DESCRIPTION
default construction should be: await new RelayClient(...).init()
Can still construct the old way, but it will generate a warning (since
it delays the first transaction)

NOTE: init() is now guarded with mutex, since its possibel that
relayTransaction() will be called before original init() finished.