### PR TITLE
Mumbai support

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "0.5.5",
-    "@truffle/hdwallet-provider": "1.0.34",
+    "@truffle/hdwallet-provider": "1.4.1",
     "@typechain/truffle-v5": "^4.0.1",
     "@types/bn.js": "^5.1.0",
     "@types/chai": "^4.2.12",

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -15,7 +15,8 @@ export const networks = new Map<string, string>([
   ['rinkeby', 'https://rinkeby.infura.io/v3/' + cliInfuraId],
   ['kovan', 'https://kovan.infura.io/v3/' + cliInfuraId],
   ['goerli', 'https://goerli.infura.io/v3/' + cliInfuraId],
-  ['mainnet', 'https://mainnet.infura.io/v3/' + cliInfuraId]
+  ['mainnet', 'https://mainnet.infura.io/v3/' + cliInfuraId],
+  ['mumbai', 'https://polygon-mumbai.infura.io/v3' + cliInfuraId]
 ])
 
 export const networksBlockExplorers = new Map<string, string>([
@@ -24,7 +25,9 @@ export const networksBlockExplorers = new Map<string, string>([
   ['rinkeby', 'https://rinkeby.etherscan.io/'],
   ['kovan', 'https://kovan.etherscan.io/'],
   ['goerli', 'https://goerli.etherscan.io/'],
-  ['mainnet', 'https://etherscan.io/']
+  ['mainnet', 'https://etherscan.io/'],
+  ['mumbai', 'https://explorer-mumbai.maticvigil.com/']
+
 ])
 
 export function supportedNetworks (): string[] {


### PR DESCRIPTION
Updating truffle wallet provider removes issue with replay protected transactions when using cli to deploy relay for mumbai/polygon network.