### PR TITLE
CHERRY_PICK paymaster support for 0.6 contracts

### DIFF
--- a/packages/contracts/src/AbstractPaymaster.sol
+++ b/packages/contracts/src/AbstractPaymaster.sol
@@ -1,0 +1,101 @@
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
+
+import "./utils/GsnTypes.sol";
+import "./interfaces/IPaymaster.sol";
+import "./interfaces/IRelayHub.sol";
+import "./utils/GsnEip712Library.sol";
+import "./forwarder/IForwarder.sol";
+
+/**
+ * Abstract base class
+ * Project-specific Paymasters should inherit BasePaymaster contract.
+ */
+abstract contract AbstractPaymaster is IPaymaster {
+
+    IRelayHub internal relayHub;
+    address private _trustedForwarder;
+
+    function getHubAddr() public override view returns (address) {
+        return address(relayHub);
+    }
+
+    //overhead of forwarder verify+signature, plus hub overhead.
+    uint256 constant public FORWARDER_HUB_OVERHEAD = 50000;
+
+    //These parameters are documented in IPaymaster.GasAndDataLimits
+    uint256 constant public PRE_RELAYED_CALL_GAS_LIMIT = 100000;
+    uint256 constant public POST_RELAYED_CALL_GAS_LIMIT = 110000;
+    uint256 constant public PAYMASTER_ACCEPTANCE_BUDGET = PRE_RELAYED_CALL_GAS_LIMIT + FORWARDER_HUB_OVERHEAD;
+    uint256 constant public CALLDATA_SIZE_LIMIT = 10500;
+
+    function getGasAndDataLimits()
+    public
+    override
+    virtual
+    view
+    returns (
+        IPaymaster.GasAndDataLimits memory limits
+    ) {
+        return IPaymaster.GasAndDataLimits(
+            PAYMASTER_ACCEPTANCE_BUDGET,
+            PRE_RELAYED_CALL_GAS_LIMIT,
+            POST_RELAYED_CALL_GAS_LIMIT,
+            CALLDATA_SIZE_LIMIT
+        );
+    }
+
+    // this method must be called from preRelayedCall to validate that the forwarder
+    // is approved by the paymaster as well as by the recipient contract.
+    function _verifyForwarder(GsnTypes.RelayRequest calldata relayRequest)
+    public
+    view
+    {
+        require(address(_trustedForwarder) == relayRequest.relayData.forwarder, "Forwarder is not trusted");
+        GsnEip712Library.verifyForwarderTrusted(relayRequest);
+    }
+
+    /*
+     * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
+     */
+    modifier relayHubOnly() {
+        require(msg.sender == getHubAddr(), "can only be called by RelayHub");
+        _;
+    }
+
+    function _setRelayHub(IRelayHub hub) internal {
+        relayHub = hub;
+    }
+
+    function __setTrustedForwarder(address forwarder) internal {
+        _trustedForwarder = forwarder;
+    }
+
+    function trustedForwarder() public virtual view override returns (address){
+        return _trustedForwarder;
+    }
+
+
+    /// check current deposit on relay hub.
+    function getRelayHubDeposit()
+    public
+    override
+    view
+    returns (uint) {
+        return relayHub.balanceOf(address(this));
+    }
+
+    // any money moved into the paymaster is transferred as a deposit.
+    // This way, we don't need to understand the RelayHub API in order to replenish
+    // the paymaster.
+    receive() external virtual payable {
+        require(address(relayHub) != address(0), "relay hub address not set");
+        relayHub.depositFor{value:msg.value}(address(this));
+    }
+
+    /// withdraw deposit from relayHub
+    function _withdrawRelayHubDepositTo(uint amount, address payable target) internal {
+        relayHub.withdraw(amount, target);
+    }
+}

--- a/packages/contracts/src/BasePaymaster.sol
+++ b/packages/contracts/src/BasePaymaster.sol
@@ -1,105 +1,28 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.7.6;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.0;
 pragma abicoder v2;
 
 import "@openzeppelin/contracts/access/Ownable.sol";
-
-import "./utils/GsnTypes.sol";
-import "./interfaces/IPaymaster.sol";
-import "./interfaces/IRelayHub.sol";
-import "./utils/GsnEip712Library.sol";
-import "./forwarder/IForwarder.sol";
+import "./AbstractPaymaster.sol";
 
 /**
- * Abstract base class to be inherited by a concrete Paymaster
+ * Base contract to be inherited by a concrete Paymaster
+ *
  * A subclass must implement:
- *  - preRelayedCall
- *  - postRelayedCall
+ *  - preRelayedCall - provide logic to validate the request, and revert if the paymaster refuse to pay.
+ *  - postRelayedCall - provide logic after the call, (e.g. charge the caller by some contract logic) for this call.
  */
-abstract contract BasePaymaster is IPaymaster, Ownable {
-
-    IRelayHub internal relayHub;
-    address private _trustedForwarder;
-
-    function getHubAddr() public override view returns (address) {
-        return address(relayHub);
-    }
-
-    //overhead of forwarder verify+signature, plus hub overhead.
-    uint256 constant public FORWARDER_HUB_OVERHEAD = 50000;
-
-    //These parameters are documented in IPaymaster.GasAndDataLimits
-    uint256 constant public PRE_RELAYED_CALL_GAS_LIMIT = 100000;
-    uint256 constant public POST_RELAYED_CALL_GAS_LIMIT = 110000;
-    uint256 constant public PAYMASTER_ACCEPTANCE_BUDGET = PRE_RELAYED_CALL_GAS_LIMIT + FORWARDER_HUB_OVERHEAD;
-    uint256 constant public CALLDATA_SIZE_LIMIT = 10500;
-
-    function getGasAndDataLimits()
-    public
-    override
-    virtual
-    view
-    returns (
-        IPaymaster.GasAndDataLimits memory limits
-    ) {
-        return IPaymaster.GasAndDataLimits(
-            PAYMASTER_ACCEPTANCE_BUDGET,
-            PRE_RELAYED_CALL_GAS_LIMIT,
-            POST_RELAYED_CALL_GAS_LIMIT,
-            CALLDATA_SIZE_LIMIT
-        );
-    }
-
-    // this method must be called from preRelayedCall to validate that the forwarder
-    // is approved by the paymaster as well as by the recipient contract.
-    function _verifyForwarder(GsnTypes.RelayRequest calldata relayRequest)
-    public
-    view
-    {
-        require(address(_trustedForwarder) == relayRequest.relayData.forwarder, "Forwarder is not trusted");
-        GsnEip712Library.verifyForwarderTrusted(relayRequest);
-    }
-
-    /*
-     * modifier to be used by recipients as access control protection for preRelayedCall & postRelayedCall
-     */
-    modifier relayHubOnly() {
-        require(msg.sender == getHubAddr(), "can only be called by RelayHub");
-        _;
-    }
+abstract contract BasePaymaster is AbstractPaymaster, Ownable {
 
     function setRelayHub(IRelayHub hub) public onlyOwner {
-        relayHub = hub;
+        _setRelayHub(hub);
     }
 
     function setTrustedForwarder(address forwarder) public virtual onlyOwner {
-        _trustedForwarder = forwarder;
+        __setTrustedForwarder(forwarder);
     }
 
-    function trustedForwarder() public virtual view override returns (address){
-        return _trustedForwarder;
-    }
-
-
-    /// check current deposit on relay hub.
-    function getRelayHubDeposit()
-    public
-    override
-    view
-    returns (uint) {
-        return relayHub.balanceOf(address(this));
-    }
-
-    // any money moved into the paymaster is transferred as a deposit.
-    // This way, we don't need to understand the RelayHub API in order to replenish
-    // the paymaster.
-    receive() external virtual payable {
-        require(address(relayHub) != address(0), "relay hub address not set");
-        relayHub.depositFor{value:msg.value}(address(this));
-    }
-
-    /// withdraw deposit from relayHub
     function withdrawRelayHubDepositTo(uint amount, address payable target) public onlyOwner {
-        relayHub.withdraw(amount, target);
+        _withdrawRelayHubDepositTo(amount, target);
     }
 }

--- a/packages/contracts/src/forwarder/IForwarder.sol
+++ b/packages/contracts/src/forwarder/IForwarder.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.7.6;
-pragma abicoder v2;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
 
 interface IForwarder {
 

--- a/packages/contracts/src/interfaces/IPaymaster.sol
+++ b/packages/contracts/src/interfaces/IPaymaster.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.7.6;
-pragma abicoder v2;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
 
 import "../utils/GsnTypes.sol";
 

--- a/packages/contracts/src/interfaces/IRelayHub.sol
+++ b/packages/contracts/src/interfaces/IRelayHub.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.7.6;
-pragma abicoder v2;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
 
 import "../utils/GsnTypes.sol";
 import "./IStakeManager.sol";

--- a/packages/contracts/src/interfaces/IStakeManager.sol
+++ b/packages/contracts/src/interfaces/IStakeManager.sol
@@ -1,8 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity >=0.7.6;
-pragma abicoder v2;
-
-import "@openzeppelin/contracts/utils/math/SafeMath.sol";
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
 
 interface IStakeManager {
 

--- a/packages/contracts/src/utils/GsnEip712Library.sol
+++ b/packages/contracts/src/utils/GsnEip712Library.sol
@@ -1,6 +1,6 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.0;
-pragma abicoder v2;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
+pragma experimental ABIEncoderV2;
 
 import "../utils/GsnTypes.sol";
 import "../interfaces/IRelayRecipient.sol";

--- a/packages/contracts/src/utils/GsnTypes.sol
+++ b/packages/contracts/src/utils/GsnTypes.sol
@@ -1,5 +1,5 @@
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
 
 import "../forwarder/IForwarder.sol";
 

--- a/packages/contracts/src/utils/GsnUtils.sol
+++ b/packages/contracts/src/utils/GsnUtils.sol
@@ -1,6 +1,6 @@
 /* solhint-disable no-inline-assembly */
-// SPDX-License-Identifier: GPL-3.0-only
-pragma solidity ^0.8.0;
+// SPDX-License-Identifier: MIT
+pragma solidity >=0.6.9;
 
 import "../utils/MinLibBytes.sol";
 

--- a/packages/contracts/src/utils/MinLibBytes.sol
+++ b/packages/contracts/src/utils/MinLibBytes.sol
@@ -2,7 +2,7 @@
 // minimal bytes manipulation required by GSN
 // a minimal subset from 0x/LibBytes
 /* solhint-disable no-inline-assembly */
-pragma solidity ^0.8.0;
+pragma solidity >=0.6.9;
 
 library MinLibBytes {
 

--- a/packages/paymasters/contracts/PermitERC20UniswapV3Paymaster.sol
+++ b/packages/paymasters/contracts/PermitERC20UniswapV3Paymaster.sol
@@ -46,7 +46,7 @@ contract PermitERC20UniswapV3Paymaster is BasePaymaster, BaseRelayRecipient {
         return "2.2.3+opengsn.permit-erc20-uniswap-v3.irelayrecipient";
     }
 
-    function trustedForwarder() override(BasePaymaster, BaseRelayRecipient) public view returns (address forwarder){
+    function trustedForwarder() override(AbstractPaymaster, BaseRelayRecipient) public view returns (address forwarder){
         forwarder = BaseRelayRecipient.trustedForwarder();
     }
 


### PR DESCRIPTION
added abstractPaymaster, whcih doesn't use openzeppelin's Ownable (which
requires solidity 0.8)