### PR TITLE
Port to master: Remove unused peerDependencies

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -22,13 +22,5 @@
   },
   "devDependencies": {
     "solhint": "^3.3.2"
-  },
-  "peerDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "bn.js": "^5.2.0",
-    "web3": "^1.6.1",
-    "web3-core": "^1.6.1",
-    "web3-eth-contract": "^1.6.1",
-    "web3-utils": "^1.6.1"
   }
 }

--- a/packages/paymasters/package.json
+++ b/packages/paymasters/package.json
@@ -45,13 +45,5 @@
     "@types/web3": "1.2.2",
     "ganache-cli": "^6.12.2",
     "solhint": "^3.3.2"
-  },
-  "peerDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "bn.js": "^5.2.0",
-    "web3": "^1.6.1",
-    "web3-core": "^1.6.1",
-    "web3-eth-contract": "^1.6.1",
-    "web3-utils": "^1.6.1"
   }
 }


### PR DESCRIPTION
these are not used directly, so they only generate "warnings" when
installing the package.