### PR TITLE
use estimateGas instead of fixed cost

### DIFF
--- a/packages/cli/src/CommandsLogic.ts
+++ b/packages/cli/src/CommandsLogic.ts
@@ -300,7 +300,6 @@ export class CommandsLogic {
           .stakeForRelayManager(relayAddress, options.unstakeDelay.toString(), {
             value: stakeValue,
             from: options.from,
-            gas: 1e6,
             gasPrice
           })
         // @ts-ignore

--- a/packages/common/src/ContractInteractor.ts
+++ b/packages/common/src/ContractInteractor.ts
@@ -703,8 +703,8 @@ export class ContractInteractor {
     return await this.web3.eth.sendSignedTransaction(rawTx)
   }
 
-  async estimateGas (gsnTransactionDetails: GsnTransactionDetails): Promise<number> {
-    return await this.web3.eth.estimateGas(gsnTransactionDetails)
+  async estimateGas (transactionDetails: TransactionConfig): Promise<number> {
+    return await this.web3.eth.estimateGas(transactionDetails)
   }
 
   async estimateGasWithoutCalldata (gsnTransactionDetails: GsnTransactionDetails): Promise<number> {

--- a/packages/dev/test/RelayServer.test.ts
+++ b/packages/dev/test/RelayServer.test.ts
@@ -369,7 +369,6 @@ contract('RelayServer', function (accounts: Truffle.Accounts) {
           await env.relayServer.transactionManager.sendTransaction({
             signer,
             serverAction: ServerAction.VALUE_TRANSFER,
-            gasLimit: defaultEnvironment.mintxgascost,
             destination: accounts[0],
             creationBlockNumber: 0
           })
@@ -703,7 +702,6 @@ contract('RelayServer', function (accounts: Truffle.Accounts) {
         signer: relayServer.workerAddress,
         serverAction: ServerAction.VALUE_TRANSFER,
         destination: accounts[0],
-        gasLimit: defaultEnvironment.mintxgascost,
         maxFeePerGas: gasPrice,
         maxPriorityFeePerGas: gasPrice,
         creationBlockNumber: 0,
@@ -750,7 +748,6 @@ contract('RelayServer', function (accounts: Truffle.Accounts) {
         serverAction: ServerAction.VALUE_TRANSFER,
         creationBlockNumber: 0,
         destination: accounts[0],
-        gasLimit: defaultEnvironment.mintxgascost,
         maxFeePerGas: gasPrice,
         maxPriorityFeePerGas: gasPrice,
         value: toHex((await relayServer.getManagerBalance()).sub(txCost))
@@ -803,7 +800,6 @@ contract('RelayServer', function (accounts: Truffle.Accounts) {
         serverAction: ServerAction.VALUE_TRANSFER,
         creationBlockNumber: 0,
         destination: accounts[0],
-        gasLimit: defaultEnvironment.mintxgascost,
         maxFeePerGas: gasPrice,
         maxPriorityFeePerGas: gasPrice,
         value: toHex((await relayServer.getManagerBalance()).sub(txCost))

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -578,7 +578,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
           serverAction: ServerAction.VALUE_TRANSFER,
           destination: this.workerAddress,
           value: toHex(refill),
-          creationBlockNumber: currentBlock,
+          creationBlockNumber: currentBlock
         }
         const { transactionHash } = await this.transactionManager.sendTransaction(details)
         transactionHashes.push(transactionHash)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -579,7 +579,6 @@ latestBlock timestamp   | ${latestBlock.timestamp}
           destination: this.workerAddress,
           value: toHex(refill),
           creationBlockNumber: currentBlock,
-          gasLimit: this.environment.mintxgascost
         }
         const { transactionHash } = await this.transactionManager.sendTransaction(details)
         transactionHashes.push(transactionHash)

--- a/packages/relay/src/TransactionManager.ts
+++ b/packages/relay/src/TransactionManager.ts
@@ -156,7 +156,7 @@ data                     | ${transaction.data}
         to: txDetails.destination,
         data: txDetails.method,
         value: txDetails.value
-      } as any)
+      })
       console.log('sendTransaction: gasLimit from estimate', gasLimit)
     }
     await this.validateBalance(txDetails.signer, maxFeePerGas, gasLimit)

--- a/packages/relay/src/TransactionManager.ts
+++ b/packages/relay/src/TransactionManager.ts
@@ -30,7 +30,7 @@ export interface SendTransactionDetails {
   method?: any
   destination: Address
   value?: IntString
-  gasLimit: number
+  gasLimit?: number
   maxFeePerGas?: IntString
   maxPriorityFeePerGas?: IntString
   creationBlockNumber: number
@@ -149,7 +149,17 @@ data                     | ${transaction.data}
     const maxFeePerGas = parseInt(txDetails.maxFeePerGas ?? await this.gasPriceFetcher.getGasPrice())
     const maxPriorityFeePerGas = parseInt(txDetails.maxPriorityFeePerGas ?? maxFeePerGas.toString())
 
-    await this.validateBalance(txDetails.signer, maxFeePerGas, txDetails.gasLimit)
+    let gasLimit = txDetails.gasLimit;
+    if (gasLimit == null) {
+      gasLimit = await this.contractInteractor.estimateGas({
+        from: txDetails.signer,
+        to: txDetails.destination,
+        data: txDetails.method,
+        value: txDetails.value
+      } as any)
+      console.log('sendTransaction: gasLimit from estimate', gasLimit)
+    }
+    await this.validateBalance(txDetails.signer, maxFeePerGas, gasLimit)
     if (isSameAddress(txDetails.destination, constants.ZERO_ADDRESS)) {
       const msg = `Preventing to send transaction with action id ${txDetails.serverAction} to address(0)! Validate your configuration!`
       this.logger.error(msg)
@@ -166,7 +176,7 @@ data                     | ${transaction.data}
         txToSign = new FeeMarketEIP1559Transaction({
           to: txDetails.destination,
           value: txDetails.value,
-          gasLimit: txDetails.gasLimit,
+          gasLimit: gasLimit,
           maxFeePerGas,
           maxPriorityFeePerGas: maxPriorityFeePerGas,
           data: Buffer.from(encodedCall.slice(2), 'hex'),
@@ -176,7 +186,7 @@ data                     | ${transaction.data}
         txToSign = new Transaction({
           to: txDetails.destination,
           value: txDetails.value,
-          gasLimit: txDetails.gasLimit,
+          gasLimit: gasLimit,
           gasPrice: maxFeePerGas,
           data: Buffer.from(encodedCall.slice(2), 'hex'),
           nonce
@@ -260,8 +270,8 @@ data                     | ${transaction.data}
 
   _resolveNewGasPrice (oldMaxFee: number, oldMaxPriorityFee: number): { newMaxFee: number, newMaxPriorityFee: number, isMaxGasPriceReached: boolean } {
     let isMaxGasPriceReached = false
-    let newMaxFee = oldMaxFee * this.config.retryGasPriceFactor
-    let newMaxPriorityFee = oldMaxPriorityFee * this.config.retryGasPriceFactor
+    let newMaxFee = Math.round(oldMaxFee * this.config.retryGasPriceFactor)
+    let newMaxPriorityFee = Math.round(oldMaxPriorityFee * this.config.retryGasPriceFactor)
     // TODO: use BN for ETH values
     // Sanity check to ensure we are not burning all our balance in gas fees
     if (newMaxFee > parseInt(this.config.maxGasPrice)) {

--- a/packages/relay/src/TransactionManager.ts
+++ b/packages/relay/src/TransactionManager.ts
@@ -157,7 +157,7 @@ data                     | ${transaction.data}
         data: txDetails.method,
         value: txDetails.value
       })
-      this.logger.debug('sendTransaction: gasLimit from estimate', gasLimit)
+      this.logger.debug(`sendTransaction: gasLimit from estimate: ${gasLimit}`)
     }
     await this.validateBalance(txDetails.signer, maxFeePerGas, gasLimit)
     if (isSameAddress(txDetails.destination, constants.ZERO_ADDRESS)) {

--- a/packages/relay/src/TransactionManager.ts
+++ b/packages/relay/src/TransactionManager.ts
@@ -157,7 +157,7 @@ data                     | ${transaction.data}
         data: txDetails.method,
         value: txDetails.value
       })
-      console.log('sendTransaction: gasLimit from estimate', gasLimit)
+      this.logger.debug('sendTransaction: gasLimit from estimate', gasLimit)
     }
     await this.validateBalance(txDetails.signer, maxFeePerGas, gasLimit)
     if (isSameAddress(txDetails.destination, constants.ZERO_ADDRESS)) {

--- a/packages/relay/src/TransactionManager.ts
+++ b/packages/relay/src/TransactionManager.ts
@@ -149,7 +149,7 @@ data                     | ${transaction.data}
     const maxFeePerGas = parseInt(txDetails.maxFeePerGas ?? await this.gasPriceFetcher.getGasPrice())
     const maxPriorityFeePerGas = parseInt(txDetails.maxPriorityFeePerGas ?? maxFeePerGas.toString())
 
-    let gasLimit = txDetails.gasLimit;
+    let gasLimit = txDetails.gasLimit
     if (gasLimit == null) {
       gasLimit = await this.contractInteractor.estimateGas({
         from: txDetails.signer,


### PR DESCRIPTION
perform gas estimation when doing value-transfer, instead of assuming
fixed-cost (which is different on rollups)

NOTE: should perform such estimates for other transactions, not only
value transfers.