### PR TITLE
add ownerAddress to sample server config

### DIFF
--- a/dockers/relaydc/config-sample/gsn-relay-config.json
+++ b/dockers/relaydc/config-sample/gsn-relay-config.json
@@ -3,6 +3,7 @@
   "baseRelayFee": 0,
   "pctRelayFee": 70,
   "versionRegistryAddress": "<deployed version registry>",
+  "ownerAddress": "<address of owner account>",
   "gasPriceFactor": 1,
-  "ethereumNodeUrl": "https://kovan.infura.io/v3/<INFURA-ID>"
+  "ethereumNodeUrl": "https://<network>.infura.io/v3/<INFURA-ID>"
 }


### PR DESCRIPTION
`ownerAddress` is a required field in the gsn-relay-config.json, but is
missing from the sample configuration file.