### PR TITLE
OG-630 - Boosted gasPrice is sometimes lower after boosing than before

### DIFF
--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -782,12 +782,12 @@ latestBlock timestamp   | ${latestBlock.timestamp}
   }
 
   async _boostStuckTransactionsForManager (blockNumber: number): Promise<Map<PrefixedHexString, SignedTransactionDetails>> {
-    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(this.managerAddress, blockNumber)
+    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(this.managerAddress, blockNumber, this.minGasPrice)
   }
 
   async _boostStuckTransactionsForWorker (blockNumber: number, workerIndex: number): Promise<Map<PrefixedHexString, SignedTransactionDetails>> {
     const signer = this.workerAddress
-    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(signer, blockNumber)
+    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(signer, blockNumber, this.minGasPrice)
   }
 
   _isTrustedPaymaster (paymaster: string): boolean {


### PR DESCRIPTION
apply our minimum value also to boosted transactions.
(NOTE: we still don't know how a small (e.g. 1 wei) value got into the
DB of old transactions, but in general, current GasPrice is good minimum
not only for new transactions but also for boosted transactions.