### PR TITLE
clean hardhat-console solidity logs from build

### DIFF
--- a/packages/contracts/testCopyContracts.js
+++ b/packages/contracts/testCopyContracts.js
@@ -1,0 +1,39 @@
+import fs from 'fs'
+import path from 'path'
+
+function mapFilesRecursive (srcPath, dstPath, mapStr) {
+  fs.mkdirSync(dstPath, { recursive: true })
+  const srcDirStats = fs.statSync(srcPath)
+  fs.utimesSync(dstPath, srcDirStats.atime, srcDirStats.mtime)
+
+  fs.readdirSync(srcPath).forEach(entry => {
+    const srcEntry = path.resolve(srcPath, entry)
+    const dstEntry = path.resolve(dstPath, entry)
+    const srcStats = fs.statSync(srcEntry)
+    if (srcStats.isDirectory()) {
+      mapFilesRecursive(srcEntry, dstEntry, mapStr)
+    } else {
+      const src = mapStr(fs.readFileSync(srcEntry, 'ascii'))
+      fs.writeFileSync(dstEntry, src)
+    }
+    // keep original file timestamp
+    fs.utimesSync(dstEntry, srcStats.atime, srcStats.mtime)
+  })
+}
+
+// copy contracts to tmp folder.
+// on production build, remove "console.log" references
+// on test (env.TEST_CONSOLE), leave files as-is
+export function copyContractsRemoveConsole (srcFolder, dstFolder) {
+  const contractsDir = path.resolve(__dirname, srcFolder)
+  const tmpContractsDir = path.resolve(__dirname, dstFolder)
+  fs.rmSync(tmpContractsDir, { recursive: true,force: true })
+  const isTest = process.env.TEST_CONSOLE
+  const mapStr = isTest
+    ? s => s /* test: don't change content */
+    : s => s.replace(/.*console\.\w.*\n/g, '') /* nontest: remove lines containing console.log or console.sol */
+
+  console.warn('contracts copied to tmp folder', tmpContractsDir, isTest ? 'testing - unmodified' : 'production - console references removed')
+  mapFilesRecursive(contractsDir, tmpContractsDir, mapStr)
+  return tmpContractsDir
+}

--- a/packages/contracts/truffle.js
+++ b/packages/contracts/truffle.js
@@ -1,8 +1,13 @@
 require('ts-node/register/transpile-only')
+const { copyContractsRemoveConsole } = require('./testCopyContracts')
+const path = require('path')
 
 module.exports = {
   // CLI package needs to deploy contracts from JSON artifacts
-  contracts_build_directory: '../cli/src/compiled',
+  contracts_build_directory:
+  copyContractsRemoveConsole(
+    path.resolve(__dirname, '../cli/src/compiled'),
+    path.resolve(__dirname, 'build/src')),
   contracts_directory: './src',
   compilers: {
     solc: {

--- a/packages/dev/truffle.js
+++ b/packages/dev/truffle.js
@@ -1,4 +1,6 @@
 require('ts-node/register/transpile-only')
+const { copyContractsRemoveConsole } = require('@opengsn/contracts/testCopyContracts')
+const path = require('path')
 
 const HDWalletProvider = require('@truffle/hdwallet-provider')
 let mnemonic = 'digital unknown jealous mother legal hedgehog save glory december universe spread figure custom found six'
@@ -16,6 +18,10 @@ if (fs.existsSync(secretMnemonicFile)) {
 }
 
 module.exports = {
+  contracts_directory: copyContractsRemoveConsole(
+    path.resolve(__dirname, '/../contracts/src'),
+    path.resolve(__dirname, '/build/src')),
+
   networks: {
 
     development: {


### PR DESCRIPTION
if TEST_CONSOLE is set, then leave contracts as-is
if not, then compile with console.log and console.sol lines removed from
code.
NOTE: it means that such logs must NOT have any side-effects!
(Also, they might modify gas calculations, so at least the test gas
should be validated with TEST_CONSOLE cleared.

the "build/src" is always a fresh copy and carries original timestamps,
so incremental build can work.