### PR TITLE
Don't suppress errors when resolving config on init

### DIFF
--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -71,10 +71,16 @@ export async function resolveConfigurationGSN (provider: Web3Provider, partialCo
   ] = await Promise.all([
 
     partialConfig.chainId ?? contractInteractor.getAsyncChainId(),
-    paymasterInstance.getHubAddr().catch(e => { throw new Error('Not a paymaster contract') }),
+    paymasterInstance.getHubAddr().catch((e: any) => { 
+      console.error('Error calling getHubAddr() on Paymaster contract')
+      throw e
+    }),
     partialConfig.forwarderAddress ?? paymasterInstance.trustedForwarder().catch(e => { throw new Error('paymaster has no trustedForwarder()') }),
-    paymasterInstance.versionPaymaster().catch((e: any) => { throw new Error('Not a paymaster contract') }).then((version: string) => contractInteractor._validateVersion(version))
-      .catch(err => console.log('WARNING: beta ignore version compatibility', err))
+    paymasterInstance.versionPaymaster().catch((e: any) => {
+      console.error('Error calling versionPaymaster() on Paymaster contract')
+      throw e
+    }).then((version: string) => contractInteractor._validateVersion(version))
+      .catch((err: any) => console.log('WARNING: beta ignore version compatibility', err))
   ])
 
   const isMetamask: boolean = (provider as any).isMetaMask


### PR DESCRIPTION
"Not a paymaster contract" thrown error was hiding the real error which was related to the web3 instance connection which had nothing to do with the contract instance or deployment.

![image](https://user-images.githubusercontent.com/561465/95749943-637af000-0c6a-11eb-835b-a2a0156474a2.png)
