### PR TITLE
Add bin field in package.json file

### DIFF
--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -3,6 +3,9 @@
   "version": "2.2.1",
   "license": "GPL-3.0-only",
   "main": "dist/commands/gsn.js",
+  "bin": {
+    "gsn": "dist/commands/gsn.js"
+  },
   "scripts": {
     "tsc": "tsc",
     "lint": "eslint -f unix .",


### PR DESCRIPTION
The `bin` field was missing in the `package.json` file.  This field allows npm to simlink correctly the binary file.

#642 