### PR TITLE
OG-1039: Fix "max priority fee per" exceeding "max fee per gas"

### DIFF
--- a/packages/provider/src/RelaySelectionManager.ts
+++ b/packages/provider/src/RelaySelectionManager.ts
@@ -261,7 +261,7 @@ export class RelaySelectionManager {
     const skippedRelays: string[] = []
     const adjustedArray = allPingResults.results
       .map(it => {
-        return adjustRelayRequestForPingResponse(this.gsnTransactionDetails, it)
+        return adjustRelayRequestForPingResponse(this.gsnTransactionDetails, it, this.logger)
       })
       .filter(it => {
         const isGasPriceWithinSlack = it.maxDeltaPercent <= this.config.gasPriceSlackPercent


### PR DESCRIPTION
The "max priority fee per" gas after adjustment for a "Relay Ping Response" may exceed "max fee per gas" leading to a broken GSN client state.