### PR TITLE
OG-79: Add account should accept hex string for private key

### DIFF
--- a/src/relayclient/AccountManager.ts
+++ b/src/relayclient/AccountManager.ts
@@ -37,6 +37,15 @@ export default class AccountManager {
   }
 
   addAccount (privateKey: PrefixedHexString): void {
+    // temporary backward-compatibility mode: addAccount used to accept AccountKeypair with Buffer in it
+    // @ts-ignore
+    // eslint-disable-next-line @typescript-eslint/strict-boolean-expressions
+    if (privateKey.privateKey) {
+      console.error('ERROR: addAccount accepts a private key as a prefixed hex string now!')
+      // @ts-ignore
+      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
+      privateKey = `0x${privateKey.privateKey.toString('hex')}`
+    }
     const address = toAddress(privateKey)
     const keypair: AccountKeypair = {
       privateKey,

--- a/src/relayclient/AccountManager.ts
+++ b/src/relayclient/AccountManager.ts
@@ -1,25 +1,29 @@
 // @ts-ignore
 import ethWallet from 'ethereumjs-wallet'
-import RelayRequest from '../common/EIP712/RelayRequest'
-import sigUtil from 'eth-sig-util'
-import { getEip712Signature, isSameAddress } from '../common/Utils'
-import { Address } from './types/Aliases'
-import { PrefixedHexString } from 'ethereumjs-tx'
-import { GSNConfig } from './GSNConfigurator'
-import { HttpProvider } from 'web3-core'
 import Web3 from 'web3'
+import sigUtil from 'eth-sig-util'
+import { HttpProvider } from 'web3-core'
+import { PrefixedHexString } from 'ethereumjs-tx'
+
+import RelayRequest from '../common/EIP712/RelayRequest'
 import TypedRequestData from '../common/EIP712/TypedRequestData'
+import { Address } from './types/Aliases'
+import { GSNConfig } from './GSNConfigurator'
+import { getEip712Signature, isSameAddress, removeHexPrefix } from '../common/Utils'
 
 require('source-map-support').install({ errorFormatterForce: true })
+
 export interface AccountKeypair {
-  privateKey: Buffer
+  privateKey: PrefixedHexString
   address: Address
 }
 
-function toAddress (wallet: any): string {
+function toAddress (privateKey: PrefixedHexString): Address {
+  const wallet = ethWallet.fromPrivateKey(Buffer.from(removeHexPrefix(privateKey), 'hex'))
   // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
   return `0x${wallet.getAddress().toString('hex')}`
 }
+
 export default class AccountManager {
   private readonly web3: Web3
   private readonly accounts: AccountKeypair[] = []
@@ -32,23 +36,24 @@ export default class AccountManager {
     this.config = config
   }
 
-  addAccount (keypair: AccountKeypair): void {
-    const wallet = ethWallet.fromPrivateKey(keypair.privateKey)
-    if (!isSameAddress(toAddress(wallet), keypair.address)) {
-      throw new Error('invalid keypair')
+  addAccount (privateKey: PrefixedHexString): void {
+    const address = toAddress(privateKey)
+    const keypair: AccountKeypair = {
+      privateKey,
+      address
     }
     this.accounts.push(keypair)
   }
 
   newAccount (): AccountKeypair {
     const a = ethWallet.generate()
-    const keypair = {
-      privateKey: a.privKey,
-      // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
-      address: toAddress(a)
+    const privateKey = `0x${(a.privKey as Buffer).toString('hex')}`
+    this.addAccount(privateKey)
+    const address = toAddress(privateKey)
+    return {
+      privateKey,
+      address
     }
-    this.addAccount(keypair)
-    return keypair
   }
 
   async sign (relayRequest: RelayRequest): Promise<PrefixedHexString> {
@@ -66,7 +71,7 @@ export default class AccountManager {
 
     try {
       if (keypair != null) {
-        signature = this._signWithControlledKey(keypair, signedData)
+        signature = this._signWithControlledKey(keypair.privateKey, signedData)
       } else {
         signature = await this._signWithProvider(signedData)
       }
@@ -99,9 +104,9 @@ export default class AccountManager {
     )
   }
 
-  _signWithControlledKey (keypair: AccountKeypair, signedData: TypedRequestData): string {
+  _signWithControlledKey (privateKey: PrefixedHexString, signedData: TypedRequestData): string {
     // @ts-ignore
-    return sigUtil.signTypedData_v4(keypair.privateKey, { data: signedData })
+    return sigUtil.signTypedData_v4(Buffer.from(removeHexPrefix(privateKey), 'hex'), { data: signedData })
   }
 
   getAccounts (): string[] {

--- a/src/relayclient/RelayProvider.ts
+++ b/src/relayclient/RelayProvider.ts
@@ -2,7 +2,7 @@
 import abiDecoder from 'abi-decoder'
 import { HttpProvider } from 'web3-core'
 import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
-import { Transaction } from 'ethereumjs-tx'
+import { PrefixedHexString, Transaction } from 'ethereumjs-tx'
 
 import { LoggerInterface } from '../common/LoggerInterface'
 import relayHubAbi from '../common/interfaces/IRelayHub.json'
@@ -216,8 +216,8 @@ export class RelayProvider implements HttpProvider {
     return this.relayClient.accountManager.newAccount()
   }
 
-  addAccount (keypair: AccountKeypair): void {
-    this.relayClient.accountManager.addAccount(keypair)
+  addAccount (privateKey: PrefixedHexString): void {
+    this.relayClient.accountManager.addAccount(privateKey)
   }
 
   _getAccounts (payload: JsonRpcPayload, callback: JsonRpcCallback): void {

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -403,10 +403,7 @@ contract('RelayProvider', function (accounts) {
       const accountsBefore = await web3.eth.getAccounts()
       const newAccount = relayProvider.newAccount()
       const address = '0x982a8cbe734cb8c29a6a7e02a3b0e4512148f6f9'
-      relayProvider.addAccount({
-        privateKey: Buffer.from('d353907ab062133759f149a3afcb951f0f746a65a60f351ba05a3ebf26b67f5c', 'hex'),
-        address
-      })
+      relayProvider.addAccount('0xd353907ab062133759f149a3afcb951f0f746a65a60f351ba05a3ebf26b67f5c')
       const accountsAfter = await web3.eth.getAccounts()
       const newAccounts = accountsAfter.filter(value => !accountsBefore.includes(value)).map(it => it.toLowerCase())
       assert.equal(newAccounts.length, 2)


### PR DESCRIPTION
Remove option to add keypair with a buffer as I can't think of a usecase
where this is more convenient