### PR TITLE
OG-122: split lookup window

### DIFF
--- a/src/relayclient/GSNConfigurator.ts
+++ b/src/relayclient/GSNConfigurator.ts
@@ -31,6 +31,7 @@ const defaultGsnConfig: GSNConfig = {
   skipRecipientForwarderValidation: false,
   preferredRelays: [],
   relayLookupWindowBlocks: DEFAULT_LOOKUP_WINDOW_BLOCKS,
+  relayLookupWindowParts: 1,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
   minGasPrice: 0,
   maxRelayNonceGap: MAX_RELAY_NONCE_GAP,
@@ -120,6 +121,7 @@ export interface GSNConfig {
   skipRecipientForwarderValidation: boolean
   preferredRelays: string[]
   relayLookupWindowBlocks: number
+  relayLookupWindowParts: number
   methodSuffix: string
   jsonStringifyRequest: boolean
   requiredVersionRange?: string

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -321,10 +321,10 @@ contract('KnownRelaysManager 2', function (accounts) {
       })
 
       it('should break large request into multiple chunks', async () => {
-        (knownRelaysManager as any).config.relayLookupWindowParts = 1
+        (knownRelaysManager as any).relayLookupWindowParts = 1
         const ret = await knownRelaysManager.getPastEventsForHub(1, 300)
 
-        assert.equal((knownRelaysManager as any).config.relayLookupWindowParts, 4)
+        assert.equal((knownRelaysManager as any).relayLookupWindowParts, 4)
         assert.equal(ret.length, 300)
         assert.equal(ret[0].event, 'event1-1-75')
         assert.equal(ret[299].event, 'event300-226-300')


### PR DESCRIPTION
added configuration item `relayLookupWindowParts` (which defaults to
"1"), to split the lookup window (defined in blocks) to multiple
requests.
added a code to increase the lookupWindowParts in case the lookup
transaction fails on "query returned more than XXX events"
(note that the increase stays in memory. if the client reloads, it will
use the configured value again)