### PR TITLE
OG-861-relayer-events

### DIFF
--- a/packages/relay/src/RelayServer.ts
+++ b/packages/relay/src/RelayServer.ts
@@ -487,8 +487,7 @@ returnValue        | ${viewRelayCallRet.returnValue}
       throw new Error('_init was already called')
     }
     const latestBlock = await this.contractInteractor.getBlock('latest')
-    const registrationAge = await this.contractInteractor.getRelayRegistrationMaxAge()
-    this.lastScannedBlock = latestBlock.number - registrationAge.toNumber()
+    this.lastScannedBlock = latestBlock.number - 10
     if (this.lastScannedBlock < 0) {
       this.lastScannedBlock = 0
     }


### PR DESCRIPTION
when starting relayer, don't read back events. start from current (or
-10) blocks.