### PR TITLE
OG-878: Remove '--withNode' option for 'gsn start'

### DIFF
--- a/packages/cli/src/GsnTestEnvironment.ts
+++ b/packages/cli/src/GsnTestEnvironment.ts
@@ -32,9 +32,6 @@ import { ReputationManager } from '@opengsn/relay/dist/ReputationManager'
 
 import { ChildProcess } from 'child_process'
 
-const { waitForCmdToStart } = require('run-with-hardhat-node')
-const onExit = require('signal-exit')
-
 export interface TestEnvironment {
   contractsDeployment: GSNContractsDeployment
   relayProvider: RelayProvider
@@ -51,17 +48,9 @@ class GsnTestEnvironmentClass {
    * @param host:
    * @return
    */
-  async startGsn (host: string, withNode = false): Promise<TestEnvironment> {
+  async startGsn (host: string): Promise<TestEnvironment> {
     await this.stopGsn()
     let hardhatNode: ChildProcess | undefined
-    if (withNode) {
-      hardhatNode = await waitForCmdToStart({ cmd: 'hardhat', args: ['node'], waitFor: 'Started HTTP' })
-      onExit(() => {
-        if (hardhatNode != null) {
-          hardhatNode.kill()
-        }
-      })
-    }
     const _host: string = getNetworkUrl(host)
     if (_host == null) {
       // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/packages/cli/src/commands/gsn-start.ts
+++ b/packages/cli/src/commands/gsn-start.ts
@@ -5,7 +5,6 @@ import { execSync } from 'child_process'
 
 gsnCommander(['n'])
   .option('-w, --workdir <directory>', 'relative work directory (defaults to build/gsn/)', 'build/gsn')
-  .option('--withNode', 'start with "hardhat node" in the background', false)
   .option('--run <command>', 'run with command after GSN is started. stop GSN when the commands finish')
   .parse(process.argv);
 
@@ -15,7 +14,7 @@ gsnCommander(['n'])
     if (network !== 'localhost' && commander.withNode != null) {
       throw new Error('can\'t have both --network and --withNode')
     }
-    const env = await GsnTestEnvironment.startGsn(network, commander.withNode)
+    const env = await GsnTestEnvironment.startGsn(network)
     saveDeployment(env.contractsDeployment, commander.workdir)
 
     if (commander.run != null) {


### PR DESCRIPTION
This mode of operations is very opinionated and conflicts with Hardhat
Deploy and conceals output of Hardhat, which is often useful.