### PR TITLE
OG-656: Consider a transaction 'pending' for 15 blocks after mining

### DIFF
--- a/dockers/relaydc/docker-compose.yml
+++ b/dockers/relaydc/docker-compose.yml
@@ -32,7 +32,7 @@ services:
 #### make sure to add instance name to the router command above
 
   gsn1:
-    image: opengsn/jsrelay:2.2.3
+    image: opengsn/jsrelay:2.2.4
     restart: on-failure
 
     # $ROOT - mapped by calling script to data folder

--- a/lerna.json
+++ b/lerna.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.2.2",
+  "version": "2.2.4",
   "npmClient": "yarn",
   "useWorkspaces": true
 }

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsn/cli",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "license": "GPL-3.0-only",
   "main": "dist/commands/gsn.js",
   "bin": {
@@ -20,9 +20,10 @@
     "access": "public"
   },
   "dependencies": {
-    "@opengsn/common": "^2.2.2",
-    "@opengsn/provider": "^2.2.2",
-    "@opengsn/relay": "^2.2.2",
+    "@ethereumjs/tx": "^3.2.0",
+    "@opengsn/common": "^2.2.4",
+    "@opengsn/provider": "^2.2.4",
+    "@opengsn/relay": "^2.2.4",
     "@truffle/hdwallet-provider": "1.0.34",
     "@types/asciichart": "^1.5.4",
     "@types/clear": "^0.1.1",
@@ -37,7 +38,6 @@
     "commander": "^6.1.0",
     "console-read-write": "^0.1.1",
     "date-format": "^3.0.0",
-    "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-util": "^7.1.0",
     "moment": "^2.29.1",
     "terminal-link": "^2.1.1",

--- a/packages/cli/src/CommandsLogic.ts
+++ b/packages/cli/src/CommandsLogic.ts
@@ -215,7 +215,6 @@ export class CommandsLogic {
       console.log('current stake=', fromWei(stake, 'ether'))
 
       if (owner !== constants.ZERO_ADDRESS && !isSameAddress(owner, options.from)) {
-        // throw new Error(`Already owned by ${owner}, our account=${options.from}`)
         throw new Error(`Already owned by ${owner}, our account=${options.from}`)
       }
 
@@ -325,7 +324,6 @@ export class CommandsLogic {
       value: 0,
       gasPrice: deployOptions.gasPrice
     }
-
     const sInstance = await this.getContractInstance(StakeManager, {
       arguments: [defaultEnvironment.maxUnstakeDelay]
     }, deployOptions.stakeManagerAddress, { ...options }, deployOptions.skipConfirmation)
@@ -383,7 +381,7 @@ export class CommandsLogic {
       const sendMethod = this
         .contract(json)
         .deploy(constructorArgs)
-      const estimatedGasCost = await sendMethod.estimateGas()
+      const estimatedGasCost = await sendMethod.estimateGas({ ...options })
       const maxCost = new BN(options.gasPrice).muln(options.gas)
       console.log(`Deploying ${contractName} contract with gas limit of ${options.gas.toLocaleString()} at ${fromWei(options.gasPrice, 'gwei')}gwei (estimated gas: ${estimatedGasCost.toLocaleString()}) and maximum cost of ~ ${fromWei(maxCost)} ETH`)
       if (!skipConfirmation) {

--- a/packages/cli/src/utils.ts
+++ b/packages/cli/src/utils.ts
@@ -14,6 +14,8 @@ export const networks = new Map<string, string>([
   ['ropsten', 'https://ropsten.infura.io/v3/' + cliInfuraId],
   ['rinkeby', 'https://rinkeby.infura.io/v3/' + cliInfuraId],
   ['kovan', 'https://kovan.infura.io/v3/' + cliInfuraId],
+  ['optimism_kovan', 'https://kovan.optimism.io/'],
+  ['optimism', 'https://mainnet.optimism.io/'],
   ['goerli', 'https://goerli.infura.io/v3/' + cliInfuraId],
   ['mainnet', 'https://mainnet.infura.io/v3/' + cliInfuraId]
 ])
@@ -23,6 +25,8 @@ export const networksBlockExplorers = new Map<string, string>([
   ['ropsten', 'https://ropsten.etherscan.io/'],
   ['rinkeby', 'https://rinkeby.etherscan.io/'],
   ['kovan', 'https://kovan.etherscan.io/'],
+  ['optimism_kovan', 'https://kovan-optimistic.etherscan.io/'],
+  ['optimism', 'https://optimistic.etherscan.io/'],
   ['goerli', 'https://goerli.etherscan.io/'],
   ['mainnet', 'https://etherscan.io/']
 ])

--- a/packages/common/package.json
+++ b/packages/common/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsn/common",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "scripts": {
@@ -16,7 +16,8 @@
     "access": "public"
   },
   "dependencies": {
-    "@opengsn/contracts": "^2.2.2",
+    "@ethereumjs/tx": "^3.2.0",
+    "@opengsn/contracts": "^2.2.4",
     "@types/bn.js": "^5.1.0",
     "@types/eth-sig-util": "^2.1.0",
     "@types/semver": "^7.3.4",
@@ -25,7 +26,6 @@
     "bn.js": "^5.2.0",
     "chalk": "^4.1.0",
     "eth-sig-util": "2.5.2",
-    "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-util": "^7.1.0",
     "ethval": "^2.1.1",
     "ow": "^0.17.0",

--- a/packages/common/src/ContractInteractor.ts
+++ b/packages/common/src/ContractInteractor.ts
@@ -345,8 +345,7 @@ export class ContractInteractor {
           const revertMsg = this._decodeRevertFromResponse(err, res)
           if (revertMsg != null) {
             reject(new Error(revertMsg))
-          }
-          if (err !== null) {
+          } else if (err !== null) {
             reject(err)
           } else {
             resolve(res.result)
@@ -405,7 +404,8 @@ export class ContractInteractor {
     if (matchGanache != null) {
       return matchGanache[1]
     }
-    const m = err?.data?.toString().match(/(0x08c379a0\S*)/)
+    const errorData = err?.data ?? res?.error?.data
+    const m = errorData?.toString().match(/(0x08c379a0\S*)/)
     if (m != null) {
       return decodeRevertReason(m[1])
     }

--- a/packages/common/src/Version.ts
+++ b/packages/common/src/Version.ts
@@ -1,2 +1,2 @@
-export const gsnRuntimeVersion = '2.2.3'
+export const gsnRuntimeVersion = '2.2.4'
 export const gsnRequiredVersion = '^2.2.0'

--- a/packages/common/src/types/Aliases.ts
+++ b/packages/common/src/types/Aliases.ts
@@ -7,6 +7,7 @@ import { RelayFailureInfo } from './RelayFailureInfo'
 import { RelayRegisteredEventInfo } from './GSNContractsDataTypes'
 import { HttpProvider, IpcProvider, WebsocketProvider } from 'web3-core'
 import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
+import BN from 'bn.js'
 
 export type Address = string
 export type EventName = string
@@ -20,7 +21,7 @@ export type PingFilter = (pingResponse: PingResponse, gsnTransactionDetails: Gsn
 export type AsyncDataCallback = (relayRequest: RelayRequest) => Promise<PrefixedHexString>
 
 export type RelayFilter = (registeredEventInfo: RelayRegisteredEventInfo) => boolean
-export type AsyncScoreCalculator = (relay: RelayRegisteredEventInfo, txDetails: GsnTransactionDetails, failures: RelayFailureInfo[]) => Promise<number>
+export type AsyncScoreCalculator = (relay: RelayRegisteredEventInfo, txDetails: GsnTransactionDetails, failures: RelayFailureInfo[]) => Promise<BN>
 
 export function notNull<TValue> (value: TValue | null | undefined): value is TValue {
   return value !== null && value !== undefined

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -21,13 +21,5 @@
   },
   "devDependencies": {
     "solhint": "^3.3.2"
-  },
-  "peerDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "bn.js": "^5.2.0",
-    "web3": "^1.2.6",
-    "web3-core": "^1.2.6",
-    "web3-eth-contract": "^1.2.6",
-    "web3-utils": "^1.2.6"
   }
 }

--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opengsn/contracts",
   "license": "GPL-3.0-only",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "main": "types/truffle-contracts/index.d.ts",
   "scripts": {
     "truffle-compile": "truffle compile --compile-all",

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsn/dev",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "license": "GPL-3.0-only",
   "main": "dist/index.js",
   "files": [
@@ -21,13 +21,15 @@
     "rm-dist": "rm -rf tsconfig.tsbuildinfo dist build"
   },
   "dependencies": {
-    "@opengsn/cli": "^2.2.2",
-    "@opengsn/contracts": "^2.2.2",
-    "@opengsn/provider": "^2.2.2",
-    "@opengsn/relay": "^2.2.2"
+    "@opengsn/cli": "^2.2.4",
+    "@opengsn/contracts": "^2.2.4",
+    "@opengsn/provider": "^2.2.4",
+    "@opengsn/relay": "^2.2.4"
   },
   "devDependencies": {
     "@ethereumjs/tx": "^3.2.0",
+    "@nomiclabs/hardhat-truffle5": "^2.0.0",
+    "@nomiclabs/hardhat-web3": "^2.0.0",
     "@types/chai-as-promised": "^7.1.3",
     "@types/eth-sig-util": "^2.1.0",
     "@types/sinon": "^9.0.10",
@@ -38,8 +40,6 @@
     "eth-sig-util": "2.5.2",
     "ethereumjs-util": "^7.1.0",
     "hardhat": "^2.6.1",
-    "@nomiclabs/hardhat-truffle5": "^2.0.0",
-    "@nomiclabs/hardhat-web3": "^2.0.0",
     "sinon": "^9.2.3",
     "sinon-chai": "^3.5.0",
     "ts-node": "8.6.2"

--- a/packages/dev/test/RegistrationManager.test.ts
+++ b/packages/dev/test/RegistrationManager.test.ts
@@ -19,7 +19,7 @@ import { assertRelayAdded, getTemporaryWorkdirs, getTotalTxCosts, ServerWorkdirs
 import { createServerLogger } from '@opengsn/relay/dist/ServerWinstonLogger'
 import { TransactionManager } from '@opengsn/relay/dist/TransactionManager'
 import { GasPriceFetcher } from '@opengsn/relay/dist/GasPriceFetcher'
-import { ether } from '@opengsn/common/dist'
+import { ether } from '@opengsn/common'
 import sinon from 'sinon'
 import chai from 'chai'
 import sinonChai from 'sinon-chai'
@@ -213,22 +213,24 @@ contract('RegistrationManager', function (accounts) {
       let transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assert.equal(transactionHashes.length, 0, 'should not re-register if already registered')
 
+      const currentBlockFake = 1000000
+
       relayServer.config.baseRelayFee = (parseInt(relayServer.config.baseRelayFee) + 1).toString()
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
 
       latestBlock = await env.web3.eth.getBlock('latest')
       await relayServer._worker(latestBlock.number)
 
       relayServer.config.pctRelayFee++
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
 
       latestBlock = await env.web3.eth.getBlock('latest')
       await relayServer._worker(latestBlock.number)
 
       relayServer.config.url = 'fakeUrl'
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
     })
   })

--- a/packages/dev/test/provider/KnownRelaysManager.test.ts
+++ b/packages/dev/test/provider/KnownRelaysManager.test.ts
@@ -3,7 +3,7 @@ import { ChildProcessWithoutNullStreams } from 'child_process'
 import { HttpProvider } from 'web3-core'
 import { ether } from '@openzeppelin/test-helpers'
 
-import { KnownRelaysManager, DefaultRelayScore } from '@opengsn/provider/dist/KnownRelaysManager'
+import { KnownRelaysManager, DefaultRelayScore, DefaultRelayFilter } from '@opengsn/provider/dist/KnownRelaysManager'
 import { ContractInteractor } from '@opengsn/common/dist/ContractInteractor'
 import { GSNConfig } from '@opengsn/provider/dist/GSNConfigurator'
 import {
@@ -21,6 +21,7 @@ import { RelayInfoUrl, RelayRegisteredEventInfo } from '@opengsn/common/dist/typ
 import { createClientLogger } from '@opengsn/provider/dist/ClientWinstonLogger'
 import { registerForwarderForGsn } from '@opengsn/common/dist/EIP712/ForwarderUtil'
 import { defaultEnvironment } from '@opengsn/common/dist/Environments'
+import { toBN } from 'web3-utils'
 
 const StakeManager = artifacts.require('StakeManager')
 const Penalizer = artifacts.require('Penalizer')
@@ -161,7 +162,7 @@ contract('KnownRelaysManager 2', function (accounts) {
   let logger: LoggerInterface
 
   const transactionDetails = {
-    gas: '0x10000',
+    gas: '0x10000000',
     gasPrice: '0x300000',
     from: '',
     data: '',
@@ -252,6 +253,23 @@ contract('KnownRelaysManager 2', function (accounts) {
       assert.equal(relays.length, 1)
       assert.equal(relays[0].relayUrl, 'stakeAndAuthorization2')
     })
+
+    it('should use DefaultRelayFilter to remove unsuitable relays when none was provided', async function () {
+      const knownRelaysManagerWithFilter = new KnownRelaysManager(contractInteractor, logger, config)
+      // @ts-ignore
+      assert.equal(knownRelaysManagerWithFilter.relayFilter.toString(), DefaultRelayFilter.toString())
+    })
+
+    describe('DefaultRelayFilter', function () {
+      it('should filter expensive relayers', function () {
+        const eventInfo = { relayUrl: 'url', relayManager: accounts[0] }
+        assert.isFalse(DefaultRelayFilter({ ...eventInfo, pctRelayFee: '101', baseRelayFee: 1e16.toString() }))
+        assert.isFalse(DefaultRelayFilter({ ...eventInfo, pctRelayFee: '99', baseRelayFee: 2e17.toString() }))
+        assert.isFalse(DefaultRelayFilter({ ...eventInfo, pctRelayFee: '101', baseRelayFee: 2e17.toString() }))
+        assert.isTrue(DefaultRelayFilter({ ...eventInfo, pctRelayFee: '100', baseRelayFee: 1e17.toString() }))
+        assert.isTrue(DefaultRelayFilter({ ...eventInfo, pctRelayFee: '50', baseRelayFee: '0' }))
+      })
+    })
   })
 
   describe('#getRelaysSortedForTransaction()', function () {
@@ -309,19 +327,24 @@ contract('KnownRelaysManager 2', function (accounts) {
         const relayScoreOneFailure = await DefaultRelayScore(relayInfoHighFee, transactionDetails, [failure])
         const relayScoreTenFailures = await DefaultRelayScore(relayInfoHighFee, transactionDetails, Array(10).fill(failure))
         const relayScoreLowFees = await DefaultRelayScore(relayInfoLowFee, transactionDetails, [])
-        assert.isAbove(relayScoreNoFailures, relayScoreOneFailure)
-        assert.isAbove(relayScoreOneFailure, relayScoreTenFailures)
-        assert.isAbove(relayScoreLowFees, relayScoreNoFailures)
+        assert.isTrue(relayScoreNoFailures.gt(relayScoreOneFailure))
+        assert.isTrue(relayScoreOneFailure.gt(relayScoreTenFailures))
+        assert.isTrue(relayScoreLowFees.gt(relayScoreNoFailures))
+      })
+      it('should use DefaultRelayScore to remove unsuitable relays when none was provided', async function () {
+        const knownRelaysManagerWithFilter = new KnownRelaysManager(contractInteractor, logger, configureGSN({}))
+        // @ts-ignore
+        assert.equal(knownRelaysManagerWithFilter.scoreCalculator.toString(), DefaultRelayScore.toString())
       })
     })
   })
 
   describe('getRelaysSortedForTransaction', function () {
-    const biasedRelayScore = async function (relay: RelayRegisteredEventInfo): Promise<number> {
+    const biasedRelayScore = async function (relay: RelayRegisteredEventInfo): Promise<BN> {
       if (relay.relayUrl === 'alex') {
-        return await Promise.resolve(1000)
+        return await Promise.resolve(toBN(1000))
       } else {
-        return await Promise.resolve(100)
+        return await Promise.resolve(toBN(100))
       }
     }
     const knownRelaysManager = new KnownRelaysManager(contractInteractor, logger, configureGSN({}), undefined, biasedRelayScore)

--- a/packages/dev/test/provider/RelaySelectionManager.test.ts
+++ b/packages/dev/test/provider/RelaySelectionManager.test.ts
@@ -7,7 +7,7 @@ import { HttpClient } from '@opengsn/common/dist/HttpClient'
 import { HttpWrapper } from '@opengsn/common/dist/HttpWrapper'
 import { PingResponse } from '@opengsn/common/dist/PingResponse'
 import { RelaySelectionManager } from '@opengsn/provider/dist/RelaySelectionManager'
-import { EmptyFilter, KnownRelaysManager } from '@opengsn/provider/dist/KnownRelaysManager'
+import { DefaultRelayFilter, KnownRelaysManager } from '@opengsn/provider/dist/KnownRelaysManager'
 import { GasPricePingFilter } from '@opengsn/provider/dist/RelayClient'
 import { PartialRelayInfo, RelayInfo } from '@opengsn/common/dist/types/RelayInfo'
 import { PingFilter } from '@opengsn/common/dist/types/Aliases'
@@ -75,7 +75,7 @@ contract('RelaySelectionManager', function (accounts) {
         logger
       }).init()
       httpClient = new HttpClient(new HttpWrapper(), this.logger)
-      knownRelaysManager = new KnownRelaysManager(contractInteractor, logger, configureGSN({}), EmptyFilter)
+      knownRelaysManager = new KnownRelaysManager(contractInteractor, logger, configureGSN({}), DefaultRelayFilter)
       stubGetRelaysSorted = sinon.stub(knownRelaysManager, 'getRelaysSortedForTransaction')
       stubGetRelaysSorted.returns(Promise.resolve([[eventInfo]]))
       relaySelectionManager = await new RelaySelectionManager(transactionDetails, knownRelaysManager, httpClient, GasPricePingFilter, logger, config).init()
@@ -120,7 +120,7 @@ contract('RelaySelectionManager', function (accounts) {
         const penalizer = await Penalizer.new(defaultEnvironment.penalizerConfiguration.penalizeBlockDelay, defaultEnvironment.penalizerConfiguration.penalizeBlockExpiration)
         relayHub = await deployHub(stakeManager.address, penalizer.address)
         await stake(stakeManager, relayHub, relayManager, accounts[0])
-        await register(relayHub, relayManager, accounts[2], preferredRelayUrl, '666', '777')
+        await register(relayHub, relayManager, accounts[2], preferredRelayUrl, '666', '77')
 
         await contractInteractor.initDeployment({
           relayHubAddress: relayHub.address,
@@ -162,7 +162,7 @@ contract('RelaySelectionManager', function (accounts) {
         assert.equal(nextRelay.relayInfo.relayUrl, preferredRelayUrl)
         assert.equal(nextRelay.relayInfo.relayManager, relayManager)
         assert.equal(nextRelay.relayInfo.baseRelayFee, '666')
-        assert.equal(nextRelay.relayInfo.pctRelayFee, '777')
+        assert.equal(nextRelay.relayInfo.pctRelayFee, '77')
       })
     })
 

--- a/packages/paymasters/package.json
+++ b/packages/paymasters/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@opengsn/paymasters",
   "license": "GPL-3.0-only",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "scripts": {
     "truffle-compile": "truffle compile --compile-all",
     "typechain-generate": "yarn truffle-compile && typechain --target truffle-v5 './build/contracts/**/*.json'",
@@ -28,12 +28,11 @@
     "access": "public"
   },
   "dependencies": {
+    "@opengsn/common": "^2.2.4",
+    "@opengsn/contracts": "^2.2.4",
+    "@opengsn/dev": "^2.2.4",
+    "@opengsn/provider": "^2.2.4",
     "@openzeppelin/contracts": "^4.2.0",
-    "@opengsn/dev": "^2.2.2",
-    "@opengsn/common": "^2.2.2",
-    "@opengsn/contracts": "^2.2.2",
-    "@opengsn/dev": "^2.2.2",
-    "@opengsn/provider": "^2.2.2",
     "@uniswap/v3-periphery": "^1.1.1",
     "ethereumjs-util": "^7.1.0"
   },

--- a/packages/paymasters/package.json
+++ b/packages/paymasters/package.json
@@ -45,13 +45,5 @@
     "@types/web3": "1.2.2",
     "ganache-cli": "^6.12.2",
     "solhint": "^3.3.2"
-  },
-  "peerDependencies": {
-    "@types/bn.js": "^5.1.0",
-    "bn.js": "^5.2.0",
-    "web3": "^1.2.6",
-    "web3-core": "^1.2.6",
-    "web3-eth-contract": "^1.2.6",
-    "web3-utils": "^1.2.6"
   }
 }

--- a/packages/provider/package.json
+++ b/packages/provider/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsn/provider",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "license": "Apache-2.0",
   "main": "dist/index.js",
   "scripts": {
@@ -16,14 +16,14 @@
     "access": "public"
   },
   "dependencies": {
-    "@opengsn/common": "^2.2.2",
+    "@ethereumjs/tx": "^3.2.0",
+    "@opengsn/common": "^2.2.4",
     "@types/body-parser": "^1.19.0",
     "@types/eth-sig-util": "^2.1.0",
     "@types/express-serve-static-core": "^4.17.18",
     "abi-decoder": "^2.4.0",
     "body-parser": "^1.19.0",
     "eth-sig-util": "2.5.2",
-    "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-util": "^7.1.0",
     "ethereumjs-wallet": "^0.6.5",
     "loglevel": "^1.7.1",

--- a/packages/provider/src/KnownRelaysManager.ts
+++ b/packages/provider/src/KnownRelaysManager.ts
@@ -16,22 +16,34 @@ import {
 } from '@opengsn/common/dist/types/GSNContractsDataTypes'
 import { LoggerInterface } from '@opengsn/common/dist/LoggerInterface'
 import { ContractInteractor } from '@opengsn/common/dist/ContractInteractor'
+import { MAX_INTEGER } from 'ethereumjs-util'
+import { toBN } from 'web3-utils'
+import BN from 'bn.js'
 
-export const EmptyFilter: RelayFilter = (): boolean => {
+export const DefaultRelayFilter: RelayFilter = function (registeredEventInfo: RelayRegisteredEventInfo): boolean {
+  const maxPctRelayFee = 100
+  const maxBaseRelayFee = 1e17
+  if (
+    parseInt(registeredEventInfo.pctRelayFee) > maxPctRelayFee ||
+    parseInt(registeredEventInfo.baseRelayFee) > maxBaseRelayFee
+  ) {
+    return false
+  }
   return true
 }
 /**
  * Basic score is reversed transaction fee, higher is better.
  * Relays that failed to respond recently will be downgraded for some period of time.
  */
-export const DefaultRelayScore = async function (relay: RelayRegisteredEventInfo, txDetails: GsnTransactionDetails, failures: RelayFailureInfo[]): Promise<number> {
-  const gasLimit = parseInt(txDetails.gas ?? '0')
-  const gasPrice = parseInt(txDetails.gasPrice ?? '0')
-  const pctFee = parseInt(relay.pctRelayFee)
-  const baseFee = parseInt(relay.baseRelayFee)
-  const transactionCost = baseFee + (gasLimit * gasPrice * (100 + pctFee)) / 100
-  let score = Math.max(Number.MAX_SAFE_INTEGER - transactionCost, 0)
-  score = score * Math.pow(0.9, failures.length)
+export const DefaultRelayScore: AsyncScoreCalculator = async function (relay: RelayRegisteredEventInfo, txDetails: GsnTransactionDetails, failures: RelayFailureInfo[]): Promise<BN> {
+  const gasLimit = toBN(txDetails.gas ?? '0')
+  const gasPrice = toBN(txDetails.gasPrice ?? '0')
+  const pctFee = toBN(relay.pctRelayFee)
+  const baseFee = toBN(relay.baseRelayFee)
+  const transactionCost = baseFee.add(gasLimit.mul(gasPrice).muln((100 + pctFee.toNumber()) / 100)
+  )
+  let score = MAX_INTEGER.sub(transactionCost)
+  score = score.muln(Math.pow(0.9, failures.length))
   return score
 }
 
@@ -51,7 +63,7 @@ export class KnownRelaysManager {
   constructor (contractInteractor: ContractInteractor, logger: LoggerInterface, config: GSNConfig, relayFilter?: RelayFilter, scoreCalculator?: AsyncScoreCalculator) {
     this.config = config
     this.logger = logger
-    this.relayFilter = relayFilter ?? EmptyFilter
+    this.relayFilter = relayFilter ?? DefaultRelayFilter
     this.scoreCalculator = scoreCalculator ?? DefaultRelayScore
     this.contractInteractor = contractInteractor
   }
@@ -173,9 +185,9 @@ export class KnownRelaysManager {
   }
 
   async _sortRelaysInternal (gsnTransactionDetails: GsnTransactionDetails, activeRelays: RelayInfoUrl[]): Promise<RelayInfoUrl[]> {
-    const scores = new Map<string, number>()
+    const scores = new Map<string, BN>()
     for (const activeRelay of activeRelays) {
-      let score = 0
+      let score = toBN(0)
       if (isInfoFromEvent(activeRelay)) {
         const eventInfo = activeRelay as RelayRegisteredEventInfo
         score = await this.scoreCalculator(eventInfo, gsnTransactionDetails, this.relayFailures.get(activeRelay.relayUrl) ?? [])
@@ -187,9 +199,9 @@ export class KnownRelaysManager {
       .filter(isInfoFromEvent)
       .map(value => (value as RelayRegisteredEventInfo))
       .sort((a, b) => {
-        const aScore = scores.get(a.relayManager) ?? 0
-        const bScore = scores.get(b.relayManager) ?? 0
-        return bScore - aScore
+        const aScore = scores.get(a.relayManager) ?? toBN(0)
+        const bScore = scores.get(b.relayManager) ?? toBN(0)
+        return bScore.cmp(aScore)
       })
   }
 

--- a/packages/provider/src/RelayClient.ts
+++ b/packages/provider/src/RelayClient.ts
@@ -19,7 +19,7 @@ import { HttpClient } from '@opengsn/common/dist/HttpClient'
 import { HttpWrapper } from '@opengsn/common/dist/HttpWrapper'
 import { RelaySelectionManager } from './RelaySelectionManager'
 import { RelayedTransactionValidator } from './RelayedTransactionValidator'
-import { DefaultRelayScore, EmptyFilter, KnownRelaysManager } from './KnownRelaysManager'
+import { DefaultRelayScore, DefaultRelayFilter, KnownRelaysManager } from './KnownRelaysManager'
 import { createClientLogger } from './ClientWinstonLogger'
 import { defaultGsnConfig, defaultLoggerConfiguration, GSNConfig, GSNDependencies } from './GSNConfigurator'
 
@@ -448,7 +448,7 @@ export class RelayClient {
 
     const httpClient = overrideDependencies?.httpClient ?? new HttpClient(new HttpWrapper(), this.logger)
     const pingFilter = overrideDependencies?.pingFilter ?? GasPricePingFilter
-    const relayFilter = overrideDependencies?.relayFilter ?? EmptyFilter
+    const relayFilter = overrideDependencies?.relayFilter ?? DefaultRelayFilter
     const asyncApprovalData = overrideDependencies?.asyncApprovalData ?? EmptyDataCallback
     const asyncPaymasterData = overrideDependencies?.asyncPaymasterData ?? EmptyDataCallback
     const scoreCalculator = overrideDependencies?.scoreCalculator ?? DefaultRelayScore

--- a/packages/relay/package.json
+++ b/packages/relay/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@opengsn/relay",
-  "version": "2.2.2",
+  "version": "2.2.4",
   "license": "GPL-3.0-only",
   "main": "dist/runServer.js",
   "files": [
@@ -16,13 +16,13 @@
     "access": "public"
   },
   "dependencies": {
-    "@opengsn/common": "^2.2.2",
+    "@ethereumjs/tx": "^3.2.0",
+    "@opengsn/common": "^2.2.4",
     "@types/cors": "^2.8.7",
     "@types/express": "^4.17.8",
     "@types/minimist": "^1.2.0",
     "@types/nedb": "^1.8.11",
     "async-mutex": "^0.2.4",
-    "@ethereumjs/tx": "^3.2.0",
     "ethereumjs-util": "^7.1.0",
     "nedb-async": "^0.1.3"
   }

--- a/packages/relay/src/RegistrationManager.ts
+++ b/packages/relay/src/RegistrationManager.ts
@@ -137,11 +137,13 @@ export class RegistrationManager {
       switch (eventData.event) {
         case RelayServerRegistered:
           if (this.lastMinedRegisterTransaction == null || isSecondEventLater(this.lastMinedRegisterTransaction, eventData)) {
+            this.logger.warn('New lastMinedRegisterTransaction: ' + JSON.stringify(eventData))
             this.lastMinedRegisterTransaction = eventData
           }
           break
         case RelayWorkersAdded:
           if (this.lastWorkerAddedTransaction == null || isSecondEventLater(this.lastWorkerAddedTransaction, eventData)) {
+            this.logger.warn('New lastWorkerAddedTransaction: ' + JSON.stringify(eventData))
             this.lastWorkerAddedTransaction = eventData
           }
           break
@@ -221,7 +223,7 @@ export class RegistrationManager {
       }
     }
     const isRegistrationCorrect = await this._isRegistrationCorrect()
-    const isRegistrationPending = await this.txStoreManager.isActionPending(ServerAction.REGISTER_SERVER)
+    const isRegistrationPending = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.REGISTER_SERVER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     if (!(isRegistrationPending || isRegistrationCorrect) || forceRegistration) {
       this.logger.debug(`will attempt registration: isRegistrationPending=${isRegistrationPending} isRegistrationCorrect=${isRegistrationCorrect} forceRegistration=${forceRegistration}`)
       transactionHashes = transactionHashes.concat(await this.attemptRegistration(currentBlock))
@@ -368,7 +370,7 @@ export class RegistrationManager {
     let transactions: PrefixedHexString[] = []
     // add worker only if not already added
     const workersAdded = await this._isWorkerValid()
-    const addWorkersPending = await this.txStoreManager.isActionPending(ServerAction.ADD_WORKER)
+    const addWorkersPending = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.ADD_WORKER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     if (!(workersAdded || addWorkersPending)) {
       const txHash = await this.addRelayWorker(currentBlock)
       transactions = transactions.concat(txHash)

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -537,7 +537,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     const mustWithdrawHubDeposit = managerEthBalance.lt(toBN(this.config.managerTargetBalance.toString())) && managerHubBalance.gte(
       toBN(this.config.minHubWithdrawalBalance))
-    const isWithdrawalPending = await this.txStoreManager.isActionPending(ServerAction.DEPOSIT_WITHDRAWAL)
+    const isWithdrawalPending = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.DEPOSIT_WITHDRAWAL, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     if (mustWithdrawHubDeposit && !isWithdrawalPending) {
       this.logger.info(`withdrawing manager hub balance (${managerHubBalance.toString()}) to manager`)
       // Refill manager eth balance from hub balance
@@ -556,7 +556,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     managerEthBalance = await this.getManagerBalance()
     const mustReplenishWorker = !this.workerBalanceRequired.isSatisfied
-    const isReplenishPendingForWorker = await this.txStoreManager.isActionPending(ServerAction.VALUE_TRANSFER, this.workerAddress)
+    const isReplenishPendingForWorker = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.VALUE_TRANSFER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks, this.workerAddress)
     if (mustReplenishWorker && !isReplenishPendingForWorker) {
       const refill = toBN(this.config.workerTargetBalance.toString()).sub(this.workerBalanceRequired.currentValue)
       this.logger.debug(
@@ -664,8 +664,8 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     const latestTxBlockNumber = this._getLatestTxBlockNumber()
     const latestRegisterTxBlockNumber = this._getLatestRegisterTxBlockNumber()
-    const isPendingRegistration = await this.txStoreManager.isActionPending(ServerAction.REGISTER_SERVER)
-    const isPendingActivity = isPendingRegistration || await this.txStoreManager.isActionPending(ServerAction.RELAY_CALL)
+    const isPendingRegistration = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.REGISTER_SERVER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
+    const isPendingActivity = isPendingRegistration || await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.RELAY_CALL, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     const registrationExpired =
       this.config.registrationBlockRate !== 0 &&
       (currentBlock - latestRegisterTxBlockNumber >= this.config.registrationBlockRate) &&

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -782,12 +782,12 @@ latestBlock timestamp   | ${latestBlock.timestamp}
   }
 
   async _boostStuckTransactionsForManager (blockNumber: number): Promise<Map<PrefixedHexString, SignedTransactionDetails>> {
-    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(this.managerAddress, blockNumber)
+    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(this.managerAddress, blockNumber, this.minGasPrice)
   }
 
   async _boostStuckTransactionsForWorker (blockNumber: number, workerIndex: number): Promise<Map<PrefixedHexString, SignedTransactionDetails>> {
     const signer = this.workerAddress
-    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(signer, blockNumber)
+    return await this.transactionManager.boostUnderpricedPendingTransactionsForSigner(signer, blockNumber, this.minGasPrice)
   }
 
   _isTrustedPaymaster (paymaster: string): boolean {

--- a/packages/relay/src/ServerConfigParams.ts
+++ b/packages/relay/src/ServerConfigParams.ts
@@ -73,6 +73,8 @@ export interface ServerConfigParams {
   coldRestartLogsFromBlock: number
   // if the number of blocks per 'getLogs' query is limited, use pagination with this page size
   pastEventsQueryMaxPageSize: number
+  // number of blocks the server will not repeat a ServerAction for regardless of blockchain state to avoid duplicates
+  recentActionAvoidRepeatDistanceBlocks: number
 }
 
 export interface ServerDependencies {
@@ -135,7 +137,8 @@ export const serverDefaultConfiguration: ServerConfigParams = {
   requestMinValidBlocks: 3000, // roughly 12 hours (half client's default of 6000 blocks
   runPaymasterReputations: true,
   coldRestartLogsFromBlock: 1,
-  pastEventsQueryMaxPageSize: Number.MAX_SAFE_INTEGER
+  pastEventsQueryMaxPageSize: Number.MAX_SAFE_INTEGER,
+  recentActionAvoidRepeatDistanceBlocks: 10
 }
 
 const ConfigParamsTypes = {
@@ -202,7 +205,8 @@ const ConfigParamsTypes = {
   maxGasPrice: 'string',
   coldRestartLogsFromBlock: 'number',
   pastEventsQueryMaxPageSize: 'number',
-  confirmationsNeeded: 'number'
+  confirmationsNeeded: 'number',
+  recentActionAvoidRepeatDistanceBlocks: 'number'
 } as any
 
 // by default: no waiting period - use VersionRegistry entries immediately.

--- a/packages/relay/src/TxStoreManager.ts
+++ b/packages/relay/src/TxStoreManager.ts
@@ -14,7 +14,7 @@ export class TxStoreManager {
   private readonly txstore: AsyncNedb<any>
   private readonly logger: LoggerInterface
 
-  constructor ({ workdir = '/tmp/test/', inMemory = false, autoCompactionInterval = 0 }, logger: LoggerInterface) {
+  constructor ({ workdir = '/tmp/test/', inMemory = false, autoCompactionInterval = 0, recentActionAvoidRepeatDistanceBlocks = 0 }, logger: LoggerInterface) {
     this.logger = logger
     this.txstore = new AsyncNedb({
       filename: inMemory ? undefined : `${workdir}/${TXSTORE_FILENAME}`,
@@ -113,8 +113,27 @@ export class TxStoreManager {
     })
   }
 
-  async isActionPending (serverAction: ServerAction, destination: Address | undefined = undefined): Promise<boolean> {
+  /**
+   * The server is originally written to fully rely on blockchain events to determine its state.
+   * However, on real networks the server's actions propagate slowly and server considers its state did not change.
+   * To mitigate this, server should not repeat its actions for at least RECENT_ACTION_BLOCK_DISTANCE blocks.
+   */
+  async isActionPendingOrRecentlyMined (serverAction: ServerAction, currentBlock: number, recencyBlockCount: number, destination: Address | undefined = undefined): Promise<boolean> {
     const allTransactions = await this.getAll()
-    return allTransactions.find(it => it.minedBlockNumber == null && it.serverAction === serverAction && (destination == null || isSameAddress(it.to, destination))) != null
+    const storedMatchingTxs = allTransactions.filter(it => it.serverAction === serverAction && (destination == null || isSameAddress(it.to, destination)))
+    const pendingTxs = storedMatchingTxs.filter(it => it.minedBlockNumber == null)
+    if (pendingTxs.length !== 0) {
+      this.logger.info(`Found ${pendingTxs.length} pending transactions that match a query: ${JSON.stringify(pendingTxs)}`)
+      return true
+    }
+    const recentlyMinedTxs = storedMatchingTxs.filter(it => {
+      const minedBlockNumber = it.minedBlockNumber ?? 0
+      return currentBlock - minedBlockNumber <= recencyBlockCount
+    })
+    if (recentlyMinedTxs.length !== 0) {
+      this.logger.info(`Found ${recentlyMinedTxs.length} recently mined transactions that match a query: ${JSON.stringify(recentlyMinedTxs)}`)
+      return true
+    }
+    return false
   }
 }


### PR DESCRIPTION
There is an inherent race condition between server sending a transaction
and observing the result in emitted event logs.

Up until now, the code considered the transaction to stop being
'pending' the moment it is mined. However, it appears to take more time
to get the RPC node to provide a satisfying response to
'getTransactionReceipt' and 'getPastEvents', causing the server to send
multiple identical transactions.