### PR TITLE
OG-413 Minor audit issues

### DIFF
--- a/contracts/BaseRelayRecipient.sol
+++ b/contracts/BaseRelayRecipient.sol
@@ -26,7 +26,7 @@ abstract contract BaseRelayRecipient is IRelayRecipient {
      * should be used in the contract anywhere instead of msg.sender
      */
     function _msgSender() internal override virtual view returns (address payable ret) {
-        if (msg.data.length >= 24 && isTrustedForwarder(msg.sender)) {
+        if (msg.data.length >= 20 && isTrustedForwarder(msg.sender)) {
             // At this point we know that the sender is a trusted forwarder,
             // so we trust that the last bytes of msg.data are the verified sender address.
             // extract sender address from the end of msg.data

--- a/contracts/RelayHub.sol
+++ b/contracts/RelayHub.sol
@@ -75,8 +75,9 @@ contract RelayHub is IRelayHub {
 
     function addRelayWorkers(address[] calldata newRelayWorkers) external override {
         address relayManager = msg.sender;
-        workerCount[relayManager] = workerCount[relayManager] + newRelayWorkers.length;
-        require(workerCount[relayManager] <= maxWorkerCount, "too many workers");
+        uint256 newWorkerCount = workerCount[relayManager] + newRelayWorkers.length;
+        workerCount[relayManager] = newWorkerCount;
+        require(newWorkerCount <= maxWorkerCount, "too many workers");
 
         require(
             isRelayManagerStaked(relayManager),
@@ -88,7 +89,7 @@ contract RelayHub is IRelayHub {
             workerToManager[newRelayWorkers[i]] = relayManager;
         }
 
-        emit RelayWorkersAdded(relayManager, newRelayWorkers, workerCount[relayManager]);
+        emit RelayWorkersAdded(relayManager, newRelayWorkers, newWorkerCount);
     }
 
     function depositFor(address target) public override payable {
@@ -321,7 +322,7 @@ contract RelayHub is IRelayHub {
             }
 
             if (vars.rejectOnRecipientRevert && !vars.relayedCallSuccess) {
-                //we trusted the recipient, but it reverted...
+                // we trusted the recipient, but it reverted...
                 revertWithStatus(RelayCallStatus.RejectedByRecipientRevert, vars.relayedCallReturnValue);
             }
         }
@@ -367,7 +368,6 @@ contract RelayHub is IRelayHub {
     }
 
     function calculateCharge(uint256 gasUsed, GsnTypes.RelayData calldata relayData) public override virtual view returns (uint256) {
-        //       relayData.baseRelayFee + (gasUsed * relayData.gasPrice * (100 + relayData.pctRelayFee)) / 100;
         return relayData.baseRelayFee.add((gasUsed.mul(relayData.gasPrice).mul(relayData.pctRelayFee.add(100))).div(100));
     }
 

--- a/contracts/interfaces/GsnTypes.sol
+++ b/contracts/interfaces/GsnTypes.sol
@@ -4,6 +4,7 @@ pragma solidity >=0.7.5;
 import "../forwarder/IForwarder.sol";
 
 interface GsnTypes {
+    /// @notice gasPrice, pctRelayFee and baseRelayFee must be validated inside of the paymaster's preRelayedCall in order not to overpay
     struct RelayData {
         uint256 gasPrice;
         uint256 pctRelayFee;

--- a/contracts/interfaces/IRelayHub.sol
+++ b/contracts/interfaces/IRelayHub.sol
@@ -22,14 +22,14 @@ interface IRelayHub {
         uint256 workersCount
     );
 
-    // Emitted when an account withdraws funds from RelayHub.
+    /// Emitted when an account withdraws funds from RelayHub.
     event Withdrawn(
         address indexed account,
         address indexed dest,
         uint256 amount
     );
 
-    // Emitted when depositFor is called, including the amount and account that was funded.
+    /// Emitted when depositFor is called, including the amount and account that was funded.
     event Deposited(
         address indexed paymaster,
         address indexed from,
@@ -49,10 +49,10 @@ interface IRelayHub {
         uint256 innerGasUsed,
         bytes reason);
 
-    // Emitted when a transaction is relayed. Note that the actual encoded function might be reverted: this will be
-    // indicated in the status field.
-    // Useful when monitoring a relay's operation and relayed calls to a contract.
-    // Charge is the ether value deducted from the recipient's balance, paid to the relay's manager.
+    /// Emitted when a transaction is relayed. Note that the actual encoded function might be reverted: this will be
+    /// indicated in the status field.
+    /// Useful when monitoring a relay's operation and relayed calls to a contract.
+    /// Charge is the ether value deducted from the recipient's balance, paid to the relay's manager.
     event TransactionRelayed(
         address indexed relayManager,
         address indexed relayWorker,
@@ -94,14 +94,14 @@ interface IRelayHub {
 
     // Balance management
 
-    // Deposits ether for a contract, so that it can receive (and pay for) relayed transactions. Unused balance can only
-    // be withdrawn by the contract itself, by calling withdraw.
-    // Emits a Deposited event.
+    /// Deposits ether for a contract, so that it can receive (and pay for) relayed transactions. Unused balance can only
+    /// be withdrawn by the contract itself, by calling withdraw.
+    /// Emits a Deposited event.
     function depositFor(address target) external payable;
 
-    // Withdraws from an account's balance, sending it back to it. Relay managers call this to retrieve their revenue, and
-    // contracts can also use it to reduce their funding.
-    // Emits a Withdrawn event.
+    /// Withdraws from an account's balance, sending it back to it. Relay managers call this to retrieve their revenue, and
+    /// contracts can also use it to reduce their funding.
+    /// Emits a Withdrawn event.
     function withdraw(uint256 amount, address payable dest) external;
 
     // Relaying
@@ -151,38 +151,37 @@ interface IRelayHub {
     /// Returns an account's deposits. It can be either a deposit of a paymaster, or a revenue of a relay manager.
     function balanceOf(address target) external view returns (uint256);
 
-    // Minimum stake a relay can have. An attack to the network will never cost less than half this value.
+    /// Minimum stake a relay can have. An attack to the network will never cost less than half this value.
     function minimumStake() external view returns (uint256);
 
-    // Minimum unstake delay blocks of a relay manager's stake on the StakeManager
+    /// Minimum unstake delay blocks of a relay manager's stake on the StakeManager
     function minimumUnstakeDelay() external view returns (uint256);
 
-    // Maximum funds that can be deposited at once. Prevents user error by disallowing large deposits.
+    /// Maximum funds that can be deposited at once. Prevents user error by disallowing large deposits.
     function maximumRecipientDeposit() external view returns (uint256);
 
-    //gas overhead to calculate gasUseWithoutPost
+    /// Gas overhead to calculate gasUseWithoutPost
     function postOverhead() external view returns (uint256);
 
-    // Gas set aside for all relayCall() instructions to prevent unexpected out-of-gas exceptions
+    /// Gas set aside for all relayCall() instructions to prevent unexpected out-of-gas exceptions
     function gasReserve() external view returns (uint256);
 
-    // maximum number of worker account allowed per manager
+    /// maximum number of worker accounts allowed per manager
     function maxWorkerCount() external view returns (uint256);
 
     function workerToManager(address worker) external view returns(address);
 
     function workerCount(address manager) external view returns(uint256);
 
+    /// Uses StakeManager info to decide if the Relay Manager can be considered staked
+    /// @return true if stake size and delay satisfy all requirements
     function isRelayManagerStaked(address relayManager) external view returns(bool);
 
-    /**
-    * @dev the total gas overhead of relayCall(), before the first gasleft() and after the last gasleft().
-    * Assume that relay has non-zero balance (costs 15'000 more otherwise).
-    */
-
-    // Gas cost of all relayCall() instructions after actual 'calculateCharge()'
+    /// Gas cost of all relayCall() instructions after actual 'calculateCharge()'
+    /// Assume that relay has non-zero balance (costs 15'000 more otherwise).
     function gasOverhead() external view returns (uint256);
 
+    /// @return a SemVer-compliant version of the hub contract
     function versionHub() external view returns (string memory);
 }
 

--- a/contracts/interfaces/IStakeManager.sol
+++ b/contracts/interfaces/IStakeManager.sol
@@ -101,5 +101,7 @@ interface IStakeManager {
 
     function getStakeInfo(address relayManager) external view returns (StakeInfo memory stakeInfo);
 
+    function maxUnstakeDelay() external view returns (uint256);
+
     function versionSM() external view returns (string memory);
 }

--- a/migrations/2_deploy_contracts.js
+++ b/migrations/2_deploy_contracts.js
@@ -5,7 +5,7 @@ const SampleRecipient = artifacts.require('TestRecipient')
 const Forwarder = artifacts.require('Forwarder')
 
 module.exports = async function (deployer) {
-  await deployer.deploy(StakeManager)
+  await deployer.deploy(StakeManager, 30000)
   await deployer.deploy(Penalizer)
   await deployer.deploy(RelayHub, StakeManager.address, Penalizer.address, 0, 0, 0, 0, 0, 0, 0)
   await deployer.deploy(Forwarder)

--- a/src/cli/CommandsLogic.ts
+++ b/src/cli/CommandsLogic.ts
@@ -27,6 +27,7 @@ import { registerForwarderForGsn } from '../common/EIP712/ForwarderUtil'
 import { LoggerInterface } from '../common/LoggerInterface'
 import HttpWrapper from '../relayclient/HttpWrapper'
 import { GSNContractsDeployment } from '../common/GSNContractsDeployment'
+import { defaultStakeManagerMaxUnstakeDelay } from '../common/Environments'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -301,7 +302,9 @@ export default class CommandsLogic {
       gasPrice: deployOptions.gasPrice ?? (1e9).toString()
     }
 
-    const sInstance = await this.getContractInstance(StakeManager, {}, deployOptions.stakeManagerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
+    const sInstance = await this.getContractInstance(StakeManager, {
+      arguments: [defaultStakeManagerMaxUnstakeDelay]
+    }, deployOptions.stakeManagerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const pInstance = await this.getContractInstance(Penalizer, {}, deployOptions.penalizerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const fInstance = await this.getContractInstance(Forwarder, {}, deployOptions.forwarderAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const rInstance = await this.getContractInstance(RelayHub, {

--- a/src/cli/CommandsLogic.ts
+++ b/src/cli/CommandsLogic.ts
@@ -27,7 +27,7 @@ import { registerForwarderForGsn } from '../common/EIP712/ForwarderUtil'
 import { LoggerInterface } from '../common/LoggerInterface'
 import HttpWrapper from '../relayclient/HttpWrapper'
 import { GSNContractsDeployment } from '../common/GSNContractsDeployment'
-import { defaultStakeManagerMaxUnstakeDelay } from '../common/Environments'
+import { defaultEnvironment } from '../common/Environments'
 
 require('source-map-support').install({ errorFormatterForce: true })
 
@@ -303,7 +303,7 @@ export default class CommandsLogic {
     }
 
     const sInstance = await this.getContractInstance(StakeManager, {
-      arguments: [defaultStakeManagerMaxUnstakeDelay]
+      arguments: [defaultEnvironment.maxUnstakeDelay]
     }, deployOptions.stakeManagerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const pInstance = await this.getContractInstance(Penalizer, {}, deployOptions.penalizerAddress, Object.assign({}, options), deployOptions.skipConfirmation)
     const fInstance = await this.getContractInstance(Forwarder, {}, deployOptions.forwarderAddress, Object.assign({}, options), deployOptions.skipConfirmation)

--- a/src/common/Environments.ts
+++ b/src/common/Environments.ts
@@ -9,15 +9,16 @@ interface Environment {
   readonly chainId: number
   readonly mintxgascost: number
   readonly relayHubConfiguration: RelayHubConfiguration
+  readonly maxUnstakeDelay: number
 }
 
 /**
  * With about 6000 blocks per day, maximum unstake delay is defined at around 5 years for the mainnet.
  * This is done to prevent mistakenly setting an unstake delay to millions of years.
  */
-export const defaultStakeManagerMaxUnstakeDelay: number = 10000000
+const defaultStakeManagerMaxUnstakeDelay: number = 10000000
 
-export const defaultRelayHubConfiguration: RelayHubConfiguration = {
+const defaultRelayHubConfiguration: RelayHubConfiguration = {
   gasOverhead: 33346,
   postOverhead: 13016,
   gasReserve: 100000,
@@ -31,16 +32,19 @@ export const environments: { [key: string]: Environment } = {
   istanbul: {
     chainId: 1,
     relayHubConfiguration: defaultRelayHubConfiguration,
+    maxUnstakeDelay: defaultStakeManagerMaxUnstakeDelay,
     mintxgascost: 21000
   },
   constantinople: {
     chainId: 1,
     relayHubConfiguration: defaultRelayHubConfiguration,
+    maxUnstakeDelay: defaultStakeManagerMaxUnstakeDelay,
     mintxgascost: 21000
   },
   ganacheLocal: {
     chainId: 1337,
     relayHubConfiguration: defaultRelayHubConfiguration,
+    maxUnstakeDelay: defaultStakeManagerMaxUnstakeDelay,
     mintxgascost: 21000
   }
 }

--- a/src/common/Environments.ts
+++ b/src/common/Environments.ts
@@ -11,6 +11,12 @@ interface Environment {
   readonly relayHubConfiguration: RelayHubConfiguration
 }
 
+/**
+ * With about 6000 blocks per day, maximum unstake delay is defined at around 5 years for the mainnet.
+ * This is done to prevent mistakenly setting an unstake delay to millions of years.
+ */
+export const defaultStakeManagerMaxUnstakeDelay: number = 10000000
+
 export const defaultRelayHubConfiguration: RelayHubConfiguration = {
   gasOverhead: 33346,
   postOverhead: 13016,

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -16,6 +16,7 @@ import { deployHub, startRelay, stopRelay } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { GSNConfig } from '../src/relayclient/GSNConfigurator'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
+import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
@@ -53,7 +54,7 @@ options.forEach(params => {
       gasless = await web3.eth.personal.newAccount('password')
       await web3.eth.personal.unlockAccount(gasless, 'password', 0)
 
-      sm = await StakeManager.new()
+      sm = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       const p = await Penalizer.new()
       rhub = await deployHub(sm.address, p.address)
       if (params.relay) {

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -16,7 +16,7 @@ import { deployHub, startRelay, stopRelay } from './TestUtils'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { GSNConfig } from '../src/relayclient/GSNConfigurator'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
-import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 
 const TestRecipient = artifacts.require('tests/TestRecipient')
 const TestPaymasterEverythingAccepted = artifacts.require('tests/TestPaymasterEverythingAccepted')
@@ -54,7 +54,7 @@ options.forEach(params => {
       gasless = await web3.eth.personal.newAccount('password')
       await web3.eth.personal.unlockAccount(gasless, 'password', 0)
 
-      sm = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      sm = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       const p = await Penalizer.new()
       rhub = await deployHub(sm.address, p.address)
       if (params.relay) {

--- a/test/PaymasterCommitment.test.ts
+++ b/test/PaymasterCommitment.test.ts
@@ -18,6 +18,7 @@ import ForwardRequest from '../src/common/EIP712/ForwardRequest'
 import RelayData from '../src/common/EIP712/RelayData'
 import { deployHub, encodeRevertReason } from './TestUtils'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
+import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Forwarder = artifacts.require('Forwarder')
@@ -92,7 +93,7 @@ contract('Paymaster Commitment', function ([_, relayOwner, relayManager, relayWo
   const pctRelayFee = '0'
 
   before(async function () {
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHubInstance = await deployHub(stakeManager.address, penalizer.address)
 

--- a/test/PaymasterCommitment.test.ts
+++ b/test/PaymasterCommitment.test.ts
@@ -18,7 +18,7 @@ import ForwardRequest from '../src/common/EIP712/ForwardRequest'
 import RelayData from '../src/common/EIP712/RelayData'
 import { deployHub, encodeRevertReason } from './TestUtils'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
-import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Forwarder = artifacts.require('Forwarder')
@@ -93,7 +93,7 @@ contract('Paymaster Commitment', function ([_, relayOwner, relayManager, relayWo
   const pctRelayFee = '0'
 
   before(async function () {
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHubInstance = await deployHub(stakeManager.address, penalizer.address)
 

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -4,7 +4,7 @@ import chai from 'chai'
 
 import { decodeRevertReason, getEip712Signature, removeHexPrefix } from '../src/common/Utils'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
-import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import {
@@ -55,7 +55,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
   let forwarder: string
 
   beforeEach(async function () {
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHubInstance = await deployHub(stakeManager.address, penalizer.address)
     paymasterContract = await TestPaymasterEverythingAccepted.new()

--- a/test/RelayHub.test.ts
+++ b/test/RelayHub.test.ts
@@ -4,7 +4,7 @@ import chai from 'chai'
 
 import { decodeRevertReason, getEip712Signature, removeHexPrefix } from '../src/common/Utils'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
-import { defaultEnvironment } from '../src/common/Environments'
+import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import {
@@ -55,7 +55,7 @@ contract('RelayHub', function ([_, relayOwner, relayManager, relayWorker, sender
   let forwarder: string
 
   beforeEach(async function () {
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHubInstance = await deployHub(stakeManager.address, penalizer.address)
     paymasterContract = await TestPaymasterEverythingAccepted.new()

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -3,7 +3,7 @@ import { ether, expectEvent } from '@openzeppelin/test-helpers'
 
 import { calculateTransactionMaxPossibleGas, getEip712Signature } from '../src/common/Utils'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
-import { defaultEnvironment } from '../src/common/Environments'
+import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
 
 import {
@@ -58,7 +58,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
     forwarder = forwarderInstance.address
     recipient = await TestRecipient.new(forwarder)
     paymaster = await TestPaymasterVariableGasLimits.new()
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     await paymaster.setTrustedForwarder(forwarder)

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -3,7 +3,7 @@ import { ether, expectEvent } from '@openzeppelin/test-helpers'
 
 import { calculateTransactionMaxPossibleGas, getEip712Signature } from '../src/common/Utils'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
-import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
 
 import {
@@ -58,7 +58,7 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
     forwarder = forwarderInstance.address
     recipient = await TestRecipient.new(forwarder)
     paymaster = await TestPaymasterVariableGasLimits.new()
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     await paymaster.setTrustedForwarder(forwarder)

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -12,7 +12,7 @@ import { privateToAddress, stripZeros, toBuffer } from 'ethereumjs-util'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
-import { defaultEnvironment } from '../src/common/Environments'
+import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 import {
   PenalizerInstance,
   RelayHubInstance, StakeManagerInstance,
@@ -49,7 +49,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
   let forwarder: string
   // TODO: 'before' is a bad thing in general. Use 'beforeEach', this tests all depend on each other!!!
   before(async function () {
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/RelayHubPenalizations.test.ts
+++ b/test/RelayHubPenalizations.test.ts
@@ -12,7 +12,7 @@ import { privateToAddress, stripZeros, toBuffer } from 'ethereumjs-util'
 import RelayRequest from '../src/common/EIP712/RelayRequest'
 import { getEip712Signature } from '../src/common/Utils'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
-import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 import {
   PenalizerInstance,
   RelayHubInstance, StakeManagerInstance,
@@ -49,7 +49,7 @@ contract('RelayHub Penalizations', function ([_, relayOwner, relayWorker, otherR
   let forwarder: string
   // TODO: 'before' is a bad thing in general. Use 'beforeEach', this tests all depend on each other!!!
   before(async function () {
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/RelayHubRegistrationsManagement.test.ts
+++ b/test/RelayHubRegistrationsManagement.test.ts
@@ -8,6 +8,7 @@ import {
   TestPaymasterEverythingAcceptedInstance
 } from '../types/truffle-contracts'
 import { deployHub } from './TestUtils'
+import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -24,7 +25,7 @@ contract('RelayHub Relay Management', function ([_, relayOwner, relayManager, re
   let penalizer: PenalizerInstance
 
   beforeEach(async function () {
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     paymaster = await TestPaymasterEverythingAccepted.new()

--- a/test/RelayHubRegistrationsManagement.test.ts
+++ b/test/RelayHubRegistrationsManagement.test.ts
@@ -8,7 +8,7 @@ import {
   TestPaymasterEverythingAcceptedInstance
 } from '../types/truffle-contracts'
 import { deployHub } from './TestUtils'
-import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -25,7 +25,7 @@ contract('RelayHub Relay Management', function ([_, relayOwner, relayManager, re
   let penalizer: PenalizerInstance
 
   beforeEach(async function () {
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     paymaster = await TestPaymasterEverythingAccepted.new()

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -7,7 +7,7 @@ import BN from 'bn.js'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { deployHub } from './TestUtils'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
-import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -44,7 +44,7 @@ contract('SampleRecipient', function (accounts) {
   // TODO: this test is in a wrong file
   it('should allow owner to withdraw balance from RelayHub', async function () {
     const deposit = new BN('100000000000000000')
-    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    const stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     const penalizer = await Penalizer.new()
     const rhub = await deployHub(stakeManager.address, penalizer.address)
     await paymaster.setTrustedForwarder(forwarder)

--- a/test/SampleRecipient.test.ts
+++ b/test/SampleRecipient.test.ts
@@ -7,6 +7,7 @@ import BN from 'bn.js'
 import { PrefixedHexString } from 'ethereumjs-tx'
 import { deployHub } from './TestUtils'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
+import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -43,7 +44,7 @@ contract('SampleRecipient', function (accounts) {
   // TODO: this test is in a wrong file
   it('should allow owner to withdraw balance from RelayHub', async function () {
     const deposit = new BN('100000000000000000')
-    const stakeManager = await StakeManager.new()
+    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     const penalizer = await Penalizer.new()
     const rhub = await deployHub(stakeManager.address, penalizer.address)
     await paymaster.setTrustedForwarder(forwarder)

--- a/test/StakeManager.test.ts
+++ b/test/StakeManager.test.ts
@@ -75,7 +75,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with no stake for relay server', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     })
 
     testStakeNotValid()
@@ -136,7 +136,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with stake deposited for relay server', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -264,7 +264,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with authorized hub', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -351,7 +351,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with scheduled deauthorization of an authorized hub', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -383,7 +383,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with scheduled unlock while hub still authorized', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,

--- a/test/StakeManager.test.ts
+++ b/test/StakeManager.test.ts
@@ -4,6 +4,7 @@ import { evmMineMany } from './TestUtils'
 import BN from 'bn.js'
 
 import { StakeManagerInstance } from '../types/truffle-contracts'
+import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 
@@ -74,7 +75,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with no stake for relay server', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     })
 
     testStakeNotValid()
@@ -114,9 +115,19 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
       )
     })
 
-    it('with owner set', async function () {
-      before(async function () {
+    context('with owner set', function () {
+      beforeEach(async function () {
         await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
+      })
+
+      it('should not allow owner to stake with an unstake delay exceeding maximum', async function () {
+        await expectRevert(
+          stakeManager.stakeForRelayManager(relayManager, defaultStakeManagerMaxUnstakeDelay + 1, {
+            value: initialStake,
+            from: owner
+          }),
+          'unstakeDelay too big'
+        )
       })
 
       testOwnerCanStake()
@@ -125,7 +136,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with stake deposited for relay server', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -253,7 +264,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with authorized hub', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -340,7 +351,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with scheduled deauthorization of an authorized hub', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,
@@ -372,7 +383,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
   describe('with scheduled unlock while hub still authorized', function () {
     beforeEach(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       await stakeManager.setRelayManagerOwner(owner, { from: relayManager })
       await stakeManager.stakeForRelayManager(relayManager, initialUnstakeDelay, {
         value: initialStake,

--- a/test/StakeManager.test.ts
+++ b/test/StakeManager.test.ts
@@ -4,7 +4,7 @@ import { evmMineMany } from './TestUtils'
 import BN from 'bn.js'
 
 import { StakeManagerInstance } from '../types/truffle-contracts'
-import { defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 
@@ -122,7 +122,7 @@ contract('StakeManager', function ([_, relayManager, anyRelayHub, owner, nonOwne
 
       it('should not allow owner to stake with an unstake delay exceeding maximum', async function () {
         await expectRevert(
-          stakeManager.stakeForRelayManager(relayManager, defaultStakeManagerMaxUnstakeDelay + 1, {
+          stakeManager.stakeForRelayManager(relayManager, defaultEnvironment.maxUnstakeDelay + 1, {
             value: initialStake,
             from: owner
           }),

--- a/test/TestBatchForwarder.test.ts
+++ b/test/TestBatchForwarder.test.ts
@@ -6,7 +6,7 @@ import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import { getEip712Signature } from '../src/common/Utils'
 
-import { defaultEnvironment } from '../src/common/Environments'
+import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
 import {
   RelayHubInstance,
   TestPaymasterEverythingAcceptedInstance,
@@ -33,7 +33,7 @@ contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
   before(async () => {
     const paymasterDeposit = 1e18.toString()
 
-    const stakeManager = await StakeManager.new()
+    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     const penalizer = await Penalizer.new()
     hub = await deployHub(stakeManager.address, penalizer.address)
     const relayHub = hub

--- a/test/TestBatchForwarder.test.ts
+++ b/test/TestBatchForwarder.test.ts
@@ -6,7 +6,7 @@ import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 
 import { getEip712Signature } from '../src/common/Utils'
 
-import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../src/common/Environments'
+import { defaultEnvironment } from '../src/common/Environments'
 import {
   RelayHubInstance,
   TestPaymasterEverythingAcceptedInstance,
@@ -33,7 +33,7 @@ contract('BatchForwarder', ([from, relayManager, relayWorker, relayOwner]) => {
   before(async () => {
     const paymasterDeposit = 1e18.toString()
 
-    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    const stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     const penalizer = await Penalizer.new()
     hub = await deployHub(stakeManager.address, penalizer.address)
     const relayHub = hub

--- a/test/common/ContractInteractor.test.ts
+++ b/test/common/ContractInteractor.test.ts
@@ -19,7 +19,7 @@ import { deployHub } from '../TestUtils'
 import VersionsManager from '../../src/common/VersionsManager'
 import { gsnRequiredVersion, gsnRuntimeVersion } from '../../src/common/Version'
 import { GSNContractsDeployment } from '../../src/common/GSNContractsDeployment'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const { expect } = chai.use(chaiAsPromised)
 
@@ -38,7 +38,7 @@ contract('ContractInteractor', function (accounts) {
   let pm: TestPaymasterConfigurableMisbehaviorInstance
 
   before(async () => {
-    sm = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    sm = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     pen = await Penalizer.new()
     rh = await deployHub(sm.address, pen.address)
     pm = await TestPaymasterConfigurableMisbehavior.new()

--- a/test/common/ContractInteractor.test.ts
+++ b/test/common/ContractInteractor.test.ts
@@ -19,6 +19,7 @@ import { deployHub } from '../TestUtils'
 import VersionsManager from '../../src/common/VersionsManager'
 import { gsnRequiredVersion, gsnRuntimeVersion } from '../../src/common/Version'
 import { GSNContractsDeployment } from '../../src/common/GSNContractsDeployment'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const { expect } = chai.use(chaiAsPromised)
 
@@ -37,7 +38,7 @@ contract('ContractInteractor', function (accounts) {
   let pm: TestPaymasterConfigurableMisbehaviorInstance
 
   before(async () => {
-    sm = await StakeManager.new()
+    sm = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     pen = await Penalizer.new()
     rh = await deployHub(sm.address, pen.address)
     pm = await TestPaymasterConfigurableMisbehavior.new()

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -20,7 +20,7 @@ import { LoggerInterface } from '../../src/common/LoggerInterface'
 import { RelayInfoUrl, RelayRegisteredEventInfo } from '../../src/common/types/RelayRegisteredEventInfo'
 import { createClientLogger } from '../../src/relayclient/ClientWinstonLogger'
 import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -74,7 +74,7 @@ contract('KnownRelaysManager', function (
       workerRelayWorkersAdded = await web3.eth.personal.newAccount('password')
       workerRelayServerRegistered = await web3.eth.personal.newAccount('password')
       workerNotActive = await web3.eth.personal.newAccount('password')
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       penalizer = await Penalizer.new()
       relayHub = await deployHub(stakeManager.address, penalizer.address)
       config = configureGSN({
@@ -188,7 +188,7 @@ contract('KnownRelaysManager 2', function (accounts) {
     let config: GSNConfig
 
     before(async function () {
-      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+      stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
       penalizer = await Penalizer.new()
       relayHub = await deployHub(stakeManager.address, penalizer.address)
       config = configureGSN({

--- a/test/relayclient/KnownRelaysManager.test.ts
+++ b/test/relayclient/KnownRelaysManager.test.ts
@@ -20,6 +20,7 @@ import { LoggerInterface } from '../../src/common/LoggerInterface'
 import { RelayInfoUrl, RelayRegisteredEventInfo } from '../../src/common/types/RelayRegisteredEventInfo'
 import { createClientLogger } from '../../src/relayclient/ClientWinstonLogger'
 import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -73,7 +74,7 @@ contract('KnownRelaysManager', function (
       workerRelayWorkersAdded = await web3.eth.personal.newAccount('password')
       workerRelayServerRegistered = await web3.eth.personal.newAccount('password')
       workerNotActive = await web3.eth.personal.newAccount('password')
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       penalizer = await Penalizer.new()
       relayHub = await deployHub(stakeManager.address, penalizer.address)
       config = configureGSN({
@@ -187,7 +188,7 @@ contract('KnownRelaysManager 2', function (accounts) {
     let config: GSNConfig
 
     before(async function () {
-      stakeManager = await StakeManager.new()
+      stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
       penalizer = await Penalizer.new()
       relayHub = await deployHub(stakeManager.address, penalizer.address)
       config = configureGSN({

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -42,6 +42,7 @@ import { LoggerInterface } from '../../src/common/LoggerInterface'
 import { ether } from '@openzeppelin/test-helpers'
 import BadContractInteractor from '../dummies/BadContractInteractor'
 import ContractInteractor from '../../src/common/ContractInteractor'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -110,7 +111,7 @@ contract('RelayClient', function (accounts) {
 
   before(async function () {
     web3 = new Web3(underlyingProvider)
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -42,7 +42,7 @@ import { LoggerInterface } from '../../src/common/LoggerInterface'
 import { ether } from '@openzeppelin/test-helpers'
 import BadContractInteractor from '../dummies/BadContractInteractor'
 import ContractInteractor from '../../src/common/ContractInteractor'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -111,7 +111,7 @@ contract('RelayClient', function (accounts) {
 
   before(async function () {
     web3 = new Web3(underlyingProvider)
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -18,7 +18,7 @@ import {
   TestRecipientInstance
 } from '../../types/truffle-contracts'
 import { Address } from '../../src/common/types/Aliases'
-import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 import { deployHub, encodeRevertReason, startRelay, stopRelay } from '../TestUtils'
 import BadRelayClient from '../dummies/BadRelayClient'
 
@@ -98,7 +98,7 @@ contract('RelayProvider', function (accounts) {
   before(async function () {
     web3 = new Web3(underlyingProvider)
     gasLess = await web3.eth.personal.newAccount('password')
-    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayclient/RelayProvider.test.ts
+++ b/test/relayclient/RelayProvider.test.ts
@@ -18,7 +18,7 @@ import {
   TestRecipientInstance
 } from '../../types/truffle-contracts'
 import { Address } from '../../src/common/types/Aliases'
-import { defaultEnvironment } from '../../src/common/Environments'
+import { defaultEnvironment, defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 import { deployHub, encodeRevertReason, startRelay, stopRelay } from '../TestUtils'
 import BadRelayClient from '../dummies/BadRelayClient'
 
@@ -98,7 +98,7 @@ contract('RelayProvider', function (accounts) {
   before(async function () {
     web3 = new Web3(underlyingProvider)
     gasLess = await web3.eth.personal.newAccount('password')
-    stakeManager = await StakeManager.new()
+    stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     penalizer = await Penalizer.new()
     relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayclient/RelaySelectionManager.test.ts
+++ b/test/relayclient/RelaySelectionManager.test.ts
@@ -15,7 +15,7 @@ import { RelayInfoUrl, RelayRegisteredEventInfo } from '../../src/common/types/R
 import { configureGSN, deployHub } from '../TestUtils'
 import { createClientLogger } from '../../src/relayclient/ClientWinstonLogger'
 import { register, stake } from './KnownRelaysManager.test'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
 
@@ -113,7 +113,7 @@ contract('RelaySelectionManager', function (accounts) {
       before(async function () {
         const StakeManager = artifacts.require('StakeManager')
         const Penalizer = artifacts.require('Penalizer')
-        const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+        const stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
         const penalizer = await Penalizer.new()
         relayHub = await deployHub(stakeManager.address, penalizer.address)
         await stake(stakeManager, relayHub, relayManager, accounts[0])

--- a/test/relayclient/RelaySelectionManager.test.ts
+++ b/test/relayclient/RelaySelectionManager.test.ts
@@ -15,6 +15,7 @@ import { RelayInfoUrl, RelayRegisteredEventInfo } from '../../src/common/types/R
 import { configureGSN, deployHub } from '../TestUtils'
 import { createClientLogger } from '../../src/relayclient/ClientWinstonLogger'
 import { register, stake } from './KnownRelaysManager.test'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const { expect, assert } = require('chai').use(chaiAsPromised)
 
@@ -112,7 +113,7 @@ contract('RelaySelectionManager', function (accounts) {
       before(async function () {
         const StakeManager = artifacts.require('StakeManager')
         const Penalizer = artifacts.require('Penalizer')
-        const stakeManager = await StakeManager.new()
+        const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
         const penalizer = await Penalizer.new()
         relayHub = await deployHub(stakeManager.address, penalizer.address)
         await stake(stakeManager, relayHub, relayManager, accounts[0])

--- a/test/relayserver/ReputationFlow.test.ts
+++ b/test/relayserver/ReputationFlow.test.ts
@@ -5,6 +5,7 @@ import { deployHub, evmMine, startRelay, stopRelay } from '../TestUtils'
 import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 import { HttpProvider } from 'web3-core'
 import { RelayProvider } from '../../src/relayclient/RelayProvider'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const TestPaymasterConfigurableMisbehavior = artifacts.require('TestPaymasterConfigurableMisbehavior')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -18,7 +19,7 @@ contract('ReputationFlow', function (accounts) {
   let testRecipient: TestRecipientInstance
 
   before(async function () {
-    const stakeManager = await StakeManager.new()
+    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     const penalizer = await Penalizer.new()
     const relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayserver/ReputationFlow.test.ts
+++ b/test/relayserver/ReputationFlow.test.ts
@@ -5,7 +5,7 @@ import { deployHub, evmMine, startRelay, stopRelay } from '../TestUtils'
 import { registerForwarderForGsn } from '../../src/common/EIP712/ForwarderUtil'
 import { HttpProvider } from 'web3-core'
 import { RelayProvider } from '../../src/relayclient/RelayProvider'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const TestPaymasterConfigurableMisbehavior = artifacts.require('TestPaymasterConfigurableMisbehavior')
 const TestRecipient = artifacts.require('TestRecipient')
@@ -19,7 +19,7 @@ contract('ReputationFlow', function (accounts) {
   let testRecipient: TestRecipientInstance
 
   before(async function () {
-    const stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    const stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     const penalizer = await Penalizer.new()
     const relayHub = await deployHub(stakeManager.address, penalizer.address)
     const forwarderInstance = await Forwarder.new()

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -44,7 +44,7 @@ import { createServerLogger } from '../../src/relayserver/ServerWinstonLogger'
 import { TransactionManager } from '../../src/relayserver/TransactionManager'
 import { GasPriceFetcher } from '../../src/relayclient/GasPriceFetcher'
 import { GSNContractsDeployment } from '../../src/common/GSNContractsDeployment'
-import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
+import { defaultEnvironment } from '../../src/common/Environments'
 
 const Forwarder = artifacts.require('Forwarder')
 const Penalizer = artifacts.require('Penalizer')
@@ -110,7 +110,7 @@ export class ServerTestEnvironment {
    * different provider from the contract interactor itself.
    */
   async init (clientConfig: Partial<GSNConfig> = {}, relayHubConfig: Partial<RelayHubConfiguration> = {}, contractFactory?: (deployment: GSNContractsDeployment) => Promise<ContractInteractor>): Promise<void> {
-    this.stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
+    this.stakeManager = await StakeManager.new(defaultEnvironment.maxUnstakeDelay)
     this.penalizer = await Penalizer.new()
     this.relayHub = await deployHub(this.stakeManager.address, this.penalizer.address, relayHubConfig)
     this.forwarder = await Forwarder.new()

--- a/test/relayserver/ServerTestEnvironment.ts
+++ b/test/relayserver/ServerTestEnvironment.ts
@@ -44,6 +44,7 @@ import { createServerLogger } from '../../src/relayserver/ServerWinstonLogger'
 import { TransactionManager } from '../../src/relayserver/TransactionManager'
 import { GasPriceFetcher } from '../../src/relayclient/GasPriceFetcher'
 import { GSNContractsDeployment } from '../../src/common/GSNContractsDeployment'
+import { defaultStakeManagerMaxUnstakeDelay } from '../../src/common/Environments'
 
 const Forwarder = artifacts.require('Forwarder')
 const Penalizer = artifacts.require('Penalizer')
@@ -109,7 +110,7 @@ export class ServerTestEnvironment {
    * different provider from the contract interactor itself.
    */
   async init (clientConfig: Partial<GSNConfig> = {}, relayHubConfig: Partial<RelayHubConfiguration> = {}, contractFactory?: (deployment: GSNContractsDeployment) => Promise<ContractInteractor>): Promise<void> {
-    this.stakeManager = await StakeManager.new()
+    this.stakeManager = await StakeManager.new(defaultStakeManagerMaxUnstakeDelay)
     this.penalizer = await Penalizer.new()
     this.relayHub = await deployHub(this.stakeManager.address, this.penalizer.address, relayHubConfig)
     this.forwarder = await Forwarder.new()


### PR DESCRIPTION
6.8-6.10 - add '@notice' comments to  GsnTypes about gas price, fees
6.12 - inconsistent natspec compliance in comments
6.20 - _msgSender only works on msg.data >= 24
6.28 - workerCount[relayManager] read thrice in this function
6.38 - the unstakeDelay could be accidentally set to unrealistically
long periods of time resulting in a forever locked stake