### PR TITLE
deployer fixes

### DIFF
--- a/packages/deployer/hardhat.config.ts
+++ b/packages/deployer/hardhat.config.ts
@@ -11,6 +11,7 @@ import { HardhatUserConfig } from 'hardhat/config'
 import { NetworkUserConfig } from 'hardhat/src/types/config'
 import path from 'path'
 import chalk from 'chalk'
+import './src/exportTask'
 
 const mnemonicFileName = process.env.MNEMONIC_FILE
 let mnemonic = 'test '.repeat(11) + 'junk'

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -19,6 +19,7 @@
     "@nomiclabs/hardhat-etherscan": "^2.1.8",
     "@nomiclabs/hardhat-web3": "^2.0.0",
     "@opengsn/common": "^3.0.0-beta.1",
+    "axios": "^0.27.2",
     "chai": "^4.3.6",
     "chalk": "^4.1.2",
     "ethers": "^5.5.1",

--- a/packages/deployer/package.json
+++ b/packages/deployer/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "deploy": "yarn --cwd ../dev solpp; hardhat deploy",
-    "export": "hardhat export --export-all  /tmp/all-networks.json ; jq .[][] /tmp/all-networks.json | jq -s > gsn-networks.json",
+    "export": "hardhat export",
     "verify": "hardhat etherscan-verify --force-license  --license GPL-3.0",
     "depinfo": "hardhat run ./src/depinfo.ts",
     "applyConfig": "hardhat run ./src/applyConfig.ts",

--- a/packages/deployer/src/deployUtils.ts
+++ b/packages/deployer/src/deployUtils.ts
@@ -67,9 +67,7 @@ export function printSampleEnvironment (defaultDevAddress: string, chainId: numb
   const sampleEnv = {
     relayHubConfiguration: {
       devAddress: defaultDevAddress,
-      devFee: 10,
-      pctRelayFee: 50,
-      baseRelayFee: 0.001e18
+      devFee: 10
     },
     deploymentConfiguration
   }
@@ -197,7 +195,8 @@ async function getTokenUpdateStakeOrNull (hub: Contract, tokenAddr: string, conf
 }
 
 async function applyStakingTokenConfiguration (hre: HardhatRuntimeEnvironment, env: Environment, hub: Contract): Promise<void> {
-  const testStakingTokenAddress = await hre.deployments.get('WrappedEthToken').then(t => t?.address).catch(null)
+  const deployments = await hre.deployments.all()
+  const testStakingTokenAddress = deployments.WrappedEthToken?.address
 
   const configChanges = await Promise.all(Object.entries(env.deploymentConfiguration?.minimumStakePerToken ?? [])
     .map(async ([tokenAddr, configMinimumStake]) =>


### PR DESCRIPTION
- add fields exported network (title, explorer)
- remove obsolete config params (relayer fees)
- the generated exported network now looks like this (added description, explorer, symbol)
- 
```
{
  "3": [
    {
      "description": "Ropsten",
      "symbol": "ROP",
      "explorer": "https://ropsten.etherscan.io",
      "name": "ropsten",
      "chainId": "3",
      "contracts": {
...
```