### PR TITLE
OG-234 Make 'sleep' for alerted mode be the first thing done

### DIFF
--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -275,6 +275,10 @@ returnValue        | ${viewRelayCallRet.returnValue}
     if (!this.isReady()) {
       throw new Error('relay not ready')
     }
+    if (this.alerted) {
+      this.logger.error('Alerted state: slowing down traffic')
+      await sleep(randomInRange(this.config.minAlertedDelayMS, this.config.maxAlertedDelayMS))
+    }
     this.validateInput(req)
     this.validateFees(req)
     await this.validateMaxNonce(req.metadata.relayMaxNonce)
@@ -308,10 +312,6 @@ returnValue        | ${viewRelayCallRet.returnValue}
     const { signedTx } = await this.transactionManager.sendTransaction(details)
     // after sending a transaction is a good time to check the worker's balance, and replenish it.
     await this.replenishServer(0, currentBlock)
-    if (this.alerted) {
-      this.logger.error('Alerted state: slowing down traffic')
-      await sleep(randomInRange(this.config.minAlertedDelayMS, this.config.maxAlertedDelayMS))
-    }
     return signedTx
   }
 


### PR DESCRIPTION
The purpose of the random 'sleep' is to make it harder for attackers to
trick the relays into broadcasting the transaction that would otherwise
fail validation. If sleep is done after the broadcst, it has no effect.