### PR TITLE
skip "yarn install" if restored cache.

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,8 +15,8 @@ jobs: # a collection of steps
       - restore_cache: # special step to restore the dependency cache
           key: dependency-cache-{{ checksum "package.json" }}-yarn2
       - run:
-          name: yarn-install
-          command: yarn
+          name: yarn-install-if-needed
+          command: test -d node_modules || yarn
 
       - save_cache: # special step to save the dependency cache
           key: dependency-cache-{{ checksum "package.json" }}-yarn2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,8 @@ jobs: # a collection of steps
             - ./node_modules
 
       - run: # run tests
-          name: test
-          command: yarn test | tee /tmp/test-results.log
+          name: CI
+          command: yarn ci | tee /tmp/test-results.log
 
 #coverage is broken (doesn't cover all contracts). disabled for now..
 #      - restore_cache: # special cache for coverage test

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
   },
   "prepublish": "npm run prepare",
   "scripts": {
-    "test": "yarn run lint && yarn generate && yarn tsc && npm run test-js",
+    "test": "npm run test-js",
+    "ci": "yarn prepare && yarn run lint && yarn run test-js",
     "ganache": "ganache-cli --chainId 1337 --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --keepAliveTimeout 2147483647",
     "test-js": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test'",
     "test-bail": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test --bail'",


### PR DESCRIPTION
after restoring cache, there's no need to perform complete "yarn install" after the restoring the cache.
it saves ~1:30 from each build
(could save more when we fix "prepare", which currently compiles all contracts twice..)