### PR TITLE
OG-656: FOR MASTER: Consider a transaction 'pending' for N blocks after mining

### DIFF
--- a/packages/dev/test/RegistrationManager.test.ts
+++ b/packages/dev/test/RegistrationManager.test.ts
@@ -216,22 +216,24 @@ contract('RegistrationManager', function (accounts) {
       let transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
       assert.equal(transactionHashes.length, 0, 'should not re-register if already registered')
 
+      const currentBlockFake = 1000000
+
       relayServer.config.baseRelayFee = (parseInt(relayServer.config.baseRelayFee) + 1).toString()
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
 
       latestBlock = await env.web3.eth.getBlock('latest')
       await relayServer._worker(latestBlock.number)
 
       relayServer.config.pctRelayFee++
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
 
       latestBlock = await env.web3.eth.getBlock('latest')
       await relayServer._worker(latestBlock.number)
 
       relayServer.config.url = 'fakeUrl'
-      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, 0, false)
+      transactionHashes = await relayServer.registrationManager.handlePastEvents([], latestBlock.number, currentBlockFake, false)
       await assertRelayAdded(transactionHashes, relayServer, false)
     })
   })

--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -546,7 +546,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     const mustWithdrawHubDeposit = managerEthBalance.lt(toBN(this.config.managerTargetBalance.toString())) && managerHubBalance.gte(
       toBN(this.config.minHubWithdrawalBalance))
-    const isWithdrawalPending = await this.txStoreManager.isActionPending(ServerAction.DEPOSIT_WITHDRAWAL)
+    const isWithdrawalPending = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.DEPOSIT_WITHDRAWAL, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     if (mustWithdrawHubDeposit && !isWithdrawalPending) {
       this.logger.info(`withdrawing manager hub balance (${managerHubBalance.toString()}) to manager`)
       // Refill manager eth balance from hub balance
@@ -565,7 +565,7 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     managerEthBalance = await this.getManagerBalance()
     const mustReplenishWorker = !this.workerBalanceRequired.isSatisfied
-    const isReplenishPendingForWorker = await this.txStoreManager.isActionPending(ServerAction.VALUE_TRANSFER, this.workerAddress)
+    const isReplenishPendingForWorker = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.VALUE_TRANSFER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks, this.workerAddress)
     if (mustReplenishWorker && !isReplenishPendingForWorker) {
       const refill = toBN(this.config.workerTargetBalance.toString()).sub(this.workerBalanceRequired.currentValue)
       this.logger.debug(
@@ -705,8 +705,8 @@ latestBlock timestamp   | ${latestBlock.timestamp}
     }
     const latestTxBlockNumber = this._getLatestTxBlockNumber()
     const latestRegisterTxBlockNumber = this._getLatestRegisterTxBlockNumber()
-    const isPendingRegistration = await this.txStoreManager.isActionPending(ServerAction.REGISTER_SERVER)
-    const isPendingActivity = isPendingRegistration || await this.txStoreManager.isActionPending(ServerAction.RELAY_CALL)
+    const isPendingRegistration = await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.REGISTER_SERVER, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
+    const isPendingActivity = isPendingRegistration || await this.txStoreManager.isActionPendingOrRecentlyMined(ServerAction.RELAY_CALL, currentBlock, this.config.recentActionAvoidRepeatDistanceBlocks)
     const registrationExpired =
       this.config.registrationBlockRate !== 0 &&
       (currentBlock - latestRegisterTxBlockNumber >= this.config.registrationBlockRate) &&

--- a/packages/relay/src/ServerConfigParams.ts
+++ b/packages/relay/src/ServerConfigParams.ts
@@ -85,6 +85,8 @@ export interface ServerConfigParams {
   pastEventsQueryMaxPageSize: number
 
   environmentName?: string
+  // number of blocks the server will not repeat a ServerAction for regardless of blockchain state to avoid duplicates
+  recentActionAvoidRepeatDistanceBlocks: number
 }
 
 export interface ServerDependencies {
@@ -150,7 +152,8 @@ export const serverDefaultConfiguration: ServerConfigParams = {
   requestMinValidBlocks: 3000, // roughly 12 hours (half client's default of 6000 blocks
   runPaymasterReputations: true,
   coldRestartLogsFromBlock: 1,
-  pastEventsQueryMaxPageSize: Number.MAX_SAFE_INTEGER
+  pastEventsQueryMaxPageSize: Number.MAX_SAFE_INTEGER,
+  recentActionAvoidRepeatDistanceBlocks: 10
 }
 
 const ConfigParamsTypes = {
@@ -219,7 +222,8 @@ const ConfigParamsTypes = {
   coldRestartLogsFromBlock: 'number',
   pastEventsQueryMaxPageSize: 'number',
   confirmationsNeeded: 'number',
-  environmentName: 'string'
+  environmentName: 'string',
+  recentActionAvoidRepeatDistanceBlocks: 'number'
 } as any
 
 // by default: no waiting period - use VersionRegistry entries immediately.

--- a/packages/relay/src/TxStoreManager.ts
+++ b/packages/relay/src/TxStoreManager.ts
@@ -116,7 +116,7 @@ export class TxStoreManager {
   /**
    * The server is originally written to fully rely on blockchain events to determine its state.
    * However, on real networks the server's actions propagate slowly and server considers its state did not change.
-   * To mitigate this, server should not repeat its actions for at least RECENT_ACTION_BLOCK_DISTANCE blocks.
+   * To mitigate this, server should not repeat its actions for at least {@link recencyBlockCount} blocks.
    */
   async isActionPendingOrRecentlyMined (serverAction: ServerAction, currentBlock: number, recencyBlockCount: number, destination: Address | undefined = undefined): Promise<boolean> {
     const allTransactions = await this.getAll()

--- a/packages/relay/src/TxStoreManager.ts
+++ b/packages/relay/src/TxStoreManager.ts
@@ -14,7 +14,7 @@ export class TxStoreManager {
   private readonly txstore: AsyncNedb<any>
   private readonly logger: LoggerInterface
 
-  constructor ({ workdir = '/tmp/test/', inMemory = false, autoCompactionInterval = 0 }, logger: LoggerInterface) {
+  constructor ({ workdir = '/tmp/test/', inMemory = false, autoCompactionInterval = 0, recentActionAvoidRepeatDistanceBlocks = 0 }, logger: LoggerInterface) {
     this.logger = logger
     this.txstore = new AsyncNedb({
       filename: inMemory ? undefined : `${workdir}/${TXSTORE_FILENAME}`,
@@ -113,8 +113,27 @@ export class TxStoreManager {
     })
   }
 
-  async isActionPending (serverAction: ServerAction, destination: Address | undefined = undefined): Promise<boolean> {
+  /**
+   * The server is originally written to fully rely on blockchain events to determine its state.
+   * However, on real networks the server's actions propagate slowly and server considers its state did not change.
+   * To mitigate this, server should not repeat its actions for at least RECENT_ACTION_BLOCK_DISTANCE blocks.
+   */
+  async isActionPendingOrRecentlyMined (serverAction: ServerAction, currentBlock: number, recencyBlockCount: number, destination: Address | undefined = undefined): Promise<boolean> {
     const allTransactions = await this.getAll()
-    return allTransactions.find(it => it.minedBlockNumber == null && it.serverAction === serverAction && (destination == null || isSameAddress(it.to, destination))) != null
+    const storedMatchingTxs = allTransactions.filter(it => it.serverAction === serverAction && (destination == null || isSameAddress(it.to, destination)))
+    const pendingTxs = storedMatchingTxs.filter(it => it.minedBlockNumber == null)
+    if (pendingTxs.length !== 0) {
+      this.logger.info(`Found ${pendingTxs.length} pending transactions that match a query: ${JSON.stringify(pendingTxs)}`)
+      return true
+    }
+    const recentlyMinedTxs = storedMatchingTxs.filter(it => {
+      const minedBlockNumber = it.minedBlockNumber ?? 0
+      return currentBlock - minedBlockNumber <= recencyBlockCount
+    })
+    if (recentlyMinedTxs.length !== 0) {
+      this.logger.info(`Found ${recentlyMinedTxs.length} recently mined transactions that match a query: ${JSON.stringify(recentlyMinedTxs)}`)
+      return true
+    }
+    return false
   }
 }


### PR DESCRIPTION
There is an inherent race condition between server sending a transaction
and observing the result in emitted event logs.

Up until now, the code considered the transaction to stop being
'pending' the moment it is mined. However, it appears to take more time
to get the RPC node to provide a satisfying response to
'getTransactionReceipt' and 'getPastEvents', causing the server to send
multiple identical transactions.

Make 'recentActionAvoidRepeatDistanceBlocks' a parameter