### PR TITLE
OG-1030: Make RelayProvider implement ExternalProvider interface

### DIFF
--- a/packages/cli/src/commands/gsn-send-request.ts
+++ b/packages/cli/src/commands/gsn-send-request.ts
@@ -1,12 +1,12 @@
 import * as bip39 from 'ethereum-cryptography/bip39'
+
+import Web3 from 'web3'
 import commander from 'commander'
 import fs from 'fs'
-import Web3 from 'web3'
+import { PrefixedHexString } from 'ethereumjs-util'
+import { StaticJsonRpcProvider } from '@ethersproject/providers'
 import { hdkey as EthereumHDKey } from 'ethereumjs-wallet'
 import { toHex, toWei } from 'web3-utils'
-
-import { StaticJsonRpcProvider } from '@ethersproject/providers'
-
 import { HttpProvider } from 'web3-core'
 
 import {
@@ -15,11 +15,10 @@ import {
 } from '@opengsn/common'
 
 import { GSNConfig, GSNDependencies, GSNUnresolvedConstructorInput, RelayProvider } from '@opengsn/provider'
+import { createCommandsLogger } from '@opengsn/logger/dist/CommandsWinstonLogger'
 
 import { getMnemonic, getNetworkUrl, gsnCommander } from '../utils'
 import { CommandsLogic } from '../CommandsLogic'
-import { createCommandsLogger } from '@opengsn/logger/dist/CommandsWinstonLogger'
-import { PrefixedHexString } from 'ethereumjs-util'
 
 function commaSeparatedList (value: string, _dummyPrevious: string[]): string[] {
   return value.split(',')

--- a/packages/dev/package.json
+++ b/packages/dev/package.json
@@ -62,7 +62,6 @@
     "ts-node": "8.6.2",
     "web3": "^1.7.4",
     "web3-core": "^1.7.4",
-    "web3-core-helpers": "^1.7.4",
     "web3-eth-contract": "^1.7.4",
     "web3-providers-http": "^1.7.4",
     "web3-utils": "^1.7.4",

--- a/packages/dev/test/provider/RelayProvider.test.ts
+++ b/packages/dev/test/provider/RelayProvider.test.ts
@@ -4,7 +4,6 @@ import chaiAsPromised from 'chai-as-promised'
 import sinon from 'sinon'
 import { ChildProcessWithoutNullStreams } from 'child_process'
 import { HttpProvider } from 'web3-core'
-import { JsonRpcPayload, JsonRpcResponse } from 'web3-core-helpers'
 import { TypedMessage } from '@metamask/eth-sig-util'
 import { ether, expectEvent, expectRevert } from '@openzeppelin/test-helpers'
 import { toBN } from 'web3-utils'
@@ -27,6 +26,8 @@ import {
 } from '@opengsn/contracts/types/truffle-contracts'
 import {
   Address,
+  JsonRpcPayload,
+  JsonRpcResponse,
   RelayRequest,
   constants,
   defaultEnvironment,

--- a/packages/provider/src/RelayProvider.ts
+++ b/packages/provider/src/RelayProvider.ts
@@ -5,10 +5,12 @@ import abiDecoder from 'abi-decoder'
 import { BigNumber } from '@ethersproject/bignumber'
 import { PrefixedHexString } from 'ethereumjs-util'
 import { TypedMessage } from '@metamask/eth-sig-util'
+import { JsonRpcProvider, TransactionReceipt, ExternalProvider } from '@ethersproject/providers'
 
 import {
   Address,
   EventData,
+  GSNConfig,
   GsnTransactionDetails,
   JsonRpcPayload,
   JsonRpcResponse,
@@ -25,9 +27,6 @@ import relayHubAbi from '@opengsn/common/dist/interfaces/IRelayHub.json'
 import { AccountKeypair } from './AccountManager'
 import { GsnEvent } from './GsnEvents'
 import { _dumpRelayingResult, GSNUnresolvedConstructorInput, RelayClient, RelayingResult } from './RelayClient'
-import { GSNConfig } from './GSNConfigurator'
-
-import { JsonRpcProvider, TransactionReceipt } from '@ethersproject/providers'
 
 abiDecoder.addABI(relayHubAbi)
 
@@ -46,7 +45,7 @@ const TX_NOTFOUND = 'tx-notfound'
 
 const BLOCKS_FOR_LOOKUP = 5000
 
-export class RelayProvider {
+export class RelayProvider implements ExternalProvider {
   protected readonly origProvider: JsonRpcProvider
   private readonly _origProviderSend: (method: string, params: any[]) => Promise<any>
   private asyncSignTypedData?: SignTypedDataCallback
@@ -118,7 +117,7 @@ export class RelayProvider {
     })
   }
 
-  send (payload: JsonRpcPayload, callback: JsonRpcCallback): void {
+  send (payload: JsonRpcPayload | any, callback: JsonRpcCallback): void {
     if (this._useGSN(payload)) {
       if (payload.method === 'eth_sendTransaction') {
         // @ts-ignore


### PR DESCRIPTION
This will raise an ignoreable TypeScript error in:

'new Web3(relayProvider)'

for Web3.js;

but it will solve a more common one:
'new Web3Provider(provider)'

for Ethers.js