### PR TITLE
gsn paymaster-balance doesn't work.

### DIFF
--- a/packages/cli/src/commands/gsn-paymaster-balance.ts
+++ b/packages/cli/src/commands/gsn-paymaster-balance.ts
@@ -20,6 +20,7 @@ const commander = gsnCommander(['h', 'n'])
   const logger = createCommandsLogger(commander.loglevel)
 
   const logic = new CommandsLogic(nodeURL, logger, { relayHubAddress: hub })
+  await logic.init();
   const balance = await logic.getPaymasterBalance(paymaster)
   console.log(`Account ${paymaster} has a GSN balance of ${Web3.utils.fromWei(balance)} ETH`)
 })().catch(

--- a/packages/cli/src/commands/gsn-paymaster-balance.ts
+++ b/packages/cli/src/commands/gsn-paymaster-balance.ts
@@ -20,7 +20,7 @@ const commander = gsnCommander(['h', 'n'])
   const logger = createCommandsLogger(commander.loglevel)
 
   const logic = new CommandsLogic(nodeURL, logger, { relayHubAddress: hub })
-  await logic.init();
+  await logic.init()
   const balance = await logic.getPaymasterBalance(paymaster)
   console.log(`Account ${paymaster} has a GSN balance of ${Web3.utils.fromWei(balance)} ETH`)
 })().catch(


### PR DESCRIPTION
reported in https://github.com/opengsn/gsn/issues/835:

`gsn paymaster-balance` aborts on error:
```
TypeError: Cannot read property 'balanceOf' of undefined
```

## root cause: 
missing init() for CommandsLogic()