### PR TITLE
OG-619: remove RelayProvider false errors.

### DIFF
--- a/packages/provider/src/KnownRelaysManager.ts
+++ b/packages/provider/src/KnownRelaysManager.ts
@@ -112,6 +112,10 @@ export class KnownRelaysManager {
   }
 
   getAuditors (excludeUrls: string[]): string[] {
+    if (this.config.auditorsCount === 0) {
+      this.logger.debug('skipping audit step as "auditorsCount" config parameter is set to 0')
+      return []
+    }
     const indexes: number[] = []
     const auditors: string[] = []
     const flatRelayers =

--- a/packages/provider/src/RelayClient.ts
+++ b/packages/provider/src/RelayClient.ts
@@ -144,12 +144,13 @@ export class RelayClient {
   async _broadcastRawTx (transaction: TypedTransaction): Promise<{ hasReceipt: boolean, broadcastError?: Error, wrongNonce?: boolean }> {
     const rawTx = '0x' + transaction.serialize().toString('hex')
     const txHash = '0x' + transaction.hash().toString('hex')
-    this.logger.info(`Broadcasting raw transaction signed by relay. TxHash: ${txHash}`)
     try {
       if (await this._isAlreadySubmitted(txHash)) {
+        this.logger.debug('Not broadcasting raw transaction as our RPC endpoint already sees it')
         return { hasReceipt: true }
       }
 
+      this.logger.info(`Broadcasting raw transaction signed by relay. TxHash: ${txHash}\nNote: this may cause a "transaction already known" error to appear in the logs. It is not a problem, please ignore that error.`)
       // can't find the TX in the mempool. broadcast it ourselves.
       await this.dependencies.contractInteractor.sendSignedTransaction(rawTx)
       return { hasReceipt: true }


### PR DESCRIPTION
Note: there is no way to prevent Metamask from logging an error. We do
the best-effort trying to fetch a transaction receipt first.
At least now it will try to inform people this error is not really an
error.