### PR TITLE
OG-227 required version logic

### DIFF
--- a/src/common/VersionsManager.ts
+++ b/src/common/VersionsManager.ts
@@ -2,15 +2,23 @@ import semver from 'semver'
 
 export default class VersionsManager {
   readonly componentVersion: string
+  readonly requiredVersionRange: string
 
   /**
    * @param componentVersion - a semver of a component that uses the VersionsManager
    */
-  constructor (componentVersion: string) {
+  constructor (componentVersion: string, requiredVersionRange?: string) {
     if (semver.valid(componentVersion) == null) {
       throw new Error('Component version is not valid')
     }
+
+    if (requiredVersionRange == null) {
+      const ver = new semver.SemVer(componentVersion)
+      ver.patch = 0
+      requiredVersionRange = '^' + ver.format()
+    }
     this.componentVersion = componentVersion
+    this.requiredVersionRange = requiredVersionRange
   }
 
   /**
@@ -21,7 +29,6 @@ export default class VersionsManager {
     // prevent crash with some early paymasters (which are otherwise perfectly valid)
     version = version.replace('_', '-')
 
-    const range = '^' + this.componentVersion
-    return semver.satisfies(version, range, { includePrerelease: true })
+    return semver.satisfies(version, this.requiredVersionRange, { includePrerelease: true })
   }
 }

--- a/src/relayclient/ContractInteractor.ts
+++ b/src/relayclient/ContractInteractor.ts
@@ -97,7 +97,7 @@ export default class ContractInteractor {
 
   constructor (provider: Web3Provider, logger: LoggerInterface, config: GSNConfig) {
     this.logger = logger
-    this.versionManager = new VersionsManager(gsnRuntimeVersion)
+    this.versionManager = new VersionsManager(gsnRuntimeVersion, config.requiredVersionRange)
     this.web3 = new Web3(provider)
     this.config = config
     this.provider = provider

--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -122,6 +122,7 @@ export interface GSNConfig {
   relayLookupWindowBlocks: number
   methodSuffix: string
   jsonStringifyRequest: boolean
+  requiredVersionRange?: string
   relayTimeoutGrace: number
   sliceSize: number
   logLevel: NpmLogLevel

--- a/test/common/VersionManager.test.ts
+++ b/test/common/VersionManager.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable no-new */
 import VersionsManager from '../../src/common/VersionsManager'
+require('source-map-support').install({ errorFormatterForce: true })
 
 describe('VersionManager', function () {
   context('constructor', function () {
@@ -11,26 +12,30 @@ describe('VersionManager', function () {
     it('should not throw on valid semver string', function () {
       new VersionsManager('2.0.0-beta.1+opengsn.something')
     })
+    it('target version with zero patch', function () {
+      assert.equal(new VersionsManager('2.3.4+opengsn.something').requiredVersionRange, '^2.3.0')
+    })
+    it('target beta version with zero patch', function () {
+      assert.equal(new VersionsManager('2.3.4-beta.5+opengsn.something').requiredVersionRange, '^2.3.0-beta.5')
+    })
   })
 
   context('#isMinorSameOrNewer()', function () {
     const manager = new VersionsManager('1.2.3')
-    it('should return true if version is same or newer', function () {
-      const isNewerSame = manager.isMinorSameOrNewer('1.2.4')
-      const isNewerPatch = manager.isMinorSameOrNewer('1.2.4')
-      const isNewerMinor = manager.isMinorSameOrNewer('1.2.4')
-      assert.isTrue(isNewerSame)
-      assert.isTrue(isNewerPatch)
-      assert.isTrue(isNewerMinor)
+    it('should ignore patch level', function () {
+      assert.isTrue(manager.isMinorSameOrNewer('1.2.2'))
+      assert.isTrue(manager.isMinorSameOrNewer('1.2.3'))
+      assert.isTrue(manager.isMinorSameOrNewer('1.2.4'))
+    })
 
-      const isNewerMajor = manager.isMinorSameOrNewer('2.3.4')
-      const isNewerPatchFalse = manager.isMinorSameOrNewer('1.2.0')
-      const isNewerMinorFalse = manager.isMinorSameOrNewer('1.1.0')
-      const isNewerMajorFalse = manager.isMinorSameOrNewer('0.2.3')
-      assert.isFalse(isNewerMajor)
-      assert.isFalse(isNewerPatchFalse)
-      assert.isFalse(isNewerMinorFalse)
-      assert.isFalse(isNewerMajorFalse)
+    it('should require minor same or equal', function () {
+      assert.isTrue(manager.isMinorSameOrNewer('1.3.0'))
+      assert.isFalse(manager.isMinorSameOrNewer('1.1.3'))
+    })
+
+    it('should require exact same major', function () {
+      assert.isFalse(manager.isMinorSameOrNewer('0.2.3'))
+      assert.isFalse(manager.isMinorSameOrNewer('3.2.3'))
     })
   })
 })


### PR DESCRIPTION
By default, required version is current version with patch=0
that is, current 2.0.1 is satisifed with "2.0.0"
it is still possible to override this default using config param
requiredVersionRange (which should include the "^" marker)