### PR TITLE
OG-859: relayer doesn't complete registration without restart

### DIFF
--- a/packages/relay/src/RegistrationManager.ts
+++ b/packages/relay/src/RegistrationManager.ts
@@ -390,6 +390,8 @@ export class RegistrationManager {
       stakeOnHubStatus.isStaked
     if (!allPrerequisitesOk) {
       this.logger.debug('will not actually attempt registration - prerequisites not satisfied')
+      await this.refreshStake()
+      await this.refreshBalance()
       return []
     }
 


### PR DESCRIPTION
This is not a good solution but this will force the same re-check that
is done in the 'init' to be done if the server wants to register itself
but is prevented from doing so by stake or balance checks not satisfied.