### PR TITLE
OG-502 Kotti client crash on "invalid externalGasLimit"

### DIFF
--- a/packages/common/src/ContractInteractor.ts
+++ b/packages/common/src/ContractInteractor.ts
@@ -291,10 +291,11 @@ export class ContractInteractor {
     maxAcceptanceBudget: number,
     relayRequest: RelayRequest,
     signature: PrefixedHexString,
-    approvalData: PrefixedHexString): Promise<{ paymasterAccepted: boolean, returnValue: string, reverted: boolean }> {
+    approvalData: PrefixedHexString,
+    maxViewableGasLimit?: number): Promise<{ paymasterAccepted: boolean, returnValue: string, reverted: boolean }> {
     const relayHub = this.relayHubInstance
     try {
-      const externalGasLimit = await this.getMaxViewableGasLimit(relayRequest)
+      const externalGasLimit = await this.getMaxViewableGasLimit(relayRequest, maxViewableGasLimit)
       const encodedRelayCall = relayHub.contract.methods.relayCall(
         maxAcceptanceBudget,
         relayRequest,
@@ -356,8 +357,8 @@ export class ContractInteractor {
     }
   }
 
-  async getMaxViewableGasLimit (relayRequest: RelayRequest): Promise<BN> {
-    const blockGasLimit = toBN(await this._getBlockGasLimit())
+  async getMaxViewableGasLimit (relayRequest: RelayRequest, maxViewableGasLimit?: number): Promise<BN> {
+    const blockGasLimit = toBN(maxViewableGasLimit ?? await this._getBlockGasLimit())
     const workerBalance = toBN(await this.getBalance(relayRequest.relayData.relayWorker))
     const workerGasLimit = workerBalance.div(toBN(
       relayRequest.relayData.gasPrice === '0' ? 1 : relayRequest.relayData.gasPrice))

--- a/packages/provider/src/GSNConfigurator.ts
+++ b/packages/provider/src/GSNConfigurator.ts
@@ -71,6 +71,7 @@ export interface GSNConfig {
   paymasterAddress?: Address
   clientId: IntString
   auditorsCount: number
+  maxViewableGasLimit?: number
 }
 
 export interface GSNDependencies {

--- a/packages/provider/src/RelayClient.ts
+++ b/packages/provider/src/RelayClient.ts
@@ -250,7 +250,7 @@ export class RelayClient {
 
     this.emit(new GsnValidateRequestEvent())
 
-    const acceptRelayCallResult = await this.dependencies.contractInteractor.validateRelayCall(maxAcceptanceBudget, httpRequest.relayRequest, httpRequest.metadata.signature, httpRequest.metadata.approvalData)
+    const acceptRelayCallResult = await this.dependencies.contractInteractor.validateRelayCall(maxAcceptanceBudget, httpRequest.relayRequest, httpRequest.metadata.signature, httpRequest.metadata.approvalData, this.config.maxViewableGasLimit)
     if (!acceptRelayCallResult.paymasterAccepted) {
       let message: string
       if (acceptRelayCallResult.reverted) {


### PR DESCRIPTION
Client crash on "invalid externaGasLimit" during request verification

root cause:
when making a view call, kotti can't pass more than (blockGasLimit/2)
gas. this breaks our calculation of externalGasLimit- initialGas.

Workaround: client to pass no more than blockGasLimit/3 during client
verification.
NOTE: a complete solution might be to copy the complete calculation of
maxPossibleGas from the relayer.