### PR TITLE
Read Stake Manager address from ContractInteractor

### DIFF
--- a/packages/dev/src/GsnTestEnvironment.ts
+++ b/packages/dev/src/GsnTestEnvironment.ts
@@ -170,7 +170,6 @@ class GsnTestEnvironmentClass {
       devMode: true,
       url: relayUrl,
       relayHubAddress: deploymentResult.relayHubAddress,
-      stakeManagerAddress: deploymentResult.stakeManagerAddress,
       ownerAddress: from,
       gasPriceFactor: 1,
       baseRelayFee: '0',

--- a/packages/dev/test/TestUtils.ts
+++ b/packages/dev/test/TestUtils.ts
@@ -46,7 +46,6 @@ export async function startRelay (
   args.push('--relayHubAddress', relayHubAddress)
   const configFile = path.resolve(__dirname, './server-config.json')
   args.push('--config', configFile)
-  args.push('--stakeManagerAddress', stakeManager.address)
   args.push('--ownerAddress', options.relayOwner)
 
   if (options.ethereumNodeUrl) {

--- a/packages/relay/src/RegistrationManager.ts
+++ b/packages/relay/src/RegistrationManager.ts
@@ -515,15 +515,16 @@ TxHash    | ${decodedEvent.transactionHash}
   async setOwnerInStakeManager (currentBlock: number): Promise<PrefixedHexString> {
     const setRelayManagerMethod = await this.contractInteractor.getSetRelayManagerMethod(this.config.ownerAddress)
     const gasLimit = await this.transactionManager.attemptEstimateGas('SetRelayManager', setRelayManagerMethod, this.managerAddress)
+    const stakeManagerAddress = this.contractInteractor.stakeManagerAddress()
     const details: SendTransactionDetails = {
       signer: this.managerAddress,
       gasLimit,
       serverAction: ServerAction.SET_OWNER,
       method: setRelayManagerMethod,
-      destination: this.config.stakeManagerAddress,
+      destination: stakeManagerAddress,
       creationBlockNumber: currentBlock
     }
-    this.logger.info(`setting relay owner ${this.config.ownerAddress} at StakeManager ${this.config.stakeManagerAddress}`)
+    this.logger.info(`setting relay owner ${this.config.ownerAddress} at StakeManager ${stakeManagerAddress}`)
     const { transactionHash } = await this.transactionManager.sendTransaction(details)
     return transactionHash
   }

--- a/packages/relay/src/ServerConfigParams.ts
+++ b/packages/relay/src/ServerConfigParams.ts
@@ -24,7 +24,6 @@ export interface ServerConfigParams {
   versionRegistryDelayPeriod?: number
   relayHubId?: string
   relayHubAddress: string
-  stakeManagerAddress: string
   ethereumNodeUrl: string
   workdir: string
   checkInterval: number
@@ -86,7 +85,6 @@ const serverDefaultConfiguration: ServerConfigParams = {
   // set to paymasters' default acceptanceBudget + RelayHub.calldataGasCost(<paymasters' default calldataSizeLimit>)
   maxAcceptanceBudget: defaultEnvironment.paymasterConfiguration.acceptanceBudget + defaultEnvironment.relayHubConfiguration.dataGasCostPerByte * defaultEnvironment.paymasterConfiguration.calldataSizeLimit,
   relayHubAddress: constants.ZERO_ADDRESS,
-  stakeManagerAddress: constants.ZERO_ADDRESS,
   trustedPaymasters: [],
   blacklistedPaymasters: [],
   gasPriceFactor: 1,
@@ -128,7 +126,6 @@ const serverDefaultConfiguration: ServerConfigParams = {
 }
 
 const ConfigParamsTypes = {
-  stakeManagerAddress: 'string',
   ownerAddress: 'string',
   config: 'string',
   baseRelayFee: 'number',


### PR DESCRIPTION
There is no need to pass Stake Manager address in a configuration as it
is read in 'init' from RelayHub anyways.