### PR TITLE
OG-349 Shortcut: disable storage for Reputation Manager (and OG-331)

### DIFF
--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -633,12 +633,10 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
   }
 
+  // TODO: do not call this method when events are processed already (stateful server thing)
   async _handleTransactionRejectedByPaymasterEvent (paymaster: Address, currentBlockNumber: number, eventBlockNumber: number): Promise<void> {
-    // TODO: do not call this method when events are processed already (stateful server thing)
-    if (currentBlockNumber - eventBlockNumber < 30) {
-      this.alerted = true
-      this.alertedBlock = currentBlockNumber
-    }
+    this.alerted = true
+    this.alertedBlock = eventBlockNumber
     this.logger.error(`Relay entered alerted state. Block number: ${currentBlockNumber}`)
     if (this.config.runPaymasterReputations) {
       await this.reputationManager.updatePaymasterStatus(paymaster, false, eventBlockNumber)

--- a/src/relayserver/ReputationEntry.ts
+++ b/src/relayserver/ReputationEntry.ts
@@ -1,7 +1,7 @@
 import { Address } from '../common/types/Aliases'
 
 export interface ReputationChange {
-  timestamp: number
+  blockNumber: number
   change: number
 }
 
@@ -9,6 +9,6 @@ export interface ReputationEntry {
   paymaster: Address
   reputation: number
   lastAcceptedRelayRequestTs: number
-  abuseStartedTs: number
+  abuseStartedBlock: number
   changes: ReputationChange[]
 }

--- a/src/relayserver/ReputationManager.ts
+++ b/src/relayserver/ReputationManager.ts
@@ -1,7 +1,7 @@
 import { Address } from '../common/types/Aliases'
 import { LoggerInterface } from '../common/LoggerInterface'
 import { ReputationStoreManager } from './ReputationStoreManager'
-import { ReputationChange, ReputationEntry } from './ReputationEntry'
+import { ReputationChange } from './ReputationEntry'
 
 export interface ReputationManagerConfiguration {
   /** All new Paymasters start with their reputation set to this value  */
@@ -53,28 +53,19 @@ function resolveReputationManagerConfiguration (partialConfig: Partial<Reputatio
 
 export class ReputationManager {
   config: ReputationManagerConfiguration
-  /*
   reputationStoreManager: ReputationStoreManager
-   */
-  localReputationEntries = new Map<Address, ReputationEntry>()
   logger: LoggerInterface
 
   constructor (reputationStoreManager: ReputationStoreManager, logger: LoggerInterface, partialConfig: Partial<ReputationManagerConfiguration>) {
     this.config = resolveReputationManagerConfiguration(partialConfig)
-    /*
     this.reputationStoreManager = reputationStoreManager
-     */
     this.logger = logger
   }
 
   async getPaymasterStatus (paymaster: Address, currentBlockNumber: number): Promise<PaymasterStatus> {
-    /*
     const entry =
       await this.reputationStoreManager.getEntry(paymaster) ??
       await this.reputationStoreManager.createEntry(paymaster, this.config.initialReputation)
-     */
-    const entry = this.localReputationEntries.get(paymaster.toLowerCase()) ??
-      this.createNewEntry(paymaster)
     if (entry.reputation <= this.config.blockReputation) {
       return PaymasterStatus.BLOCKED
     }
@@ -82,10 +73,7 @@ export class ReputationManager {
       if (currentBlockNumber - entry.abuseStartedBlock <= this.config.abuseTimeWindowBlocks) {
         return PaymasterStatus.ABUSED
       } else {
-        /*
         await this.reputationStoreManager.clearAbuseFlag(paymaster, this.config.abuseTimeoutReputation)
-         */
-        entry.abuseStartedBlock = 0
       }
     }
     if (
@@ -96,37 +84,14 @@ export class ReputationManager {
     return PaymasterStatus.GOOD
   }
 
-  createNewEntry (paymaster: string): ReputationEntry {
-    const newEntry = {
-      paymaster: paymaster.toLowerCase(),
-      reputation: this.config.initialReputation,
-      lastAcceptedRelayRequestTs: 0,
-      abuseStartedBlock: 0,
-      changes: []
-    }
-    this.localReputationEntries.set(paymaster.toLowerCase(), newEntry)
-    return newEntry
-  }
-
   async onRelayRequestAccepted (paymaster: Address): Promise<void> {
-    /*
     await this.reputationStoreManager.updateLastAcceptedTimestamp(paymaster)
-     */
-    const lastAcceptedRelayRequestTs = Date.now()
-    const entry = this.localReputationEntries.get(paymaster.toLowerCase()) ??
-      this.createNewEntry(paymaster)
-    entry.lastAcceptedRelayRequestTs = lastAcceptedRelayRequestTs
-    this.logger.debug(`Paymaster ${paymaster} was last accepted at ${lastAcceptedRelayRequestTs}`)
   }
 
   async updatePaymasterStatus (paymaster: Address, transactionSuccess: boolean, eventBlockNumber: number): Promise<void> {
     const change = transactionSuccess ? 1 : -1
-    /*
     const entry =
       await this.reputationStoreManager.getEntry(paymaster)
-     */
-    const entry = this.localReputationEntries.get(paymaster.toLowerCase()) ??
-      this.createNewEntry(paymaster)
     if (entry == null) {
       throw new Error(`Could not query reputation for paymaster: ${paymaster}`)
     }
@@ -137,40 +102,9 @@ export class ReputationManager {
       .filter(it => eventBlockNumber - it.blockNumber < this.config.abuseTimeWindowBlocks)
       .reduce((previousValue: number, currentValue: ReputationChange) => previousValue + currentValue.change, 0)
     if (-changeInAbuseWindow >= this.config.abuseReputationChange) {
-      /*
-      await this.reputationStoreManager.setAbuseFlag(paymaster)
-       */
-      entry.abuseStartedBlock = eventBlockNumber
+      await this.reputationStoreManager.setAbuseFlag(paymaster, eventBlockNumber)
     }
     const oldChangesExpirationBlock = eventBlockNumber - this.config.abuseTimeWindowBlocks
-    /*
-    await this.reputationStoreManager.updatePaymasterReputation(paymaster, change, oldChangesExpirationTs)
-     */
-    this.updatePaymasterReputation(paymaster, change, oldChangesExpirationBlock, eventBlockNumber)
-  }
-
-  updatePaymasterReputation (
-    paymaster: Address,
-    change: number,
-    oldChangesExpirationBlock: number,
-    eventBlockNumber: number
-  ): void {
-    if (eventBlockNumber <= oldChangesExpirationBlock) {
-      throw new Error(`Invalid change expiration parameter! Passed ${oldChangesExpirationBlock}, but event was emitted at block height ${eventBlockNumber}`)
-    }
-
-    const existing: ReputationEntry = this.localReputationEntries.get(paymaster.toLowerCase()) ??
-      this.createNewEntry(paymaster)
-    const reputationChange: ReputationChange = {
-      blockNumber: eventBlockNumber,
-      change
-    }
-    const reputation = existing.reputation + change
-    const changes =
-      [...existing.changes, reputationChange]
-        .filter(it => it.blockNumber > oldChangesExpirationBlock)
-    existing.reputation = reputation
-    existing.changes = changes
-    this.logger.info(`Paymaster ${paymaster} reputation changed from ${existing.reputation} to ${reputation}. Change is ${change}`)
+    await this.reputationStoreManager.updatePaymasterReputation(paymaster, change, oldChangesExpirationBlock, eventBlockNumber)
   }
 }

--- a/src/relayserver/ReputationStoreManager.ts
+++ b/src/relayserver/ReputationStoreManager.ts
@@ -27,7 +27,7 @@ export class ReputationStoreManager {
       paymaster: paymaster.toLowerCase(),
       reputation,
       lastAcceptedRelayRequestTs: 0,
-      abuseStartedTs: 0,
+      abuseStartedBlock: 0,
       changes: []
     }
     return await this.txstore.asyncInsert(entry)
@@ -36,14 +36,14 @@ export class ReputationStoreManager {
   async clearAbuseFlag (paymaster: Address, reputation: number): Promise<void> {
     const update: Partial<ReputationEntry> = {
       reputation,
-      abuseStartedTs: 0
+      abuseStartedBlock: 0
     }
     await this.updateEntry(paymaster, update)
   }
 
-  async setAbuseFlag (paymaster: Address): Promise<void> {
+  async setAbuseFlag (paymaster: Address, currentBlockNumber: number): Promise<void> {
     const update: Partial<ReputationEntry> = {
-      abuseStartedTs: Date.now()
+      abuseStartedBlock: currentBlockNumber
     }
     this.logger.warn(`Paymaster ${paymaster} was flagged as abused`)
     await this.updateEntry(paymaster, update)
@@ -58,20 +58,19 @@ export class ReputationStoreManager {
     await this.updateEntry(paymaster, update)
   }
 
-  async updatePaymasterReputation (paymaster: Address, change: number, oldChangesExpirationTs: number): Promise<void> {
-    const now = Date.now()
-    if (now <= oldChangesExpirationTs) {
-      throw new Error(`Invalid change expiration parameter! Passed ${oldChangesExpirationTs}, but current clock is at ${now}`)
+  async updatePaymasterReputation (paymaster: Address, change: number, oldChangesExpirationBlock: number, eventBlockNumber: number): Promise<void> {
+    if (eventBlockNumber <= oldChangesExpirationBlock) {
+      throw new Error(`Invalid change expiration parameter! Passed ${oldChangesExpirationBlock}, but event was emitted at block height ${eventBlockNumber}`)
     }
     const existing: ReputationEntry = await this.txstore.asyncFindOne({ paymaster: paymaster.toLowerCase() })
     const reputationChange: ReputationChange = {
-      timestamp: now,
+      blockNumber: eventBlockNumber,
       change
     }
     const reputation = existing.reputation + change
     const changes =
       [...existing.changes, reputationChange]
-        .filter(it => it.timestamp > oldChangesExpirationTs)
+        .filter(it => it.blockNumber > oldChangesExpirationBlock)
     const update: Partial<ReputationEntry> = {
       reputation,
       changes

--- a/src/relayserver/runServer.ts
+++ b/src/relayserver/runServer.ts
@@ -77,7 +77,7 @@ async function run (): Promise<void> {
 
   let reputationManager: ReputationManager | undefined
   if (runPaymasterReputations) {
-    const reputationStoreManager = new ReputationStoreManager({ workdir }, logger)
+    const reputationStoreManager = new ReputationStoreManager({ workdir, inMemory: true }, logger)
     reputationManager = new ReputationManager(reputationStoreManager, logger, reputationManagerConfig)
   }
 

--- a/test/relayserver/ReputationManager.test.ts
+++ b/test/relayserver/ReputationManager.test.ts
@@ -78,6 +78,11 @@ contract('ReputationManager', function () {
       await reputationStoreManager.clearAll()
       await reputationStoreManager.createEntry(paymaster, initialReputation)
       await reputationStoreManager.setAbuseFlag(paymaster)
+      /* start - disabled storage */
+      reputationManager.localReputationEntries.clear()
+      reputationManager.createNewEntry(paymaster)
+      reputationManager.localReputationEntries.get(paymaster)!.abuseStartedTs = Date.now()
+      /* end - disabled storage */
       let status = await reputationManager.getPaymasterStatus(paymaster)
       assert.equal(status, PaymasterStatus.ABUSED)
       mockSleep(abuseBlockDurationMs)
@@ -90,6 +95,11 @@ contract('ReputationManager', function () {
     beforeEach(async function () {
       await reputationStoreManager.clearAll()
       await reputationStoreManager.createEntry(paymaster, 100)
+      /* start - disabled storage */
+      reputationManager.localReputationEntries.clear()
+      reputationManager.createNewEntry(paymaster)
+      reputationManager.localReputationEntries.get(paymaster)!.reputation = 100
+      /* end - disabled storage */
     })
 
     it('should detect an abuse if the reputation drops too fast', async function () {

--- a/test/relayserver/ReputationManager.test.ts
+++ b/test/relayserver/ReputationManager.test.ts
@@ -6,6 +6,10 @@ import {
   ReputationManager,
   ReputationManagerConfiguration
 } from '../../src/relayserver/ReputationManager'
+import { evmMineMany } from '../TestUtils'
+import ContractInteractor from '../../src/common/ContractInteractor'
+import { HttpProvider } from 'web3-core'
+
 require('source-map-support').install({ errorFormatterForce: true })
 
 /**
@@ -15,8 +19,9 @@ contract('ReputationManager', function () {
   const paymaster = constants.ZERO_ADDRESS
   const initialReputation = 2
   const throttleDelayMs = 100
-  const abuseTimeWindowMs = 1000
-  const abuseBlockDurationMs = 1000
+  const abuseTimeWindowBlocks = 100
+  const abuseBlacklistDurationBlocks = 100
+  let contractInteractor: ContractInteractor
   let reputationManager: ReputationManager
   let reputationStoreManager: ReputationStoreManager
   let saveNow: any
@@ -38,12 +43,16 @@ contract('ReputationManager', function () {
     const reputationManagerConfig: Partial<ReputationManagerConfiguration> = {
       initialReputation,
       throttleDelayMs,
-      abuseTimeWindowMs,
-      abuseBlockDurationMs
+      abuseTimeWindowBlocks,
+      abuseBlacklistDurationBlocks
     }
     reputationStoreManager = new ReputationStoreManager({}, logger)
     await reputationStoreManager.clearAll()
     reputationManager = new ReputationManager(reputationStoreManager, logger, reputationManagerConfig)
+    contractInteractor = new ContractInteractor({
+      provider: web3.currentProvider as HttpProvider,
+      logger
+    })
   })
 
   after(() => {
@@ -52,41 +61,46 @@ contract('ReputationManager', function () {
 
   describe('getPaymasterStatus', function () {
     it('should report paymaster as THROTTLED if requesting multiple transactions too fast', async function () {
-      let status = await reputationManager.getPaymasterStatus(paymaster)
+      const currentBlockNumber = await contractInteractor.getBlockNumber()
+      let status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.GOOD)
-      await reputationManager.updatePaymasterStatus(paymaster, false)
+      await reputationManager.updatePaymasterStatus(paymaster, false, currentBlockNumber)
       await reputationManager.onRelayRequestAccepted(paymaster)
-      status = await reputationManager.getPaymasterStatus(paymaster)
+      status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.THROTTLED)
     })
 
     it('should report paymaster as GOOD if enough time has passed since the last one', async function () {
       mockSleep(throttleDelayMs)
-      const status = await reputationManager.getPaymasterStatus(paymaster)
+      const currentBlockNumber = await contractInteractor.getBlockNumber()
+      const status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.GOOD)
     })
 
     it('should report paymaster as BLOCKED if the reputation falls to 0', async function () {
-      let status = await reputationManager.getPaymasterStatus(paymaster)
+      const currentBlockNumber = await contractInteractor.getBlockNumber()
+      let status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.GOOD)
-      await reputationManager.updatePaymasterStatus(paymaster, false)
-      status = await reputationManager.getPaymasterStatus(paymaster)
+      await reputationManager.updatePaymasterStatus(paymaster, false, currentBlockNumber)
+      status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.BLOCKED)
     })
 
     it('should reset the paymaster reputation after abuse cool-down period', async function () {
+      let currentBlockNumber = await contractInteractor.getBlockNumber()
       await reputationStoreManager.clearAll()
       await reputationStoreManager.createEntry(paymaster, initialReputation)
-      await reputationStoreManager.setAbuseFlag(paymaster)
+      await reputationStoreManager.setAbuseFlag(paymaster, currentBlockNumber)
       /* start - disabled storage */
       reputationManager.localReputationEntries.clear()
       reputationManager.createNewEntry(paymaster)
-      reputationManager.localReputationEntries.get(paymaster)!.abuseStartedTs = Date.now()
+      reputationManager.localReputationEntries.get(paymaster)!.abuseStartedBlock = currentBlockNumber
       /* end - disabled storage */
-      let status = await reputationManager.getPaymasterStatus(paymaster)
+      let status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.ABUSED)
-      mockSleep(abuseBlockDurationMs)
-      status = await reputationManager.getPaymasterStatus(paymaster)
+      await evmMineMany(abuseBlacklistDurationBlocks + 1)
+      currentBlockNumber = await contractInteractor.getBlockNumber()
+      status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.GOOD)
     })
   })
@@ -103,19 +117,21 @@ contract('ReputationManager', function () {
     })
 
     it('should detect an abuse if the reputation drops too fast', async function () {
-      let status = await reputationManager.getPaymasterStatus(paymaster)
+      const currentBlockNumber = await contractInteractor.getBlockNumber()
+      let status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.GOOD)
       for (let i = 0; i <= 20; i++) {
-        await reputationManager.updatePaymasterStatus(paymaster, false)
+        await reputationManager.updatePaymasterStatus(paymaster, false, currentBlockNumber)
       }
-      status = await reputationManager.getPaymasterStatus(paymaster)
+      status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.ABUSED)
     })
 
     it('should not update reputation above the specified maximum value', async function () {
+      const currentBlockNumber = await contractInteractor.getBlockNumber()
       const entry = await reputationStoreManager.getEntry(paymaster)
       assert.equal(entry?.reputation, 100)
-      await reputationManager.updatePaymasterStatus(paymaster, true)
+      await reputationManager.updatePaymasterStatus(paymaster, true, currentBlockNumber)
       assert.equal(entry?.reputation, 100)
     })
   })

--- a/test/relayserver/ReputationManager.test.ts
+++ b/test/relayserver/ReputationManager.test.ts
@@ -46,7 +46,7 @@ contract('ReputationManager', function () {
       abuseTimeWindowBlocks,
       abuseBlacklistDurationBlocks
     }
-    reputationStoreManager = new ReputationStoreManager({}, logger)
+    reputationStoreManager = new ReputationStoreManager({ inMemory: true }, logger)
     await reputationStoreManager.clearAll()
     reputationManager = new ReputationManager(reputationStoreManager, logger, reputationManagerConfig)
     contractInteractor = new ContractInteractor({
@@ -91,11 +91,6 @@ contract('ReputationManager', function () {
       await reputationStoreManager.clearAll()
       await reputationStoreManager.createEntry(paymaster, initialReputation)
       await reputationStoreManager.setAbuseFlag(paymaster, currentBlockNumber)
-      /* start - disabled storage */
-      reputationManager.localReputationEntries.clear()
-      reputationManager.createNewEntry(paymaster)
-      reputationManager.localReputationEntries.get(paymaster)!.abuseStartedBlock = currentBlockNumber
-      /* end - disabled storage */
       let status = await reputationManager.getPaymasterStatus(paymaster, currentBlockNumber)
       assert.equal(status, PaymasterStatus.ABUSED)
       await evmMineMany(abuseBlacklistDurationBlocks + 1)
@@ -109,11 +104,6 @@ contract('ReputationManager', function () {
     beforeEach(async function () {
       await reputationStoreManager.clearAll()
       await reputationStoreManager.createEntry(paymaster, 100)
-      /* start - disabled storage */
-      reputationManager.localReputationEntries.clear()
-      reputationManager.createNewEntry(paymaster)
-      reputationManager.localReputationEntries.get(paymaster)!.reputation = 100
-      /* end - disabled storage */
     })
 
     it('should detect an abuse if the reputation drops too fast', async function () {


### PR DESCRIPTION
This will prevent the bug where paymaster reputation is permanently
affected by the same accepted/rejected event on every server restart.

This should also prevent crash on update to version >2.0.3 (OG-331)