### PR TITLE
OG-410: forwarder frontrun value

### DIFF
--- a/contracts/forwarder/Forwarder.sol
+++ b/contracts/forwarder/Forwarder.sol
@@ -67,7 +67,7 @@ contract Forwarder is IForwarder {
 
         //this is a signed number (can be nagative). all params are known values,
         // so can't overflow.
-        uint excessBalance = address (this).balance - preBalance + req.value;
+        int excessBalance = int(address (this).balance - preBalance + req.value);
 
         // preBalance is the balance before this TX (and value sent to it as payable)
         // preBalance-req.value - the expected balance after the call, assuming it didn't send anything back
@@ -75,9 +75,9 @@ contract Forwarder is IForwarder {
         //   positive: the value sent by the method back to us: transfer to "from" address
         //   negative: too much was sent to the forwarder (preBalance > req.value)
         //         this excess is inaccessible.
-        if ( int(excessBalance)>0 ) {
+        if ( excessBalance>0 ) {
             //can't fail: req.from signed (off-chain) the request, so it must be an EOA...
-            payable(req.from).transfer(excessBalance);
+            payable(req.from).transfer(uint(excessBalance));
         }
         return (success,ret);
     }

--- a/contracts/forwarder/Forwarder.sol
+++ b/contracts/forwarder/Forwarder.sol
@@ -59,15 +59,13 @@ contract Forwarder is IForwarder {
         _verifyAndUpdateNonce(req);
 
         bytes memory callData = abi.encodePacked(req.data, req.from);
-        uint preBalance = address (this).balance;
+        uint256 preBalance = address(this).balance;
         require(preBalance >= req.value, "FWD: insufficient value");
-        require( gasleft()*63/64 >= req.gas, "FWD: insufficient gas" );
+        require(gasleft()*63/64 >= req.gas, "FWD: insufficient gas" );
         // solhint-disable-next-line avoid-low-level-calls
-        (success,ret) = req.to.call{gas : req.gas, value : req.value}(callData);
+        (success,ret) = req.to.call{gas: req.gas, value: req.value}(callData);
 
-        //this is a signed number (can be nagative). all params are known values,
-        // so can't overflow.
-        int excessBalance = int(address (this).balance - preBalance + req.value);
+        int256 excessBalance = int256(address(this).balance - preBalance + req.value);
 
         // preBalance is the balance before this TX (and value sent to it as payable)
         // preBalance-req.value - the expected balance after the call, assuming it didn't send anything back
@@ -77,7 +75,7 @@ contract Forwarder is IForwarder {
         //         this excess is inaccessible.
         if ( excessBalance>0 ) {
             //can't fail: req.from signed (off-chain) the request, so it must be an EOA...
-            payable(req.from).transfer(uint(excessBalance));
+            payable(req.from).transfer(uint256(excessBalance));
         }
         return (success,ret);
     }

--- a/contracts/forwarder/IForwarder.sol
+++ b/contracts/forwarder/IForwarder.sol
@@ -72,3 +72,4 @@ interface IForwarder {
      */
     function registerDomainSeparator(string calldata name, string calldata version) external;
 }
+

--- a/test/forwarder/Forwarder.test.ts
+++ b/test/forwarder/Forwarder.test.ts
@@ -506,32 +506,32 @@ contract('Forwarder', ([from]) => {
       it('should leave excess forwarder funds in forwarder', async () => {
         const snap = await snapshot()
         try {
-        const senderPrivateKey = toBuffer(bytes32(2))
-        const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
+          const senderPrivateKey = toBuffer(bytes32(2))
+          const senderAddress = toChecksumAddress(bufferToHex(privateToAddress(senderPrivateKey)))
 
-        const value = ether('1')
-        const func = recipient.contract.methods.mustReceiveEth(value.toString()).encodeABI()
+          const value = ether('1')
+          const func = recipient.contract.methods.mustReceiveEth(value.toString()).encodeABI()
 
-        // value = ether('0');
-        const req1 = {
-          to: recipient.address,
-          data: func,
-          from: senderAddress,
-          nonce: (await fwd.getNonce(senderAddress)).toString(),
-          value: value.toString(),
-          gas: 1e6,
-          validUntil: 0
-        }
+          // value = ether('0');
+          const req1 = {
+            to: recipient.address,
+            data: func,
+            from: senderAddress,
+            nonce: (await fwd.getNonce(senderAddress)).toString(),
+            value: value.toString(),
+            gas: 1e6,
+            validUntil: 0
+          }
 
-        const extraFunds = ether('4')
-        await web3.eth.sendTransaction({ from, to: fwd.address, value: extraFunds })
+          const extraFunds = ether('4')
+          await web3.eth.sendTransaction({ from, to: fwd.address, value: extraFunds })
 
-        const sig = signTypedData_v4(senderPrivateKey, { data: { ...data, message: req1 } })
+          const sig = signTypedData_v4(senderPrivateKey, { data: { ...data, message: req1 } })
 
-        // note: not transfering value in TX.
-        const ret = await testfwd.callExecute(fwd.address, req1, domainSeparator, typeHash, '0x', sig)
-        assert.equal(ret.logs[0].args.error, '')
-        assert.equal(ret.logs[0].args.success, true)
+          // note: not transfering value in TX.
+          const ret = await testfwd.callExecute(fwd.address, req1, domainSeparator, typeHash, '0x', sig)
+          assert.equal(ret.logs[0].args.error, '')
+          assert.equal(ret.logs[0].args.success, true)
 
           assert.equal(await web3.eth.getBalance(fwd.address), extraFunds.sub(value).toString())
         } finally {


### PR DESCRIPTION
Make sure forwarder is deterministic on using value:
The forwrader will only handle value explicitly mentioned in
request.value, and value returned by the recipient call.