### PR TITLE
OG-513 add client "registration lookup window"

### DIFF
--- a/packages/provider/src/GSNConfigurator.ts
+++ b/packages/provider/src/GSNConfigurator.ts
@@ -28,6 +28,7 @@ export const defaultGsnConfig: GSNConfig = {
   preferredRelays: [],
   relayLookupWindowBlocks: DEFAULT_LOOKUP_WINDOW_BLOCKS,
   relayLookupWindowParts: 1,
+  relayRegistrationLookupBlocks: Number.MAX_SAFE_INTEGER,
   gasPriceFactorPercent: GAS_PRICE_PERCENT,
   gasPriceOracleUrl: '',
   gasPriceOraclePath: '',
@@ -57,6 +58,8 @@ export interface GSNConfig {
   preferredRelays: string[]
   relayLookupWindowBlocks: number
   relayLookupWindowParts: number
+  relayRegistrationLookupBlocks: number
+
   methodSuffix: string
   jsonStringifyRequest: boolean
   requiredVersionRange?: string

--- a/packages/provider/src/KnownRelaysManager.ts
+++ b/packages/provider/src/KnownRelaysManager.ts
@@ -71,9 +71,12 @@ export class KnownRelaysManager {
     if (relayManagers.size === 0) {
       return []
     }
+    const toBlock = await this.contractInteractor.getBlockNumber()
+    const fromBlock = Math.max(0, toBlock - this.config.relayRegistrationLookupBlocks)
+
     const topics = addresses2topics(Array.from(relayManagers))
-    const relayServerRegisteredEvents = await this.contractInteractor.getPastEventsForHub(topics, { fromBlock: 1 }, [RelayServerRegistered])
-    const relayManagerExitEvents = await this.contractInteractor.getPastEventsForStakeManager([StakeUnlocked, HubUnauthorized, StakePenalized], topics, { fromBlock: 1 })
+    const relayServerRegisteredEvents = await this.contractInteractor.getPastEventsForHub(topics, { fromBlock }, [RelayServerRegistered])
+    const relayManagerExitEvents = await this.contractInteractor.getPastEventsForStakeManager([StakeUnlocked, HubUnauthorized, StakePenalized], topics, { fromBlock })
 
     this.logger.info(`== fetchRelaysAdded: found ${relayServerRegisteredEvents.length} unique RelayAdded events`)
 


### PR DESCRIPTION
by default, we search for registration events (for specific relayers)
from block 1.
This works great no ethereum mainnet, testnets.
Some alternate networks (mumbai, kotti) are slower to handler such large
block ranges.
For such networks, the client should configure
relayRegistrationLookupBlocks, as registrations are only looked up in
that block range.
This value should be smaller than the server's registrationBlockRate,
which is the rate the relayers refresh their registration.