### PR TITLE
dry-run publish support (using verdaccio)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,7 +34,7 @@ yarn-error.log
 /packages/contracts/build/
 /packages/contracts/json-input.json
 /packages/contracts/types/truffle-contracts/
-/verdaccio/
+/verdaccio/db/
 /.yarnrc
 /build/gsn
 /gsn.iml

--- a/htpasswd
+++ b/htpasswd
@@ -1,1 +1,0 @@
-admin:{SHA}0DPiKuNIrrVmD8IUCuw1hQxNqZc=

--- a/package.json
+++ b/package.json
@@ -61,9 +61,10 @@
     "lerna-run-test-with-testrpc": "run-with-testrpc --chainId 1337 --hardfork 'istanbul' --port 8544 --gasLimit 12000000 --defaultBalanceEther 1000 --deterministic 'yarn lerna-run-test'",
     "lerna-run-test-with-hardhat": "run-with-testrpc --testrpc-cmd ./scripts/hardhat-node --port 8544 'yarn lerna-run-test'",
     "lerna-run-test-only-with-hardhat": "run-with-testrpc --testrpc-cmd ./scripts/hardhat-node --port 8544 'yarn lerna-run-test-only'",
-    "verdaccio-start": "verdaccio --config verdaccio.yaml",
-    "verdaccio-clean": "rm -rf verdaccio",
-    "verdaccio-clean-opengsn": "rm -rf verdaccio/@opengsn"
+    "verdaccio-start": "yarn verdaccio-clean && yarn verdaccio-run",
+    "dry-run-publish": "lerna publish --no-git-tag-version --no-push --registry http://localhost:4873",
+    "verdaccio-run": "verdaccio --config verdaccio/verdaccio.yaml",
+    "verdaccio-clean": "rm -rf verdaccio/db"
   },
   "devDependencies": {
     "@openzeppelin/test-helpers": "0.5.5",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "lerna-run-test-with-hardhat": "run-with-testrpc --testrpc-cmd ./scripts/hardhat-node --port 8544 'yarn lerna-run-test'",
     "lerna-run-test-only-with-hardhat": "run-with-testrpc --testrpc-cmd ./scripts/hardhat-node --port 8544 'yarn lerna-run-test-only'",
     "verdaccio-start": "yarn verdaccio-clean && yarn verdaccio-run",
-    "dry-run-publish": "lerna publish --no-git-tag-version --no-push --registry http://localhost:4873",
+    "verdaccio-publish": "lerna publish --no-git-tag-version --no-push --registry http://localhost:4873",
     "verdaccio-run": "verdaccio --config verdaccio/verdaccio.yaml",
     "verdaccio-clean": "rm -rf verdaccio/db"
   },

--- a/verdaccio/.verdaccio-db.json
+++ b/verdaccio/.verdaccio-db.json
@@ -1,1 +1,0 @@
-{"list":["@opengsn/paymasters"],"secret":"3025636a6c64caa062b81818d4d006e91f415bb804a6ecc15ae82c7ea0b13114"}

--- a/verdaccio/.verdaccio-db.json
+++ b/verdaccio/.verdaccio-db.json
@@ -1,0 +1,1 @@
+{"list":["@opengsn/paymasters"],"secret":"3025636a6c64caa062b81818d4d006e91f415bb804a6ecc15ae82c7ea0b13114"}

--- a/verdaccio/README.md
+++ b/verdaccio/README.md
@@ -1,0 +1,9 @@
+# Using local registry for testing
+
+- in a background terminal, run `yarn verdaccio-start`
+- to publish local build, use `yarn verdaccio-publish`, which will publish into this repo
+  (note that it requires a clean git, and make local commit - but doesn't push anything)
+- use `gsn/verdaccio/yarn` instead of normal `yarn` to initialize a test app
+  - it will fetch "@opengsn" packages from our verdaccio (with a fallback to npmjs.com)
+  - all other packages are fetched directly.
+- (this script simply does `yarn --use-yarnrc=gsn/verdaccio/yarnrc`)

--- a/verdaccio/verdaccio.yaml
+++ b/verdaccio/verdaccio.yaml
@@ -1,20 +1,18 @@
-storage: ./verdaccio
-auth:
-  htpasswd:
-    file: ./htpasswd
+storage: ./db
 uplinks:
   npmjs:
     url: https://registry.npmjs.org/
+    cache: false
 packages:
   '@*/*':
     access: $all
-    publish: $authenticated
+    publish: $all
     proxy: npmjs
   '**':
     access: $all
-    publish: $authenticated
+    publish: $all
     proxy: npmjs
 logs:
-  - {type: stdout, format: pretty, level: trace}
+  - {type: stdout, format: pretty, level: info}
 publish:
   allow_offline: true

--- a/verdaccio/yarn
+++ b/verdaccio/yarn
@@ -1,0 +1,2 @@
+#wrapper script, to run yarn with our verdaccio config.
+yarn --use-yarnrc `dirname $0`/yarnrc "$@"

--- a/verdaccio/yarnrc
+++ b/verdaccio/yarnrc
@@ -1,0 +1,2 @@
+"@opengsn:registry" "http://localhost:4873"
+


### PR DESCRIPTION
verdaccio-start - (in separate terminal) start local npm repository
verdaccio-publish - like lerna-publish, BUT only to local verdaccio repo
(and no git-push)
gsn/verdaccio/yarn - wrapper for yarn, to use local repo: use from a
test app to install the just-published test version.