### PR TITLE
OG-322 Remove ability to pass 'forwarder' and 'paymaster' addresses as tx details

### DIFF
--- a/packages/common/src/ContractInteractor.ts
+++ b/packages/common/src/ContractInteractor.ts
@@ -174,8 +174,11 @@ export class ContractInteractor {
 
     if (this.deployment.paymasterAddress != null) {
       await this._resolveDeploymentFromPaymaster(this.deployment.paymasterAddress)
+    } else if (this.deployment.relayHubAddress != null) {
+      // TODO: this branch shouldn't exist as it's only used by the Server and can lead to broken Client configuration
+      await this._resolveDeploymentFromRelayHub(this.deployment.relayHubAddress)
     } else {
-      this.logger.info('Contract interactor cannot resolve a full deployment without a Paymaster address')
+      this.logger.info(`Contract interactor cannot resolve a full deployment from the following input: ${JSON.stringify(this.deployment)}`)
     }
   }
 

--- a/packages/common/src/ContractInteractor.ts
+++ b/packages/common/src/ContractInteractor.ts
@@ -174,10 +174,8 @@ export class ContractInteractor {
 
     if (this.deployment.paymasterAddress != null) {
       await this._resolveDeploymentFromPaymaster(this.deployment.paymasterAddress)
-    } else if (this.deployment.relayHubAddress != null) {
-      await this._resolveDeploymentFromRelayHub(this.deployment.relayHubAddress)
     } else {
-      this.logger.info(`Contract interactor cannot resolve a full deployment from the following input: ${JSON.stringify(this.deployment)}`)
+      this.logger.info('Contract interactor cannot resolve a full deployment without a Paymaster address')
     }
   }
 

--- a/packages/common/src/types/GsnTransactionDetails.ts
+++ b/packages/common/src/types/GsnTransactionDetails.ts
@@ -15,10 +15,6 @@ export interface GsnTransactionDetails {
   gas?: PrefixedHexString
   gasPrice?: PrefixedHexString
 
-  // Required parameters for GSN, but assigned later
-  readonly forwarder?: Address
-  readonly paymaster?: Address
-
   readonly paymasterData?: PrefixedHexString
   readonly clientId?: IntString
 

--- a/packages/dev/test/Flows.test.ts
+++ b/packages/dev/test/Flows.test.ts
@@ -193,6 +193,14 @@ options.forEach(params => {
           await approvalPaymaster.setRelayHub(rhub.address)
           await approvalPaymaster.setTrustedForwarder(await sr.getTrustedForwarder())
           await rhub.depositFor(approvalPaymaster.address, { value: (1e18).toString() })
+          relayClientConfig = { ...relayClientConfig, ...{ paymasterAddress: approvalPaymaster.address } }
+          const relayProvider = await RelayProvider.newProvider(
+            {
+              provider: web3.currentProvider as HttpProvider,
+              config: relayClientConfig
+            }).init()
+          // @ts-ignore
+          TestRecipient.web3.setProvider(relayProvider)
         })
 
         const setRecipientProvider = async function (asyncApprovalData: AsyncDataCallback): Promise<void> {
@@ -256,9 +264,7 @@ options.forEach(params => {
               await setRecipientProvider(async () => '0x')
 
               await sr.emitMessage('xxx', {
-                from: gasless,
-                // @ts-ignore
-                paymaster: approvalPaymaster.address
+                from: gasless
               })
             }, 'unexpected approvalData: \'\' instead of')
           } catch (e) {

--- a/packages/dev/test/RelayServer.test.ts
+++ b/packages/dev/test/RelayServer.test.ts
@@ -700,7 +700,7 @@ contract('RelayServer', function (accounts: Truffle.Accounts) {
         // eslint-disable-next-line @typescript-eslint/return-await
         return (await _sendTransactionOrig.call(server.transactionManager, ...arguments))
       }
-      const req = await env.createRelayHttpRequest({ paymaster: rejectingPaymaster.address })
+      const req = await env.createRelayHttpRequest({}, { paymasterAddress: rejectingPaymaster.address })
       await env.relayServer.createRelayTransaction(req)
       // await relayTransaction(relayTransactionParams2, options2, { paymaster: rejectingPaymaster.address }, false)
       const currentBlock = await env.web3.eth.getBlock('latest')

--- a/packages/dev/test/common/StatisticsManager.test.ts
+++ b/packages/dev/test/common/StatisticsManager.test.ts
@@ -51,7 +51,8 @@ contract('StatisticsManager', function (accounts) {
       await evmMine()
     }
     await misbehavingPaymaster.setRevertPreRelayCallOnEvenBlocks(true)
-    await env.relayServer.createRelayTransaction(await env.createRelayHttpRequest({ paymaster: misbehavingPaymaster.address }))
+
+    await env.relayServer.createRelayTransaction(await env.createRelayHttpRequest({}, { paymasterAddress: misbehavingPaymaster.address }))
 
     const httpClient = new HttpClient(new HttpWrapper(), env.relayServer.logger)
     statusLogic = new StatisticsManager(env.contractInteractor, httpClient, env.relayServer.logger)

--- a/packages/dev/test/penalizer/PenalizationFlow.test.ts
+++ b/packages/dev/test/penalizer/PenalizationFlow.test.ts
@@ -96,7 +96,6 @@ contract('PenalizationFlow', function (accounts) {
       from: accounts[0],
       to: env.recipient.address,
       data: env.recipient.contract.methods.emitMessage('hello world').encodeABI(),
-      forwarder: env.forwarder.address,
       paymasterData: '0x',
       clientId: '1'
     }

--- a/packages/dev/test/provider/GsnTestEnvironment.test.ts
+++ b/packages/dev/test/provider/GsnTestEnvironment.test.ts
@@ -45,7 +45,6 @@ contract('GsnTestEnvironment', function () {
       const ret = await relayClient.relayTransaction({
         from: sender,
         to: sr.address,
-        forwarder: await sr.getTrustedForwarder(),
         gas: '0x' + 1e6.toString(16),
         data: sr.contract.methods.emitMessage('hello').encodeABI()
       })

--- a/packages/dev/test/provider/RelayClient.test.ts
+++ b/packages/dev/test/provider/RelayClient.test.ts
@@ -147,8 +147,6 @@ contract('RelayClient', function (accounts) {
       from,
       to,
       data,
-      forwarder: forwarderAddress,
-      paymaster: paymaster.address,
       paymasterData: '0x',
       clientId: '1'
     }
@@ -541,7 +539,7 @@ contract('RelayClient', function (accounts) {
         provider: web3.currentProvider as HttpProvider,
         logger,
         maxPageSize,
-        deployment: { relayHubAddress: relayHub.address }
+        deployment: { paymasterAddress: paymaster.address }
       }).init()
       const badHttpClient = new BadHttpClient(logger, false, false, false, pingResponse, '0x123')
       const badTransactionValidator = new BadRelayedTransactionValidator(logger, true, contractInteractor, configureGSN(gsnConfig))

--- a/packages/provider/src/RelayClient.ts
+++ b/packages/provider/src/RelayClient.ts
@@ -202,9 +202,11 @@ export class RelayClient {
     }
     const relayingErrors = new Map<string, Error>()
     const auditPromises: Array<Promise<AuditResponse>> = []
+    const paymaster = this.dependencies.contractInteractor.getDeployment().paymasterAddress
+
     while (true) {
       let relayingAttempt: RelayingAttempt | undefined
-      const activeRelay = await relaySelectionManager.selectNextRelay()
+      const activeRelay = await relaySelectionManager.selectNextRelay(paymaster)
       if (activeRelay != null) {
         this.emit(new GsnNextRelayEvent(activeRelay.relayInfo.relayUrl))
         relayingAttempt = await this._attemptRelay(activeRelay, gsnTransactionDetails)
@@ -303,8 +305,8 @@ export class RelayClient {
     gsnTransactionDetails: GsnTransactionDetails
   ): Promise<RelayTransactionRequest> {
     const relayHubAddress = this.dependencies.contractInteractor.getDeployment().relayHubAddress
-    const forwarder = gsnTransactionDetails.forwarder ?? this.dependencies.contractInteractor.getDeployment().forwarderAddress
-    const paymaster = gsnTransactionDetails.paymaster ?? this.dependencies.contractInteractor.getDeployment().paymasterAddress
+    const forwarder = this.dependencies.contractInteractor.getDeployment().forwarderAddress
+    const paymaster = this.dependencies.contractInteractor.getDeployment().paymasterAddress
     if (relayHubAddress == null || paymaster == null || forwarder == null) {
       throw new Error('Contract addresses are not initialized!')
     }


### PR DESCRIPTION
This functionality basically only makes sense in tests and should not be
exposed to users.

A client app should initialize a RelayProvider for a specific
configuration to avoid compatibility issues.

Note that it also means that initialization of a ContractInteractor
without a paymaster address is no longer supported.