### PR TITLE
OG-427 Make Relay Server account for 63/64 rule estimating 'relayCall' gas limit

### DIFF
--- a/contracts/test/TestRecipient.sol
+++ b/contracts/test/TestRecipient.sol
@@ -38,14 +38,15 @@ contract TestRecipient is BaseRelayRecipient {
     // solhint-disable-next-line no-empty-blocks
     receive() external payable {}
 
-    event SampleRecipientEmitted(string message, address realSender, address msgSender, address origin, uint256 msgValue, uint256 balance);
+    event SampleRecipientEmitted(string message, address realSender, address msgSender, address origin, uint256 msgValue, uint256 gasLeft, uint256 balance);
 
     function emitMessage(string memory message) public payable returns (string memory) {
+        uint256 gasLeft = gasleft();
         if (paymaster != address(0)) {
             withdrawAllBalance();
         }
 
-        emit SampleRecipientEmitted(message, _msgSender(), msg.sender, tx.origin, msg.value, address(this).balance);
+        emit SampleRecipientEmitted(message, _msgSender(), msg.sender, tx.origin, msg.value, gasLeft, address(this).balance);
         return "emitMessage return value";
     }
 
@@ -57,7 +58,7 @@ contract TestRecipient is BaseRelayRecipient {
     function dontEmitMessage(string calldata message) public {}
 
     function emitMessageNoParams() public {
-        emit SampleRecipientEmitted("Method with no parameters", _msgSender(), msg.sender, tx.origin, 0, address(this).balance);
+        emit SampleRecipientEmitted("Method with no parameters", _msgSender(), msg.sender, tx.origin, 0, gasleft(), address(this).balance);
     }
 
     //return (or revert) with a string in the given length

--- a/package.json
+++ b/package.json
@@ -35,8 +35,8 @@
   "scripts": {
     "test": "yarn run lint && yarn generate && yarn tsc && npm run test-js",
     "ganache": "ganache-cli --chainId 1337 --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --keepAliveTimeout 2147483647",
-    "test-js": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test'",
-    "test-bail": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 10000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test --bail'",
+    "test-js": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test'",
+    "test-bail": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test --bail'",
     "extract_abi": "./scripts/extract_abi.js",
     "truffle-test": "yarn tsc && npx truffle test",
     "truffle-compile": "truffle compile",

--- a/package.json
+++ b/package.json
@@ -34,9 +34,9 @@
   "prepublish": "npm run prepare",
   "scripts": {
     "test": "yarn run lint && yarn generate && yarn tsc && npm run test-js",
-    "ganache": "ganache-cli --chainId 1337 --hardfork 'istanbul' --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic --keepAliveTimeout 2147483647",
-    "test-js": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test'",
-    "test-bail": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 100000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test --bail'",
+    "ganache": "ganache-cli --chainId 1337 --hardfork 'istanbul' --gasLimit 12000000 --defaultBalanceEther 1000 --deterministic --keepAliveTimeout 2147483647",
+    "test-js": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 12000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test'",
+    "test-bail": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 12000000 --defaultBalanceEther 1000 --deterministic 'npx truffle --network npmtest test --bail'",
     "extract_abi": "./scripts/extract_abi.js",
     "truffle-test": "yarn tsc && npx truffle test",
     "truffle-compile": "truffle compile",

--- a/src/common/Utils.ts
+++ b/src/common/Utils.ts
@@ -128,14 +128,11 @@ export function calculateTransactionMaxPossibleGas (
     msgDataGasCostInsideTransaction
   }: TransactionGasCostComponents): number {
   return hubOverhead +
-      parseInt(gasAndDataLimits.preRelayedCallGasLimit) +
-      parseInt(gasAndDataLimits.postRelayedCallGasLimit) +
-      parseInt(relayCallGasLimit) +
     msgDataGasCostInsideTransaction +
     calculateCalldataCost(msgData) +
     parseInt(relayCallGasLimit) +
     parseInt(gasAndDataLimits.preRelayedCallGasLimit) +
-    parseInt(gasAndDataLimits.postRelayedCallGasLimit) +
+    parseInt(gasAndDataLimits.postRelayedCallGasLimit)
 }
 
 export function getEcRecoverMeta (message: PrefixedHexString, signature: string | Signature): PrefixedHexString {

--- a/src/relayserver/RelayServer.ts
+++ b/src/relayserver/RelayServer.ts
@@ -21,7 +21,7 @@ import { LoggerInterface } from '../common/LoggerInterface'
 import { defaultEnvironment } from '../common/Environments'
 import { gsnRequiredVersion, gsnRuntimeVersion } from '../common/Version'
 import {
-  address2topic, calculateCalldataCost,
+  address2topic,
   calculateTransactionMaxPossibleGas,
   decodeRevertReason,
   getLatestEventData,

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -168,7 +168,7 @@ options.forEach(params => {
        * to the recipient. We are setting 10M as a block gas limit, so cannot go much higher than 9M gas here.
        */
       describe('with different gas limits', function () {
-        [1e4, 1e5, 1e6, 1e7, 9e7]
+        [1e4, 1e5, 1e6, 1e7]
           .forEach(innerGasLimit =>
             it(`should calculate valid external tx gas limit for a transaction with inner call gas limit of  ${innerGasLimit.toString()}`, async function () {
               const gas = innerGasLimit

--- a/test/Flows.test.ts
+++ b/test/Flows.test.ts
@@ -179,7 +179,7 @@ options.forEach(params => {
                 console.log('error is ', e.message)
                 throw e
               }
-              const actual: BN = res.logs[0].args.gasLeft
+              const actual: BN = res.logs.find((e: any) => e.event === 'SampleRecipientEmitted').args.gasLeft
               assert.closeTo(actual.toNumber(), innerGasLimit, 1500)
               assert.equal('Method with no parameters', res.logs[0].args.message)
             })

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -1,7 +1,7 @@
 import BN from 'bn.js'
 import { ether, expectEvent } from '@openzeppelin/test-helpers'
 
-import { calculateTransactionMaxPossibleGas, getEip712Signature } from '../src/common/Utils'
+import { calculateCalldataCost, calculateTransactionMaxPossibleGas, getEip712Signature } from '../src/common/Utils'
 import TypedRequestData from '../src/common/EIP712/TypedRequestData'
 import { defaultEnvironment } from '../src/common/Environments'
 import RelayRequest, { cloneRelayRequest } from '../src/common/EIP712/RelayRequest'
@@ -14,7 +14,7 @@ import {
   IForwarderInstance,
   PenalizerInstance
 } from '../types/truffle-contracts'
-import { calculateCalldataCost, deployHub, revert, snapshot } from './TestUtils'
+import { deployHub, revert, snapshot } from './TestUtils'
 import { registerForwarderForGsn } from '../src/common/EIP712/ForwarderUtil'
 import { toBuffer } from 'ethereumjs-util'
 
@@ -151,14 +151,15 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
         const { tx } = res
         const gasAndDataLimits = await paymaster.getGasAndDataLimits()
         const hubOverhead = (await relayHub.gasOverhead()).toNumber()
-        const msgDataLength = toBuffer(
-          relayHub.contract.methods.relayCall(10e6, relayRequest, signature, '0x', transactionGasLimit.toNumber()).encodeABI()).length
-        const msgDataGasCost = hubDataGasCostPerByte * msgDataLength
+        const msgData: string = relayHub.contract.methods.relayCall(10e6, relayRequest, signature, '0x', transactionGasLimit.toNumber()).encodeABI()
+        const msgDataLength = toBuffer(msgData).length
+        const msgDataGasCostInsideTransaction = hubDataGasCostPerByte * msgDataLength
         const maxPossibleGas = calculateTransactionMaxPossibleGas({
           gasAndDataLimits: gasAndDataLimits,
           hubOverhead,
           relayCallGasLimit: gasLimit.toString(),
-          msgDataGasCost
+          msgData,
+          msgDataGasCostInsideTransaction
         })
 
         // Magic numbers seem to be gas spent on calldata. I don't know of a way to calculate them conveniently.

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -154,15 +154,13 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
         const msgData: string = relayHub.contract.methods.relayCall(10e6, relayRequest, signature, '0x', transactionGasLimit.toNumber()).encodeABI()
         const msgDataLength = toBuffer(msgData).length
         const msgDataGasCostInsideTransaction = hubDataGasCostPerByte * msgDataLength
-        let maxPossibleGas = calculateTransactionMaxPossibleGas({
+        const maxPossibleGas = calculateTransactionMaxPossibleGas({
           gasAndDataLimits: gasAndDataLimits,
           hubOverhead,
           relayCallGasLimit: gasLimit.toString(),
           msgData,
           msgDataGasCostInsideTransaction
         })
-        // TODO: this is a hotfix until OG-431 us addressed; calldata cost must be part of the 'maxPossibleGas'
-        maxPossibleGas -= calculateCalldataCost(msgData)
 
         // Magic numbers seem to be gas spent on calldata. I don't know of a way to calculate them conveniently.
         const events = await paymaster.contract.getPastEvents('SampleRecipientPreCallWithValues')

--- a/test/RelayHubGasCalculations.test.ts
+++ b/test/RelayHubGasCalculations.test.ts
@@ -154,13 +154,16 @@ contract('RelayHub gas calculations', function ([_, relayOwner, relayWorker, rel
         const msgData: string = relayHub.contract.methods.relayCall(10e6, relayRequest, signature, '0x', transactionGasLimit.toNumber()).encodeABI()
         const msgDataLength = toBuffer(msgData).length
         const msgDataGasCostInsideTransaction = hubDataGasCostPerByte * msgDataLength
-        const maxPossibleGas = calculateTransactionMaxPossibleGas({
+        let maxPossibleGas = calculateTransactionMaxPossibleGas({
           gasAndDataLimits: gasAndDataLimits,
           hubOverhead,
           relayCallGasLimit: gasLimit.toString(),
           msgData,
           msgDataGasCostInsideTransaction
         })
+
+        // TODO: this is a hotfix until OG-431 us addressed; calldata cost must be part of the 'maxPossibleGas'
+        maxPossibleGas -= calculateCalldataCost(msgData)
 
         // Magic numbers seem to be gas spent on calldata. I don't know of a way to calculate them conveniently.
         await expectEvent.inTransaction(tx, TestPaymasterVariableGasLimits, 'SampleRecipientPreCallWithValues', {

--- a/test/TestUtils.ts
+++ b/test/TestUtils.ts
@@ -67,6 +67,9 @@ export async function startRelay (
   if (options.initialReputation) {
     args.push('--initialReputation', options.initialReputation)
   }
+  if (options.workerTargetBalance) {
+    args.push('--workerTargetBalance', options.workerTargetBalance)
+  }
   const runServerPath = path.resolve(__dirname, '../src/relayserver/runServer.ts')
   const proc: ChildProcessWithoutNullStreams = childProcess.spawn('./node_modules/.bin/ts-node',
     [runServerPath, ...args])
@@ -124,7 +127,7 @@ export async function startRelay (
   await web3.eth.sendTransaction({
     to: relayManagerAddress,
     from: options.relayOwner,
-    value: ether('2')
+    value: options.value ?? ether('2')
   })
 
   // TODO: this entire function is a logical duplicate of 'CommandsLogic::registerRelay'
@@ -274,13 +277,6 @@ export async function deployHub (
 
 export function configureGSN (partialConfig: Partial<GSNConfig>): GSNConfig {
   return Object.assign({}, defaultGsnConfig, partialConfig) as GSNConfig
-}
-
-export function calculateCalldataCost (calldata: string): number {
-  const calldataBuf = Buffer.from(calldata.replace('0x', ''), 'hex')
-  let sum = 0
-  calldataBuf.forEach(ch => { sum += (ch === 0 ? defaultEnvironment.gtxdatazero : defaultEnvironment.gtxdatanonzero) })
-  return sum
 }
 
 /**

--- a/test/relayclient/RelayClient.test.ts
+++ b/test/relayclient/RelayClient.test.ts
@@ -246,8 +246,8 @@ contract('RelayClient', function (accounts) {
 
       // validate we've got the "SampleRecipientEmitted" event
       // TODO: use OZ test helpers
-      const topic: string = web3.utils.sha3('SampleRecipientEmitted(string,address,address,address,uint256,uint256)') ?? ''
-      assert(res.logs.find(log => log.topics.includes(topic)))
+      const topic: string = web3.utils.sha3('SampleRecipientEmitted(string,address,address,address,uint256,uint256,uint256)') ?? ''
+      assert.ok(res.logs.find(log => log.topics.includes(topic)), 'log not found')
 
       const destination: string = validTransaction.to.toString('hex')
       assert.equal(`0x${destination}`, relayHub.address.toString().toLowerCase())


### PR DESCRIPTION
1. Emit 'gasleft' in the TestRecipient to check it is close to requested
2. Set high target worker balance for large gas limit test
3. Take into account calldata cost when calculating external gas limit
(defaultEnvironment is hard-coded as of now)
4. Multiply gas limit by a factor to accomodate EIP-150 63/64th rule
(factor hardcoded at 1.1 as of now)
5. Increase 'run-with-testrpc' gas limit for large gaslimit test